### PR TITLE
Add support for dynamic tags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ CHANGELOG
 
 Unreleased
 ==========
+* Added: Support for creating dynamic tags
 * Changed: Overhaul of all tests for reliability & speed improvements. pytest-vcr and pytest-xdist are now test dependencies.
 
 1.7.0

--- a/tenable_io/api/tags.py
+++ b/tenable_io/api/tags.py
@@ -2,7 +2,7 @@ from json import loads
 
 from tenable_io.api.base import BaseApi
 from tenable_io.api.base import BaseRequest
-from tenable_io.api.models import AssetTagAssignmentList, TagCategory, TagCategoryList, TagValue, TagValueList
+from tenable_io.api.models import AssetTagAssignmentList, TagCategory, TagCategoryList, TagValue, TagValueList, TagValueFilters
 
 
 class TagsApi(BaseApi):
@@ -208,7 +208,8 @@ class TagValueRequest(BaseRequest):
             category_uuid=None,
             category_name=None,
             category_description=None,
-            description=None
+            description=None,
+            filters=None
     ):
         """Request for TagsApi.create_value and TagsApi.edit_value.
 
@@ -222,12 +223,20 @@ class TagValueRequest(BaseRequest):
         :type value: string
         :param description: The description of the tag value.
         :type description: string
+        :param filters: Optional filters to create a dynamic tag
+        :type filters: TagValueFilters
         """
         self.category_uuid = category_uuid
         self.category_name = category_name
         self.category_description = category_description
         self.value = value
         self.description = description
+        if filters is not None:
+            assert filters.operator in [
+                TagValueFilters.OPERATOR_AND,
+                TagValueFilters.OPERATOR_OR
+            ]
+            self.filters = filters.as_payload()
 
 
 class AssetAssignmentsRequest(BaseRequest):

