### PR TITLE
During scan import user should have aggregate option 

### DIFF
--- a/tenable_io/api/scans.py
+++ b/tenable_io/api/scans.py
@@ -125,14 +125,21 @@ class ScansApi(BaseApi):
                                     path_params={'scan_id': scan_id, 'history_id': history_id})
         return ScanHistory.from_json(response.text)
 
-    def import_scan(self, scan_import):
+    def import_scan(self, scan_import, include_aggregate=True):
         """Import an existing scan which has been uploaded using :func:`TenableIO.FileApi.upload`
 
         :param scan_import: An instance of :class:`ScanImportRequest`.
+        :param include_aggregate: Boolean indicating whether scan data should appear in Workbenches.
         :raise TenableIOApiException:  When API error is encountered.
         :return: The ID of the imported scan.
         """
-        response = self._client.post('scans/import', scan_import)
+        aggregate_option = 0
+        if include_aggregate:
+            aggregate_option = 1
+
+        response = self._client.post('scans/import?include_aggregate=%(include_aggregate)s',
+                                     scan_import,
+                                     path_params={'include_aggregate': aggregate_option})
         return loads(response.text).get('scan', {}).get('id')
 
     def launch(self, scan_id, scan_launch_request):

--- a/tenable_io/helpers/scan.py
+++ b/tenable_io/helpers/scan.py
@@ -131,15 +131,16 @@ class ScanHelper(object):
 
         return template
 
-    def import_scan(self, path):
+    def import_scan(self, path, include_aggregate=True):
         """Uploads and then imports scan report.
 
         :param path: Path of the scan report.
+        :param include_aggregate: Flag indicating whether import scan results should be shown on Workbenches.
         :return: ScanRef referenced by id if exists.
         """
         uploaded_file_name = self._client.file_helper.upload(path)
 
-        imported_scan_id = self._client.scans_api.import_scan(ScanImportRequest(uploaded_file_name))
+        imported_scan_id = self._client.scans_api.import_scan(ScanImportRequest(uploaded_file_name), include_aggregate)
 
         return self.id(imported_scan_id)
 


### PR DESCRIPTION
There is an optional param on the /scans/import endpoint that allows users to choose whether or not the scan should be included in the aggregate. Without this param, it defaults to False, which is not how it is handled in the User Interface. This change is to support that param. 