### PR TITLE
Enable Requests Proxy Configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ TenableIOClient Constructor Arguments
 
 .. code:: python
 
-    TenableIOClient(access_key='YOUR_ACCESS_KEY', secret_key='YOUR_SECRET_KEY')
+    TenableIOClient(access_key='YOUR_ACCESS_KEY', secret_key='YOUR_SECRET_KEY', proxies={ 'http': 'http://proxy:port', 'https': 'https://prxy:port', 'no': '127.0.0.1,192.168.1.0/24' })
 
 INI File
 ^^^^^^^^
@@ -51,8 +51,7 @@ INI File
 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^
 
-TenableIOClient looks for the environment variables ``TENABLEIO_ACCESS_KEY``
-and ``TENABLEIO_SECRET_KEY``.
+TenableIOClient looks for the environment variables ``TENABLEIO_ACCESS_KEY``, ``TENABLEIO_SECRET_KEY`, ``HTTP_PROXY``, ``HTTTPS_PROXY``, and ``NO_PROXY``. If no proxy variable is set via either config or passing it, it will be set to blank for all three.
 
 Python Version
 --------------

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ INI File
 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^
 
-TenableIOClient looks for the environment variables ``TENABLEIO_ACCESS_KEY``, ``TENABLEIO_SECRET_KEY`, ``HTTP_PROXY``, ``HTTTPS_PROXY``, and ``NO_PROXY``. If no proxy variable is set via either config or passing it, it will be set to blank for all three.
+TenableIOClient looks for the environment variables ``TENABLEIO_ACCESS_KEY``, ``TENABLEIO_SECRET_KEY`, ``HTTP_PROXY``, ``HTTPS_PROXY``, and ``NO_PROXY``. If no proxy variable is set via either config or passing it, it will be set to blank for all three.
 
 Python Version
 --------------

--- a/tenable_io.ini.example
+++ b/tenable_io.ini.example
@@ -8,6 +8,10 @@ secret_key={{SECRET_KEY}}
 ;polling_interval={{POLLING_INTERVAL}}
 ; Maximum retries on calling the endpoint. (Default: 3)
 ;max_retries={{MAX_RETRIES}}
+; Configure proxy variables
+;http_proxy={{HTTP_PROXY}}
+;https_proxy={HTTPS_PROXY}}
+;no_proxy={{NO_PROXY}}
 
 [tenable_io-test]
 ; Amount of seconds to wait for a test condition before timing out. (Default: 300)

--- a/tenable_io/client.py
+++ b/tenable_io/client.py
@@ -63,7 +63,8 @@ class TenableIOClient(object):
         self._secret_key = secret_key
         self._endpoint = endpoint
         self._impersonate = impersonate
-        # specify proxies via { 'http': 'http://proxy:port', 'https': 'https://prxy:port', 'no': '127.0.0.1,192.168.1.0/24' }
+        # specify proxies via 
+        # { 'http': 'http://proxy:port', 'https': 'https://prxy:port', 'no': '127.0.0.1' }
         self._proxies = proxies
 
         self._init_session()

--- a/tenable_io/client.py
+++ b/tenable_io/client.py
@@ -51,6 +51,7 @@ class TenableIOClient(object):
 
     def __init__(
             self,
+            proxies = { 'http': TenableIOConfig.get('http_proxy'), 'https': TenableIOConfig.get('https_proxy'), 'no': TenableIOConfig.get('no_proxy') }
             access_key=TenableIOConfig.get('access_key'),
             secret_key=TenableIOConfig.get('secret_key'),
             endpoint=TenableIOConfig.get('endpoint'),
@@ -60,6 +61,8 @@ class TenableIOClient(object):
         self._secret_key = secret_key
         self._endpoint = endpoint
         self._impersonate = impersonate
+        # specify proxies via { 'http': 'http://proxy:port', 'https': 'https://prxy:port', 'no': '127.0.0.1,192.168.1.0/24' }
+        self._proxies = proxies
 
         self._init_session()
         self._init_api()
@@ -70,6 +73,7 @@ class TenableIOClient(object):
         Initializes the requests session
         """
         self._session = requests.Session()
+        self._session.proxies.update(self._proxies)
         self._session.headers.update({
             u'X-ApiKeys': u'accessKey=%s; secretKey=%s;' % (self._access_key, self._secret_key),
             u'User-Agent': u'TenableIOSDK Python/%s' % ('.'.join([str(i) for i in sys.version_info][0:3]))

--- a/tenable_io/client.py
+++ b/tenable_io/client.py
@@ -51,7 +51,9 @@ class TenableIOClient(object):
 
     def __init__(
             self,
-            proxies = { 'http': TenableIOConfig.get('http_proxy'), 'https': TenableIOConfig.get('https_proxy'), 'no': TenableIOConfig.get('no_proxy') }
+            proxies={'http': TenableIOConfig.get('http_proxy'),
+                     'https': TenableIOConfig.get('https_proxy'),
+                     'no': TenableIOConfig.get('no_proxy')}
             access_key=TenableIOConfig.get('access_key'),
             secret_key=TenableIOConfig.get('secret_key'),
             endpoint=TenableIOConfig.get('endpoint'),

--- a/tenable_io/client.py
+++ b/tenable_io/client.py
@@ -53,7 +53,7 @@ class TenableIOClient(object):
             self,
             proxies={'http': TenableIOConfig.get('http_proxy'),
                      'https': TenableIOConfig.get('https_proxy'),
-                     'no': TenableIOConfig.get('no_proxy')}
+                     'no': TenableIOConfig.get('no_proxy')},
             access_key=TenableIOConfig.get('access_key'),
             secret_key=TenableIOConfig.get('secret_key'),
             endpoint=TenableIOConfig.get('endpoint'),

--- a/tenable_io/config.py
+++ b/tenable_io/config.py
@@ -14,6 +14,9 @@ base_config = {
     'polling_interval': environ.get('TENABLEIO_POLLING_INTERVAL', '10'),
     'max_retries': environ.get('TENABLEIO_MAX_RETRIES', '3'),
     'retry_sleep_milliseconds': environ.get('TENABLEIO_RETRY_SLEEP_MILLISECONDS', '500'),
+    'http_proxy': environ.get('HTTP_PROXY', ''),
+    'https_proxy': environ.get('HTTPS_PROXY', ''),
+    'no_proxy': environ.get('NO_PROXY', ''),
 }
 
 # Read tenable_io.ini config. Default to environment variables if exist.


### PR DESCRIPTION
Added the ability to specify the proxy configuration via a few different methods.

- Environmental variables for HTTP_PROXY, HTTPS_PROXY, NO_PROXY
- Configured in tenable_io.ini
- Pass the configuration when initializing the client

Updated documents to show how to configure proxy.