### PR TITLE
Bugfix/add scan acls

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,6 @@
 
 @Library('tenable.common')
 
-def startTime = System.currentTimeMillis()
-
 def projectProperties = [
     [$class: 'BuildDiscarderProperty',strategy: [$class: 'LogRotator', numToKeepStr: '5']],disableConcurrentBuilds(),
     [$class: 'ParametersDefinitionProperty', parameterDefinitions: [[$class: 'StringParameterDefinition', defaultValue: 'io/qa-milestone', description: '', name: 'SITE_BRANCH']]]
@@ -98,7 +96,7 @@ catch (exc) {
 }
 finally {
     String tests = common.jenkinsTestResults()
-    String took  = '\nTook: ' + common.jenkinsDuration(startTime)
+    String took  = '\nTook: ' + common.jenkinsDuration()
 
     currentBuild.result = currentBuild.result ?: 'FAILURE'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,8 @@
 
 @Library('tenable.common')
 
+def startTime = System.currentTimeMillis()
+
 def projectProperties = [
     [$class: 'BuildDiscarderProperty',strategy: [$class: 'LogRotator', numToKeepStr: '5']],disableConcurrentBuilds(),
     [$class: 'ParametersDefinitionProperty', parameterDefinitions: [[$class: 'StringParameterDefinition', defaultValue: 'io/qa-milestone', description: '', name: 'SITE_BRANCH']]]
@@ -96,7 +98,7 @@ catch (exc) {
 }
 finally {
     String tests = common.jenkinsTestResults()
-    String took  = '\nTook: ' + common.jenkinsDuration()
+    String took  = '\nTook: ' + common.jenkinsDuration(startTime)
 
     currentBuild.result = currentBuild.result ?: 'FAILURE'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ try {
                     common.prepareGit()
 
                     sshagent([global.BITBUCKETUSER]) {
-                        timeout(time: 60, unit: 'MINUTES') {
+                        timeout(time: 120, unit: 'MINUTES') {
                             try {
                                 sh '''
 cd automation || exit 1

--- a/tenable_io/api/models.py
+++ b/tenable_io/api/models.py
@@ -679,6 +679,65 @@ class ImportAssetJobs(BaseModel):
         self._asset_import_jobs = asset_import_jobs
 
 
+class Permissions(BaseModel):
+
+    class Scan:
+        # Scan Permissions
+        PERMISSION_NO_ACCESS = 0
+        PERMISSION_CAN_VIEW = 16
+        PERMISSION_CAN_CONTROL = 32
+        PERMISSION_CAN_CONFIGURE = 64
+
+    class Policy:
+        # Policy Permissions
+        PERMISSION_NO_ACCESS = 0
+        PERMISSION_CAN_USE = 16
+        PERMISSION_CAN_EDIT = 32
+
+    class Scanner:
+        # Scanner Permissions
+        PERMISSION_NO_ACCESS = 0
+        PERMISSION_CAN_USE = 16
+        PERMISSION_CAN_MANAGE = 32
+
+    class Agent:
+        # Agent Permissions
+        PERMISSION_NO_ACCESS = 0
+        PERMISSION_CAN_USE = 16
+
+    class TargetGroup:
+        # Target Group Permissions
+        PERMISSION_NO_ACCESS = 0
+        PERMISSION_CAN_VIEW = 32
+        PERMISSION_CAN_SCAN = 64
+
+    class User:
+        # User Roles
+        PERMISSION_BASIC = 16
+        PERMISSION_STANDARD = 32
+        PERMISSION_ADMINISTRATOR = 64
+
+    class Type:
+        # Types of Permissible entity
+        DEFAULT = u'default'
+        USER = u'user'
+        GROUP = u'group'
+
+    def __init__(
+            self,
+            owner=None,
+            type=None,
+            permissions=None,
+            id=None,
+            name=None,
+    ):
+        self.owner = owner
+        self.type = type
+        self.permissions = permissions
+        self.id = id
+        self.name = name
+
+
 class Plugin(BaseModel):
 
     def __init__(
@@ -1599,6 +1658,7 @@ class ScanSettings(BaseModel):
             folder_id=None,
             policy_id=None,
             scanner_id=None,
+            acls=[],
     ):
         self.name = name
         self.description = description
@@ -1609,6 +1669,7 @@ class ScanSettings(BaseModel):
         self.policy_id = policy_id
         self.scanner_id = scanner_id
         self.text_targets = text_targets
+        self.acls = acls
 
 
 class ScannerLicense(BaseModel):

--- a/tenable_io/client.py
+++ b/tenable_io/client.py
@@ -35,6 +35,7 @@ from tenable_io.api.users import UsersApi
 from tenable_io.api.workbenches import WorkbenchesApi
 from tenable_io.helpers.file import FileHelper
 from tenable_io.helpers.folder import FolderHelper
+from tenable_io.helpers.permissions import PermissionsHelper
 from tenable_io.helpers.policy import PolicyHelper
 from tenable_io.helpers.scan import ScanHelper
 from tenable_io.helpers.workbench import WorkbenchHelper
@@ -122,6 +123,7 @@ class TenableIOClient(object):
         """
         self.file_helper = FileHelper(self)
         self.folder_helper = FolderHelper(self)
+        self.permissions_helper = PermissionsHelper(self)
         self.policy_helper = PolicyHelper(self)
         self.scan_helper = ScanHelper(self)
         self.workbench_helper = WorkbenchHelper(self)

--- a/tenable_io/helpers/permissions.py
+++ b/tenable_io/helpers/permissions.py
@@ -1,0 +1,38 @@
+from tenable_io.api.models import Permissions
+
+
+class PermissionsHelper(object):
+
+    def __init__(self, client):
+        self._client = client
+
+    def default_scan(self, access_level):
+        """Generates a Permission object for the default role.
+
+        :param access_level: The access level the default user group should be granted for a scan (0, 16, 32, 64). See `Permissions.Scan`.
+        :return: A Permissions instance
+        """
+        return Permissions(type=Permissions.Type.DEFAULT,
+                           permissions=access_level)
+
+    def user_scan(self, user_id, access_level):
+        """Generates a Permission object for the given user id with the given permissions
+
+        :param user_id: Numeric User Id
+        :param access_level: The access level the default user group should be granted for a scan (0, 16, 32, 64). See `Permissions.Scan`.
+        :return: A Permissions instance
+        """
+        user = self._client.users_api.get(user_id)
+        return Permissions(owner=user.id,
+                           type=Permissions.Type.USER,
+                           permissions=access_level,
+                           id=user.id,
+                           name=user.name)
+
+    def as_acl(self, permissions):
+        """Can be used as part of an acl.
+
+        :param permissions: An instance of `Permissions`
+        :return: dict
+        """
+        return permissions.as_payload()

--- a/tests/integration/helpers/test_permissions.py
+++ b/tests/integration/helpers/test_permissions.py
@@ -1,0 +1,26 @@
+import pytest
+import random
+
+from tests.base import BaseTest
+from tenable_io.api.models import Permissions
+
+class TestPermissionsHelper(BaseTest):
+
+    def test_default_scan(self, client):
+        default_view = client.permissions_helper.default_scan(Permissions.Scan.PERMISSION_CAN_VIEW)
+        assert isinstance(default_view, Permissions)
+        assert default_view.type == u'default'
+        assert default_view.permissions == 16
+
+        default_control = client.permissions_helper.default_scan(Permissions.Scan.PERMISSION_CAN_CONTROL)
+        assert isinstance(default_control, Permissions)
+        assert default_control.type == u'default'
+        assert default_control.permissions == 32
+
+    def test_user_scan(self, client):
+        test_user = random.choice(client.users_api.list().users)
+        user_control = client.permissions_helper.user_scan(test_user.id, Permissions.Scan.PERMISSION_CAN_CONTROL)
+        assert isinstance(user_control, Permissions)
+        assert user_control.type == u'user'
+        assert user_control.permissions == 32
+        assert user_control.name == test_user.name


### PR DESCRIPTION
ACLs were missing from the ScanSettings Model which did not allow users to easily add granular permissions to scans. I also added an additional helper and model to ease building these permissions. 