--- a/tests/integration/api/cassettes/test_tags_value_create_dynamic.yaml
+++ b/tests/integration/api/cassettes/test_tags_value_create_dynamic.yaml
@@ -1,0 +1,177 @@
+interactions:
+- request:
+    body: '{"name": "test_category_9553"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.7.0
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/tags/categories
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42POw7CMBBE7+IaR/4mcSoOQUUTbbybCAEJsh1QhLg72yBRUNDOezPSPMW6nlB0
+        AlsdQDVKOmyMdLE2cnCjlahNbC2BQ3JiJ2IiKIQ9FO4YpYNUQer2oF1nQ+d1FWp//PKGjT2YMdFj
+        n/FcLWliut7wr5WP93tlhitxXiiXPrI3LWnrg/eWWaJM6U78bIRLptcbEpyFBegAAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Sep 2019 14:39:52 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-prod-ca-central-1
+      X-Request-Uuid:
+      - f058de62baf024bd7ebbc7a0f115c601
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"category_name": "d819a070-4d72-4c62-b4f3-d12c83ea4de4", "value": "test_value_852",
+      "filters": {"asset": {"and": [{"field": "ipv4", "operator": "eq", "value": "127.0.0.1"}]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '176'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.7.0
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/tags/values
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42Py26DMBBF/8XrTMT4BWbVj+iqpUK2x0SoNFBjUqGIf69BrZRFF5U343PvPO6d
+        LUtPrGZauQ7LooKKtAMpNIJVSkGn0AUyygou2Yn5GGwK1NqUe3iBBgoDWD2jrIWpFT9zjS8PPrdm
+        n71SDF9PM72fx3jJ6jLRv6b8+v6e4rN2GePa/kRw0hNh6UEYzBGk0eBQK0AkZXQpvKA9ws0OS8j2
+        FObUHp+2UjwLaZ12TuvVfvT+cUEGh1KhsUVZgKSSg/Sag5OdAELuKxGspLAv6PohhTiz+s7sPIc9
+        473Zz29Y/Zqrrg/DXjesn26yYaeGjVOINo3xoOHzYMdpB0Benov8sGHb28a27RuhLLEetgEAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Sep 2019 14:39:52 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-prod-ca-central-1
+      X-Request-Uuid:
+      - 677723cf5d9733dd46c9a8bb426ed819
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.7.0
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/tags/values/65bf1708-8d6b-4361-a555-f51bed95a324
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42Py26DMBBF/8XrTMT4BWbVj+iqpUK2x0SoNFBjUqGIf69BrZRFF5U343PvPO6d
+        LUtPrGZauQ7LooKKtAMpNIJVSkGn0AUyygou2Yn5GGwK1NqUe3iBBgoDWD2jrIWpFT9zjS8PPrdm
+        n71SDF9PM72fx3jJ6jLRv6b8+v6e4rN2GePa/kRw0hNh6UEYzBGk0eBQK0AkZXQpvKA9ws0OS8j2
+        FObUHp+2UjwLaZ12TuvVfvT+cUEGh1KhsUVZgKSSg/Sag5OdAELuKxGspLAv6PohhTiz+s7sPIc9
+        473Zz29Y/Zqrrg/DXjesn26yYaeGjVOINo3xoOHzYMdpB0Benov8sGHb28a27RuhLLEetgEAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Sep 2019 14:39:52 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-prod-ca-central-1
+      X-Request-Uuid:
+      - 829cb94289028c5c5a7dc674d06dc099
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/api/cassettes/test_tags_value_edit_dynamic.yaml
+++ b/tests/integration/api/cassettes/test_tags_value_edit_dynamic.yaml
@@ -1,0 +1,181 @@
+interactions:
+- request:
+    body: '{"name": "test_category_6720"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.7.0
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/tags/categories
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42POw7CMBBE7+IaR17HNnEqDkFFEy32JkJAgvwBRYi7sw0SBQXtvDcjzVPUeoqi
+        FzB2YFy0skMfpAmtkmhcK0Mg4zSM3jgrNiIkwkJxwMIdrcBL5SV0e7C9Uj3oxmp3+PKOK3s4x0SP
+        XY7nZkkT03qLf618vN8rM16J80K5DIG9aUnr4LZaMUuUKd2Jn414yfR6AwdgYjroAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Sep 2019 15:00:12 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-prod-ca-central-1
+      X-Request-Uuid:
+      - 3a9b30979ea9fbff9bab4620d7c6f77c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"category_name": "1f8146d5-8a9c-4c30-a463-cce4621f9465", "value": "test_value_100"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '84'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.7.0
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/tags/values
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42PwU7DMAyG3yVnPNmJk6Y77SE4calcx50mYJvaFFQh3p0MgbQDB47+v+//JX+4
+        dT0Vt3edIltHASJxBM7BwyjRIIyGIUyjSOncg9PZpFoZpLaOR+oBe6D8SHGPuCe/63J+uvPGrXly
+        LrO9H5byvLvMx0bXa/nXyq/394o2drzM2/DzQg7JcOoJImsGtjhBTp5BTRLq6FNKudXe5GW1pldb
+        6vB9DITYQN2ut3ypUk96v3+W1xugKROnEiFLr8AaEIRTAFXj5GnqOUX3+QUAdY0zUgEAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Sep 2019 15:00:12 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-prod-ca-central-1
+      X-Request-Uuid:
+      - 175a9b8108bcf119fe188eab79287b29
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "test_edit_value_dynamic", "filters": {"asset": {"and": [{"field":
+      "ipv4", "operator": "eq", "value": "127.0.0.1"}]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '128'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.7.0
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: PUT
+    uri: https://cloud.tenable.com/tags/values/7c04e713-5145-4832-ba5e-3be033fbaad7
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA32PzW6DMBCE38XnLPI/hlMfoqeUChl7HaHSQI1JhSLevQZVbQ5V5cvqm5ldz50s
+        S+9JTUpHJZZMgGJSgTSCQ2cVguiQChE6a31JTsRFtAl9a1POcMoqoBUw88xUTWnNeFEac37wdWv2
+        2auP+Pk0+7dijJesLpP/b4so8snzg+/vLS5rlzGu7XcFIzTSUDFQ0hmQqAIYzSU4tJq6jmutTY7d
+        7LBgtiecU4u+T+1BWr9e7XvvsiOt0274BT+XMtgVFgyT2iswtnIgnaBgpRbgHErNWaikVjkW+iFh
+        nEl9J3aecS97b/YeDalf8hR6HPa5If10kw05NWScMNo0xoPix8GO7x2A8bKg+bGGbK8b2bYvTkws
+        FL8BAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Sep 2019 15:00:13 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-prod-ca-central-1
+      X-Request-Uuid:
+      - 13ee1541461b8318824902ee43076831
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/api/test_tags.py
+++ b/tests/integration/api/test_tags.py
@@ -156,7 +156,7 @@ def test_tags_asset_tag_assignments(client, new_tag_category):
 
 @pytest.mark.vcr()
 def test_tags_value_create_dynamic(client, new_tag_category):
-    tag_filter = TagValueFilter(field='ipv4', operator='eq', value='127.0.0.1')
+    tag_filter = TagValueFilter(field='ipv4', operator=TagValueFilter.OPERATOR_EQ, value='127.0.0.1')
     filters = TagValueFilters(operator=TagValueFilters.OPERATOR_AND, filters=[tag_filter])
     value = create_value(client, new_tag_category.uuid, filters)
     assert isinstance(value, TagValue), u'The `create_value` method did not return type `TagValue`.'
@@ -176,7 +176,7 @@ def test_tags_value_edit_dynamic(client, new_tag_category):
     value = create_value(client, new_tag_category.uuid)
 
     edit_name = 'test_edit_value_dynamic'
-    tag_filter = TagValueFilter(field='ipv4', operator='eq', value='127.0.0.1')
+    tag_filter = TagValueFilter(field='ipv4', operator=TagValueFilter.OPERATOR_EQ, value='127.0.0.1')
     filters = TagValueFilters(operator=TagValueFilters.OPERATOR_AND, filters=[tag_filter])
 
     edit_value = client.tags_api.edit_value(value.uuid, TagValueRequest(


### PR DESCRIPTION
This PR adds support for dynamic tagging via the `filters` property on the `TagValue` object. 

Ref: https://developer.tenable.com/reference#tags-create-tag-value, https://developer.tenable.com/docs/apply-dynamic-tags