### PR TITLE
Add support for schedule_uuid in place of numeric scan id for Scans API and Helper methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 CHANGELOG
 =========
 
+Unreleased
+==========
+* Changed: Scans API and Scan Helper methods will now accept schedule_uuid as a param to improve lookup perfomance.
+
 1.9.1
 ==========
 * Fixed: Scan exports for WAS scans caused 404s due to missing param

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('tenable.common@v1.0.0')
+@Library('tenable.common')
 import com.tenable.jenkins.*
 import com.tenable.jenkins.builds.*
 import com.tenable.jenkins.builds.checkmarx.*
@@ -30,18 +30,11 @@ try {
                 checkout scm
             }
             dir('automation') {
-                git(branch:'develop',
-                    changelog:false,
-                    credentialsId: Constants.BITBUCKETUSER,
-                    poll:false,
-                    url:'ssh://git@stash.corp.tenablesecurity.com:7999/aut/automation-tenableio.git')
-            }
-            dir('site') {
-                git(branch:params.SITE_BRANCH,
-                    changelog:false,
-                    credentialsId: Constants.BITBUCKETUSER,
-                    poll:false,
-                    url:'ssh://git@stash.corp.tenablesecurity.com:7999/aut/site-configs.git')
+                git(branch:'master',
+                        changelog:false,
+                        credentialsId:'githubkey',
+                        poll:false,
+                        url: 'git@github.eng.tenable.com:Product/catium-tenableio.git')
             }
         }
 
@@ -50,7 +43,7 @@ try {
                 stage('build auto') {
                     buildsCommon.prepareGit()
 
-                    sshagent([Constants.BITBUCKETUSER]) {
+                    sshagent([Constants.GITHUBKEY]) {
                         timeout(time: 24, unit: Constants.HOURS) {
                             try {
                                 sh '''

--- a/tenable_io/api/models.py
+++ b/tenable_io/api/models.py
@@ -1275,6 +1275,7 @@ class Scan(BaseModel):
     STATUS_PAUSED = u'paused'
     STATUS_PAUSING = u'pausing'
     STATUS_PENDING = u'pending'
+    STATUS_PROCESSING = u'processing'
     STATUS_RESUMING = u'resuming'
     STATUS_RUNNING = u'running'
     STATUS_STOPPING = u'stopping'
@@ -1394,6 +1395,7 @@ class ScanInfo(BaseModel):
             name=None,
             user_permissions=None,
             control=None,
+            schedule_uuid=None
     ):
         self.acls = acls
         self.edit_allowed = edit_allowed
@@ -1414,6 +1416,7 @@ class ScanInfo(BaseModel):
         self.name = name
         self.user_permissions = user_permissions
         self.control = control
+        self.schedule_uuid = schedule_uuid
 
     @classmethod
     def from_dict(cls, dict_):

--- a/tenable_io/helpers/scan.py
+++ b/tenable_io/helpers/scan.py
@@ -441,9 +441,9 @@ class ScanRef(object):
             schedule_uuid=self.uuid
         )
         util.wait_until(
-            lambda: self._client.scans_api.export_status(file_id, is_was=is_was, schedule_uuid=self.uuid) == ScansApi.STATUS_EXPORT_READY)
+            lambda: self._client.scans_api.export_status(file_id=file_id, is_was=is_was, schedule_uuid=self.uuid) == ScansApi.STATUS_EXPORT_READY)
 
-        iter_content = self._client.scans_api.export_download(file_id, is_was=is_was, schedule_uuid=self.uuid)
+        iter_content = self._client.scans_api.export_download(file_id=file_id, is_was=is_was, schedule_uuid=self.uuid)
         with open(path, file_open_mode) as fd:
             for chunk in iter_content:
                 fd.write(chunk)

--- a/tenable_io/helpers/scan.py
+++ b/tenable_io/helpers/scan.py
@@ -1,5 +1,4 @@
 import six
-import os
 import re
 import time
 
@@ -44,7 +43,7 @@ class ScanHelper(object):
             scans = [scan for scan in scans if name_regex.match(scan.name)]
         elif name:
             scans = [scan for scan in scans if name == scan.name]
-        return [ScanRef(self._client, scan.id) for scan in scans]
+        return [ScanRef(self._client, scan.id, scan.schedule_uuid) for scan in scans]
 
     def id(self, id):
         """Get scan by ID.
@@ -52,10 +51,21 @@ class ScanHelper(object):
         :param id: Scan ID.
         :return: ScanRef referenced by id if exists.
         """
-        self._client.scans_api.details(id)
+        scan = self._client.scans_api.details(id)
         # object_id is not returned by the API when the current user is not the owner of the scan.
         # return ScanRef(self._client, self._client.scans_api.details(id).info.object_id)
-        return ScanRef(self._client, id)
+        return ScanRef(self._client, scan.id, scan.info.schedule_uuid)
+
+    def uuid(self, schedule_uuid):
+        """Get scan by schedule UUID.
+
+        :param schedule_uuid: Scan Schedule UUID.
+        :return: ScanRef referenced by uuid if exists.
+        """
+        scan = self._client.scans_api.details(schedule_uuid=schedule_uuid)
+        # object_id is not returned by the API when the current user is not the owner of the scan.
+        # return ScanRef(self._client, self._client.scans_api.details(id).info.object_id)
+        return ScanRef(self._client, scan.info.object_id, scan.schedule_uuid)
 
     def stop_all(self, folder=None, folder_id=None):
         """Stop all scans.
@@ -80,7 +90,7 @@ class ScanHelper(object):
         return self
 
     def create(self, name, text_targets, template):
-        """Get scan by ID.
+        """Create new scan.
 
         :param name: The name of the Scan to be created.
         :param text_targets: A string of comma separated targets or a list of targets.
@@ -101,16 +111,18 @@ class ScanHelper(object):
         if not t:
             raise TenableIOException(u'Template with name or title as "%s" not found.' % template)
 
-        scan_id = self._client.scans_api.create(
+        scan_uuid = self._client.scans_api.create(
             ScanCreateRequest(
                 t.uuid,
                 ScanSettings(
                     name,
                     text_targets,
                 )
-            )
+            ),
+            return_uuid=True
         )
-        return ScanRef(self._client, scan_id)
+        scan = self._client.scans_api.details(schedule_uuid=scan_uuid)
+        return ScanRef(self._client, scan.info.object_id, scan.info.schedule_uuid)
 
     def template(self, name=None, title=None):
         """Get template by name or title. The `title` argument is ignored if `name` is passed.
@@ -370,17 +382,18 @@ class ScanActivity(object):
 
 class ScanRef(object):
 
-    def __init__(self, client, id):
+    def __init__(self, client, id, uuid):
         self._client = client
         self.id = id
+        self.uuid = uuid
 
     def copy(self):
         """Create a copy of the scan.
 
         :return: An instance of ScanRef that references the newly copied scan.
         """
-        scan = self._client.scans_api.copy(self.id)
-        return ScanRef(self._client, scan.id)
+        scan = self._client.scans_api.copy(schedule_uuid=self.uuid)
+        return ScanRef(self._client, scan.id, scan.uuid)
 
     def delete(self, force_stop=False):
         """Delete the scan.
@@ -389,7 +402,8 @@ class ScanRef(object):
         """
         if force_stop and not self.stopped():
             self.stop()
-        self._client.scans_api.delete(self.id)
+
+        self._client.scans_api.delete(schedule_uuid=self.id)
         return self
 
     def details(self, history_id=None):
@@ -397,7 +411,7 @@ class ScanRef(object):
 
         :return: An instance of :class:`tenable_io.api.models.ScanDetails`.
         """
-        return self._client.scans_api.details(self.id, history_id=history_id)
+        return self._client.scans_api.details(schedule_uuid=self.uuid, history_id=history_id)
 
     def download(self, path, history_id=None, format=ScanExportRequest.FORMAT_PDF,
                  chapter=ScanExportRequest.CHAPTER_EXECUTIVE_SUMMARY, file_open_mode='wb', is_was=False):
@@ -421,15 +435,15 @@ class ScanRef(object):
             export_request = ScanExportRequest(format=format)
 
         file_id = self._client.scans_api.export_request(
-            self.id,
-            export_request,
-            history_id,
-            is_was=is_was
+            scan_export=export_request,
+            history_id=history_id,
+            is_was=is_was,
+            schedule_uuid=self.uuid
         )
         util.wait_until(
-            lambda: self._client.scans_api.export_status(self.id, file_id, is_was=is_was) == ScansApi.STATUS_EXPORT_READY)
+            lambda: self._client.scans_api.export_status(file_id, is_was=is_was, schedule_uuid=self.uuid) == ScansApi.STATUS_EXPORT_READY)
 
-        iter_content = self._client.scans_api.export_download(self.id, file_id, is_was=is_was)
+        iter_content = self._client.scans_api.export_download(file_id, is_was=is_was, schedule_uuid=self.uuid)
         with open(path, file_open_mode) as fd:
             for chunk in iter_content:
                 fd.write(chunk)
@@ -470,8 +484,8 @@ class ScanRef(object):
             alt_targets = [alt_targets]
 
         self._client.scans_api.launch(
-            self.id,
-            ScanLaunchRequest(alt_targets=alt_targets)
+            scan_launch_request=ScanLaunchRequest(alt_targets=alt_targets),
+            schedule_uuid=self.uuid
         )
         if wait:
             util.wait_until(lambda: self.status() not in ScanHelper.STATUSES_PENDING)
@@ -521,7 +535,7 @@ class ScanRef(object):
         :class:`tenable_io.api.models.Scan`.STATUS_PAUSING. Default is False.
         :return: The same ScanRef instance.
         """
-        self._client.scans_api.pause(self.id)
+        self._client.scans_api.pause(schedule_uuid=self.uuid)
         if wait:
             util.wait_until(lambda: self.status() != Scan.STATUS_PAUSING)
         return self
@@ -533,7 +547,7 @@ class ScanRef(object):
         :class:`tenable_io.api.models.Scan`.STATUS_RESUMING. Default is False.
         :return: The same ScanRef instance.
         """
-        self._client.scans_api.resume(self.id)
+        self._client.scans_api.resume(schedule_uuid=self.uuid)
         if wait:
             util.wait_until(lambda: self.status() != Scan.STATUS_RESUMING)
         return self
@@ -545,9 +559,9 @@ class ScanRef(object):
         :return: The same ScanRef instance.
         """
         if history_id is not None:
-            status = self._client.scans_api.history(self.id, history_id=history_id).status
+            status = self._client.scans_api.history(schedule_uuid=self.uuid, history_id=history_id).status
         else:
-            status = self._client.scans_api.latest_status(self.id)
+            status = self._client.scans_api.latest_status(schedule_uuid=self.uuid)
         return status
 
     def stop(self, wait=True):
@@ -556,7 +570,7 @@ class ScanRef(object):
         :param wait: If True, the method blocks until the scan's status is stopped. Default is False.
         :return: The same ScanRef instance.
         """
-        self._client.scans_api.stop(self.id)
+        self._client.scans_api.stop(schedule_uuid=self.uuid)
         if wait:
             self.wait_until_stopped()
         return self

--- a/tests/integration/api/cassettes/test_scans_configure.yaml
+++ b/tests/integration/api/cassettes/test_scans_configure.yaml
@@ -11,7 +11,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -19,48 +19,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -71,11 +77,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:18 GMT
+      - Thu, 21 Nov 2019 15:14:20 GMT
       Expires:
       - '0'
       Pragma:
@@ -83,8 +89,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -94,9 +100,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - ea26c61516e59a062d6ddaac80c7396b
+      - 5ddef4e96bcde336ffcff034f6fb453c
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -104,7 +110,7 @@ interactions:
       message: OK
 - request:
     body: '{"uuid": "731a8e52-3ea6-a291-ec0a-d2ff0619c19d7bd788d6be818b65", "settings":
-      {"name": "test_scan_5188", "enabled": false, "text_targets": "fakehost.tenable.com",
+      {"name": "test_scan_fixture", "enabled": false, "text_targets": "fakehost.tenable.com",
       "acls": [], "asset_lists": []}}'
     headers:
       Accept:
@@ -114,13 +120,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '208'
+      - '196'
       Content-Type:
       - application/json
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -128,14 +134,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VS246jMAz9lzw3FQQCoU/7JygXw0QbEpSLqu5o/n0dWjpaaScPKNjHx+fY+SRJ
-        S09un0QHn6X1EGdryI30vFVKj4JOimna66WjqpGcdoMBM3WjEtyQCwn3WlHKUQMj10YLoIoJSXvZ
-        jVRMmtFB8wFExyfeSKx5oTNsu5MZKG8ZV5ii0I8tReBAh2UaKQwt6zuDad1DByMshmlh+KImgTRe
-        bnDQpDxXEzNvRY0bSDraPduAvnxx7kL24Kx+HMbYcDksn0afgDPykta8Dv3P56fTYmvYpHXpTbrh
-        ldSwl8oBEi/SJUCFMn2oIKOZF+vghFuvXTEwy3WNsOJgyC3HAk9xc7YbzHfrTbifBbqkHLY5y7hC
-        rq2eN3bdi6rXa342TqBLtPlx1WFDNQlzudKdPDEWBJ1/NfMn+HfWh2wXq2WdZ9WbIX47/JCx+mpw
-        qQnHt0PcbEqIREjLRF3GIovL/2aa17tBydKbCPdfyfy+hri+H9SxqQtxEne7BfMtwBxzafnQMTZN
-        E3bQEX5K5cdeXwiOA9eP3Afr+PX1F+V2Uln1AgAA
+        H4sIAAAAAAAAA3VS227rIBD8F55D5GDjS57On1gLrB1UDBZg5bRV/72LE6c60ikPlsXOzM7s8smS
+        Bs+un0wHn8F6jKM17MoaeVFKdz0flNC80VPNVQWS161BM9Sd6qVhJxbuhbFtOwc7qY3ukSvRA2+g
+        7ng/aMFbLVvsaznICojzRGdcVgcZuZSqEwINh7YWfJKo+FTpicveqEqoAYRRGlozdAitaDswOJCM
+        hwV3mZTHEmKc7N+8RaSSwaSjXbMNFM1vzp3YGpzV73s2UdWnPfYR9oE4bp72qufh//n8di7UGxew
+        Lr1EF/pl5dqDckjCE7iEZBHSTQWIhmw7PODWa7cZHGGeI840HHbNccOHuTHbBce79SbcD4LeUg7L
+        mCHOmEurCd7wFlI+50fHsw4LtU+EyIV/EGPcHL5slspH8K+qD9lOVkOZYDGYMf5EukEsQSraZKJ5
+        rRgXmxIhCXIRfRn/BJvL/1aq52Mhj+BNxPufZN7OIc6vV7Tv5sQc0EKXYH4MmH0QF9k1dTOIlpR0
+        xN9K+X0tz2LdFC2ctB8bb76+vgF1/El06wIAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -146,7 +152,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:18 GMT
+      - Thu, 21 Nov 2019 15:14:20 GMT
       Expires:
       - '0'
       Pragma:
@@ -154,8 +160,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -167,9 +173,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - b0b042169b9fc70f2cad2cb57f586e42
+      - 5e8a12445e3a67979ffe941036d605d6
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -192,22 +198,22 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: PUT
-    uri: https://cloud.tenable.com/scans/27
+    uri: https://cloud.tenable.com/scans/template-55b722ed-a632-f5eb-f0cf-58db02b9a2dbca6d97ea6267ade9
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VS247cIAz9F56HKiEhl3naP4kMOFlUAhEXjbZV/70mO5lVpa0fEPI5ts8x/GY6
-        +AzWY1ysYXfWy1YpPU58VkLzXq8dVw1I3g0GzdyNapKG3Vh41IpSzhocpTZ6Qq7EBLyHbuTTrAUf
-        tBxw6uQsG6CaJzvjfjjIyGUrpCKIYz+2nIgDH9Z55Di0ou8MwbrHDkdcjdCTkauaJ2rjYUdqkzT4
-        pd4XNDZT3mDS0R7ZBs/uvjh3Y0dwVn+cxsRwO0suo5+EK/OU1jyDf3P8L1oajTtYl15Nd7qymvag
-        HFLjFVxCUgjpXQWIZlmtw4tuvXbF4ALbFnGjxbB7jgU/xS3ZksOH9SY8rgJdUg77kiFumOsoBclq
-        mpcolWvBxYyxOHzpqsiv4F+oD9muVkPdWFWUMX55eIdYlTf0bIkWdGDcbUrEJEorprruFYrL/yLN
-        82eQKPAm4uMtmZ8/QtxeX+Z8ixtzkPKyB/MlwJzOWzl0QswU5DPitxANzx9H/QNHUe50fnYd//wF
-        qixiRc4CAAA=
+        H4sIAAAAAAAAA3VS227kIAz9F56HVUJCLvPUP4kMdlJUAhEQjWar/vtCZjLVSi0PCNnn2OfYfDLt
+        XQLjKEwG2ZW1slZK9wMfldC81XPDVQWSNx0Sjk2vBonswvytMPb94FAvNeqBuBID8Baang+jFrzT
+        sqOhkaOsIHOe6ETrZiERl1L1QhBy6BrBZ0mKz5WeuRxQVUKNIFBp6HDsCTrR9YA05jIOVsplogY3
+        lfdEaFKOI0UdzJaMd+zqdmsvbPPW6PthTFTN5eCcTh+IM/LUVj0P/+H67dS5N61gbHwVXfOTlbAD
+        ZSkXnsFGyhIhvisPAafZWDrhxmm7I02wLIGWPBl2TWGnh7gpmWzxZhz620nQe0x+nRKEhVJppSAa
+        nfvFHEqFcCJD2C29dJXMX+9eWeeTmY2GMrKiKFH49vAOoSiv8t5iHtBGYTUxZmSG1GIo855ht+n/
+        TPX8GlkUOAx0e4v48ceH5fVnjmVcmIWYptXjtwA8nNeyb5t2FF2dfQb6MZWbpPtWPsG2K3s4f6y4
+        /foHALCAMtACAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -218,7 +224,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:19 GMT
+      - Thu, 21 Nov 2019 15:14:21 GMT
       Expires:
       - '0'
       Pragma:
@@ -226,8 +232,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -239,9 +245,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - e6252efcd13333c8e2f800d973c9ebb1
+      - 757756bb69fa859b2cc63b5829a4fb90
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -259,21 +265,21 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/27
+    uri: https://cloud.tenable.com/scans/template-55b722ed-a632-f5eb-f0cf-58db02b9a2dbca6d97ea6267ade9
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRy27CMBD8FbTnpCKBkDSnqr33gnpCKDLxBlyMHdlrRRHi37sJgbZUva1m9jEz
-        ewZlGgvlGWxn0EEJwkiH3YuXxyfr9hCBESdk3NfCVENdoVQ04LYi4fZIUDZCe4ygsVqiq5SE0gSt
-        I6itIWc1lOQC88Ez26I7Ke+VNR7KJC0i3nxAGTRWIQyjQHhqtSCMsyTNdtlcxLjMkxiLxSpeNc95
-        jKskXS4k0/USF5hjI9O6kFmzey5Y2KCvElrbDuXt9KCe/VWTmY/17E3bIGfrK85TrdWq7pl7FV7V
-        s3ekzrrj2MCsPwiHd19294k1jUbTPAIS+ykKf+sQteZ6c4ZfdufRLeZrl1SenfaTqiv2s/5Okvp2
-        0C2xEUETXKKHzWOQ0+7kcfG/P/2Dj47u14Z/wWXL7klQ4CvAn6Ger8NBebKO49psL197YLz6RAIA
-        AA==
+        H4sIAAAAAAAAA3VRy07DQAz8lcrnBIWFpG1OCO5cKk5VFTm7Trt0m432oSiq+u846QMo4maN7fHM
+        +Ai6bSyUR7B9Sw5KwFY56l+82j9Yt4UEWjwQ415iW411RUqHEbdVQLelAGWDxlMCjTWKXKUVlG00
+        JgFp2+CsgTK4yP3ouduRO2jvtW09lI9ikTDzjlQ0VMU4rkKgQ2cwUJrn9VwIUikWTyJtcqrTJpNN
+        mi9UnYl6iULVEgu1nBMWopijoiULG/VVaIztSV1Pj+rZX3Ux87GavRkb1Wx1xnmrs0bLgXuv6LWc
+        vVPordtPA9z1O3R082XrT5JhMiqy5wQCbi9Z+OsISsP1+gi//GbJNefzlNKerQ4XWWfsZ/0dZRi6
+        UbiiBqMJcErumKckL9yP98T/PvUPPlm6XRsfBqcN2w8YIl8Bfk0Y+DrstA/WcV7rzekLSQ+q2kUC
+        AAA=
     headers:
       Cache-Control:
       - no-cache
@@ -284,12 +290,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:19 GMT
+      - Thu, 21 Nov 2019 15:14:21 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -299,9 +305,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 3e26e0214784b27e14efdb60f9319913
+      - d316c403fbba8666fd53acbdd4842ae0
     status:
       code: 200
       message: OK

--- a/tests/integration/api/cassettes/test_scans_control_endpoints.yaml
+++ b/tests/integration/api/cassettes/test_scans_control_endpoints.yaml
@@ -8,10 +8,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -19,48 +17,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -71,11 +75,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:53:19 GMT
+      - Thu, 21 Nov 2019 15:39:35 GMT
       Expires:
       - '0'
       Pragma:
@@ -83,8 +87,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -94,9 +98,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 288347a7d7d4f26dfebbbeb7bce6952b
+      - 106f811c31577a7107f4dfb12bf261ef
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -120,7 +124,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -128,14 +132,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VS246jMAz9lzw3FRACoU/zJ8gkphNtICgXdbuj+fdxaOlopJ08IBPbJ+f4+INF
-        DSu7fDDt1wR2xTBawy6slfU06V7xYWo0b/Us+FSB5KIzaAbRT0oadmL+Vjpy3nuwl9pohXxqFPAW
-        RM/VoBveadmhEnKQFVDPszrhsjlIyHHSoEEI3ohB8B6w46qeJUW1NE2jhlqrQVStBmil6iuou5Zg
-        Vlhwh4lpLCLG2f5NOSClDEYd7JasJ2lrdu7ENu+svu/a6mo47bIPsY+K4+ZJr3oe/p/Pb6emt3EB
-        6+ILdKGQlesVJocEPIOLSBQhvk8egiHaDo9yu2qXDY5wvQa80nDYJYWMD3JjsguON7safzsadI7J
-        L2OCcMVUnnpEzXnLUwnP6fFwRJ2DTfez9guxiZRLBe7ACSFT0fFXMv/8+squPtnZaigDLXwThm+F
-        7xCKroqMjTS+DcNiY6RKKqkbVdyYIbv0M1M9d4cow2oC3t6i+XP24fpaquJCc2IOyN/Fm28CZp9L
-        LTshetUPZKYO+Fsq3beyJTQO8p+w9wWoq8/PLykFMPf6AgAA
+        H4sIAAAAAAAAA3VS247jIAz9F55LFZISknmaP4kMOB20JERc1O2O5t/XpE1HK+3wEBF8fHyO7U+W
+        DKzs7ZOZsGZwK8bJWfbGLlJobdTAR90afjFzx3UDkne9RTt2Sg/SshMLt5pRyp6DShprBuS6HYBf
+        oFN8GE3LeyN7HDo5ygYo54nOuGweMhJQ9wK05tKInot2BC6wtRxUM5jGyrkTl35Wg+yFkmPf9M2s
+        iGaFBXealKdqYprd71wiUshiMtFt2QWythbvT2wL3pn77q0Vw2m3fZh9II6Xp7zmefh/Pj8dQbVx
+        AefTi3ShK6vPK2iPRDyDT0gSIX3oANGSbI8H3K3GF4sTXK8Rr9Qc9pZjwYe4KbsFp5tbbbgdCaak
+        HJYpQ7xirqUet/a8FV2v5/wonNCU6PL9bMJCahLFcqU7eGIsBDr+auRPWF/RNWQ3OwO1oVVvxvjt
+        8ANi9dXQYBO1b8O4uJQISRDRDnUaMxSf/400z90hybDaiLf3ZH+dQ7y+lmof1Yl5oPkuwX4LsHtf
+        hFSXTjZKSepCxJ9C+b7VLaF20PyJ+7EA49fXXzySmpj6AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -146,7 +150,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:53:19 GMT
+      - Thu, 21 Nov 2019 15:39:35 GMT
       Expires:
       - '0'
       Pragma:
@@ -154,8 +158,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -167,9 +171,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 35cdc4994a5b0ac513084e4ffdf82d27
+      - 7b50d6a2800fc98e025b065d37580f51
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -187,21 +191,21 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRS2/CMAz+K8jndqItj9LTtN13QTshVJnEhYzQoMQRQ4j/PhcK25h2s/zZ/h4+
-        gWkbB9UJ3KElDxVgqz0dnoPePjm/hgRa3JH0mQLXQWFbN+aTo6cOcjWjXxND1aANlEDjrCZfGw1V
-        G61NQLmWvbNQsY+CxyDonvzOhGBcG6DK8jKBoDako6U6xm5VyHZ7i0wprRQqLIo0L2ZFOkWapGXW
-        jKXKxjrPy1mmylkxHCnE0bicDjGbjEQYacM1WusOpG/UnXaxWPd+3ueDV+uiHsyvfdnaO2vUUbAX
-        DEYN3ogPzm8vA4KGDXq6+3KrD1J8MZplwwQY130W4TaCykq9OMEvvzLbR32d0iaI1WMv69r7WX9H
-        ycd9J1xTg9EynJOHy5ck+9vZ4+F///qn3xHmd7buYXBein1GjsIC8ho+CjtsTGDnJa/F8vwF54QF
-        10gCAAA=
+        H4sIAAAAAAAAA3VRS2/CMAz+K8jndmo6WqCnabvvgnZCqDKJCxmhQYmjrkL896XlsZd2s/zZ/h4+
+        gW4bC9UJbNeSgwqwVY66J6/2D9ZtIYEWDxT7TJ5rL7GtG/3BwdEA2ZrRbYmhatB4SqCxRpGrtYKq
+        DcYkIG3Lzhqo2IWIBx/RI7mD9l7b1kMl8nkCXu5IBUN1CMNqJDscDTKlU9yUAjebtJCiTEW+wFRQ
+        rlKcZXOZqaJ5FNOymc2LUsyKRZmVWTOLwkhprtEY25G6UQ/ao8X66udtOXkxNqjJ8tKPW0drtOwj
+        9oxey8krcWfdfhyIqN+ho7svu3knyaPRXCwSYNxes/C3EZQm1qsT/PCbJbeoL1NK+2i1v8q69L7X
+        X1FyfxyEK2owGIZz8uvymOT1tvh9+N+//umPlu5sw8PgvI72GTlEFoiv4T6yw057ti7mtVqfPwGA
+        BRFESAIAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -212,12 +216,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:53:20 GMT
+      - Thu, 21 Nov 2019 15:39:36 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -227,9 +231,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - cec765473dd62e58ca7024d37603d982
+      - d786f18e8f50ad30529755f0114b221a
     status:
       code: 200
       message: OK
@@ -249,16 +253,16 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/110/launch
+    uri: https://cloud.tenable.com/scans/219/launch
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSsjCxtEwzMkjWtUxJNNE1sbQw17VITUrWNTVISbRMTbG0
-        NDE1VqoFAItWBdg0AAAA
+        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSMjMxT040t7TQTUk1NNI1sUg10k1KMzbSNU02NzY2MjE2
+        NDA1UKoFAODUGZQ0AAAA
     headers:
       Cache-Control:
       - no-cache
@@ -269,7 +273,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:53:21 GMT
+      - Thu, 21 Nov 2019 15:39:37 GMT
       Expires:
       - '0'
       Pragma:
@@ -277,8 +281,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -290,9 +294,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - c4f23ce1d9becc21d7b4ba4e5163765f
+      - 04c999657f294731c61ad89b972b7ad6
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -310,76 +314,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPbGLB5mSVAJtkNhAMJ3TvdWY6wBWhjbMaWc+mQ/74l
-        2QYRbEI6l2Zm8kBkVUmu+upilXx5yBF37OVqDznv1sV+rpZDru3j238G9nXR8ye5Qs5FMwz9FAd0
-        GFjIHY7JHQ19zEjekCJ/gmmuNkZOgAu5sefY2B8SO1dzQ8cp5CzPpb7n5GrUD4EeBkCdY39GgoB4
-        bpCrqZpRyAXWFNuhg4dhyIbCyWZzB1Es45GFLFQqyVrJLMlVhCuyoY7L0FLLtqYZpmoZZknRLYT0
-        slFVkFrRQTBsEzpEjuPdYnspGxMedBzGCl32pYbjhbbUj/ph2NxziHUPtCMUEEvqYHrr+decAajB
-        FPl4qZg3+h+2KNdUVZVCjqJJDEaQsCDLgfaXh9yawsAbYx1x2SQAXe9jsaI+sb3Ckt7PmeA2HqPQ
-        obnHwpOZOZTx3OrTiTMNu9HPTqgtz8Yslnu8KuSmXkAtL3QpVyE2lKGb5lhTLNm0kS7rplGVDbCZ
-        XFZsZGLbNPVyiUFHEQ1BQvA2QglyyDfislNxf4pPNA9yDMUYwbilFefhiDWLFLto5OAAW6FP6H3R
-        8mbAjxyaoD4ESVfGnltEhsnlcO54aN0HhiCND1qo5UqpVDUMBbCiZAb+jWbz9e4pCq5Hy8FwhELw
-        LOoj4my4VTwrM9Uj8JKAev49N3/cjnxFMTRTKSWGGsZgWz5GFKw4tMHr12VwEATezLPJmFhZPC+z
-        hgj40jJz7NqJUaJg9LmhMxBOPII5ODRvQge0QSPigH1x3Akmmgs87NAhyLVwdDwmDsV+FCGxLzLu
-        IqhSyAEeNrN34r31IMBUOm3mhJTykGiCoeOeD5rgOzj+osgmksdXD8ajfLA80B/l/EPpcXmsao8H
-        hZ1Z8z+JUiVnUlStpJcrVRmNLFvGY0WVWYdcqRom62I9EKg5DwIVgRMwbXP4dxZ9/HeGqDVlR1ED
-        UJn4XjhPtBZhvecBHxPmTjghbhGBL5JRCLm5OEqF7SicgLf+vitw/2UaX/0cwXL1c7rOncv2UavH
-        hb9zsDuhU3BG40OUxHcQzpDaxz5wsNw8hOC7QUGK5o16Z1DvS61ohHScjEjFwfa9uQ0BCUQHgpXJ
-        z65XcMidPXeVqd0rlIlEH86RdY0mOFuF7pJhJ8GjUdDR1GLl2QRw/GlKKB52IcYgKn0I+nfR6s7H
-        41qj1buQG400nYAi1e0bEkBG3NktG3U58kg5cdCnPfmf/p7mq8D2H/iTT5vSAcE1CY41RSnJipH/
-        mLBcwpGFxUCc67vjNF157FNpcCmBCNjHkHcjDFQAQM3vS/x6fqrrn/daex2781Spu62dzFdMzasX
-        rc8XH+OU1g0u+ug2TYPBbhr89wA4F5Bq8vKBaprmQlO+KOoVd8d8FJIPegGur7vxZTnwoAXhqpZl
-        WMlUCvFRRVYVuOR+FFJBMByhAEPpk+Gpg35fgnoBQ5kQcewevl+/FuMA/iVV/2qxvKEmrJmAdcJ/
-        38STmYas3vJ85GzX8iLmepWmqYrqRe2DFb2B4s3zM6NA1HbAWXe8UMFI7W+t2sHlonveWBwvThad
-        Zv6wd1Y7OD9eXCw+LS6jjgawNBaXvUWDHfM4+a6R+YzQadVOClKrdrwB6xvHxvM4vhy++qB2cLao
-        Lzr5wzpoe7JoL86gGdYOOov+op0/bLBWd9HIH54uW/WktcTyddNkAQuzdgoS/NbfGdrSDnnnplRU
-        /ujJp7Rj9uG6/vFTUOklOWhd55dGUg1GH0YZheeTz3E6ibPJ5yiZQC5Z9OAgjpuXDfrB6ae0K4bf
-        BR1LIB1IIGeLbpRCzhYn+cNuj/Xy5iXPG738YZ/h1eAZ5QRIHZ5R4lY9aYkAv/HUPzRZRSXOp1aa
-        AT7tupyMQ/O5iuZT62k1A+Xcu5Ryq92qoY0DyydztveWpuMUW9dShx288dr/DURfgpUm+JJN6gls
-        e6HCppfFu95DZEWb0Jv6NCOOw3+7UA1K9Ygv2J+acbP4tbUhdhzipWnT4oR9roGX0kdjn1XhPULk
-        XXcp0A0iDpMhTbdYqbrAsyd24fm41TyS+WZSluBNRBFbYL7tltNe7Q3HPdNwlI3DCSfuieVigWPe
-        IQbzZKxsWmucUgs4d1UjHhpIyMeS6OIdT4oFkEgAl9nfQ8Lud3LCNc+pOH3oe2KB7eHofjhDzi1K
-        LQ1aCZt0dC+1l2z7ZdBICRcHQZh2q2JNh07C9UNU4Dfg4nv6m4KeAJU1D0+7Ut22fRD1FQldNbWi
-        WjGKalErqFXWLsKPvGoqSkFV2L9iGZbMml7g0uE7BOsWzG8Af9wW/ml9UE9BhHW/MIPKX+ryb0j+
-        diWvZ9Sn/RkZlp9xYw2sqnJdVtSy+pG3NUCUo3RMjj4ck6NUTI4+EpOAkskwwDeYPZ+Qjktb6q/o
-        u6BDbk4HVz9n6LyaLVL5dPDB1k+7qcW6P9z6Fz8+Iog7pFNAAd+mpfhTV7qYYkjut3tUkGRfVff1
-        Qios7maYooB3psm/JO5zAbVSIauCEvT4w1RPPDm0+8dpyaFNLN8LvDGVjkLHwZS4u+WJdv/J7f8n
-        HRmZod03Tdk0TWBXFLlqmB+IwHl/0Ey7OvL+P03RNWcTDOfhyFl7OG1T7S5jlLorRlaAZiQYIIwJ
-        duwNIB70x8Oooa0aqZCwhz4O2+3DZnPD5Gx62WFZI27hpDmhq9aykwPGW6/dLtm6i9jl/FJzjWmf
-        tuLGaEYc/gxjpvDHnGVrfh3OQoeSVZZdnqUH1c8JotKZZ7G7O/FTnhLfXGWXTP7spCDVSVe+/LyV
-        WxO4m3hEkLuVvSSw9z0H+VADb+PXBf5jbHs+2speFtgbv55KaBQGOCFWBOKvYGLP2zpXVRQ17Le2
-        MhsCc/10O2SmwPuJuGCwQKpJm0l7aRBFHIBHMK1/wx7pjMmiwfrti6409z1wm9mSQbTRsY/xUb+5
-        3QNEK12OQpeG2/lFK/UdZF2zZc32IaKl2uzhaHT9zAjRfD088yiWxsTBErKsqELmXKLVGmDk8/72
-        WUXDHV90k+4UGyUOr6xJbsEJnokQdS1EXAKc3pgbkfBbAZxJtFGbBFYxIaxFTDRGsjHFVpy9OJO+
-        dgq+QS9duuRO3J/njOkBAu73ud9PeNbiBEHG8T2PwtKfQc4TD+cSge51G0m3kerclwH2pRly0QTP
-        ML+twJnN9YiExOgkeUJEOdlEXSYREdEuxr584cnsv3TMHKI/hbTiJs/Yl0RkG6f9xnlCEJE9Jj6+
-        RY6zPIWI6BF4tO15y4griSj2G/VmPSGI0DU7CaIlESuAwgF/lYLIlss5ReC6/A0JaXXrKGEyn5oG
-        ScEUO85T6+jKmtdQyCaTZUpdQ8/zqRQ/W79kEBFjb2dENQonrWPmTgDztRyrr6WCTjsJKF2ErHOa
-        IKNXnqYBcrM9w+siloM2TzSt/vYI1EVsj/yQZQ7PhziCdQMS2ER0/xW63vZLU3kNY4uAX7OXB6Qz
-        4oZ320eKFmh7I+a0TSx6Q1k0wbmPLODYYV7ROvUZ+gbrvx1GiSbrIseT6g7dfmksi9Y8CdEtJtv5
-        RTMfl5NXfp7Bt7qBwaC9fYRo51PXIjbYROrhYO65QeLCZdHKA+LT0Pv2bbu6FdHSv11sXwlU1Me3
-        K2O3rQN3LW4OlMUXFRbx0UpeKVQe8wdfvwY/yezn4Ckp/8tBgRNeOCqjaPrM/gr8V+a/T+onRVHe
-        o+aPelLe58lEsy2w/jWKpozNkBiPPd0I8UI6D9P2omKxzxP69wpO8R0teHQKFzbW/JitjNhddynw
-        IzX/yhV+DBZXMhOgi4i60xakw7I5n4qtod5kExJWVUX2kyZg1L3rrtSDWig/rjLvqi9J1M9xZSRm
-        QykYkHxlQzGUF+Tk5DlNZu0XwuF71LM8Jw2SFWm3PWNrDkehzX6JNZu/hcnES0WKiD1soYBK/2AF
-        FZ6nGzBF0oib396PZoDm+z2NwhYkUF6miB9T/jQbogHGQ+QEXqqqGBawnLRvF68tdy233rDM2taD
-        Ne6Y6XnmsYdX2tgmIXtb+4RMmHQNmI+wzPYuDhd4TpgRK/0VaZ+2VkXh711vHpC0W4j9FWlPhQ/d
-        IJyzlBo973KDXZs/c/1Uk8sVH3viZZDw/ZDbchTqt2viTopj4gd0OPZCN620WX9N85jxQpmF013p
-        T7G+WQLDP0CwGy5n6E8Py6bb38z9YtabK+vwdH3i8bq8h9i+l3Qw6PbyL7ruJS+x/MB3dhjrLgXB
-        E9X/MnXBMm7YpzWeB6ZPM9HYTH4dzK6nx+SOL9zqFiU3mK/ggtAfI+tt1nAUTYqlatlQEfvQTgUp
-        sq6hsWzalZGsj1SjUjI1zS6ZKartOOw77g/yzw/dICfEw5KqAgNvbxI2t7gCTOUp/0RE3HI9+jIw
-        FL1UNXRUkTXFVkGrkSKjsYplBeFKScGqpVlWChg7DnsdGGUjHQvofw8o+BkgjPGEfdCmwj8n81Tv
-        NJ5XKlnWMrQEwrtYXK3aVbOsyljXdFnHWJWRoWNZHWNlrJkaVuxxmsV3G/Y6MKrlSjoYjPD+Nq8a
-        /PzbjR4zvU5RXS2lK8oI76FopYTLCCMsm5UqZC9DG8mGYSNZt0pjfWSNqraqp6i+47DXgcG+aJaO
-        Bqe8DRxX7JNuNPl8k49nMDe/ZEPPw+Pj/wGKiCABLU4AAA==
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBevPxlFgFHdwQ5onTvdrucIimw1pAwefho8X/fW5UE
+        Atwg2mozM/4QK1VfVe797iNVlYTHHHNGbu7gMefeOdTLHeSIY3n07p++dVN0vXGukHPIhEJ9QP1g
+        4JvEGYzYfRB6lDe5g4B4YxrkDkbE9mkhN3Jti3oDZuUOnNC2CznTdQLPtXMHgRdCe+hD65R6E+b7
+        zHX83IGqVQs537ymVmjTQRjyrnCxydQmAZUNMiyrZDiUS6ZallWtRmSVapZMKkrVVKzSSFeN8qhS
+        LZXVSqlWVsrKqAKCUYsFA2Lb7h215rJx4UHHQazQZU9q2G5oSb2oHrpNXZuZD9B2SHxmSh0a3Lne
+        jQBAq39NPDpXzB3+j5qB0FRTa4VcQMYxGX4CIaYN5S+PuSWFlULCdYSymA+6PsRiRXXp8oLL4GHK
+        BbfoiIR2kHsqrIwsqIzHVlcHzjTsWr1QaX41brHc01Uhd+36gemGTiBUiA1VNiomqdSqskVVTTaq
+        VJOHI10Dc1V0XTN0VSkpnLqABCFICN7GAkZs9o05/FLCn+ILTf0cZzFmMC5pxWk45MViQB0ytKlP
+        zdBjwUPRdCeAJ3aQsD4ASRfGnppMhsHlcGq7ZNkHBiCNB1qopYqhl5RKpQLXZRPwbzKZLldfE/9m
+        OO8MZyQEzwo8wuw1t4pH5aZ6AizzA9d7EOaPy8JXVFUp6zU1MdQgJtv0KAnAigMLvH5ZBptA4E1c
+        i42YmYV5mTXShM8tM6WOlRglCkZPGDqD4cQjuIND8Ta0QRsyZDbYl8aVYKJpCsNPbUYck0bnI2YH
+        1IsiJPZFji6CKoUc8GFxeyfeW/d9GkgnzVwqpTwmmlCoeBCdxvQezr8oMiSK0dVj9Unem58YT3L+
+        UX+an6va015ha2j+p7RUyZUUVdONUrkik6FpyXSkqDKvkMuVao1X8RoI1JwLgUrACbi2Ofo7jz5x
+        nJDAvOZnUQFYGXtuOE20TtP6IAI+bpja4Zg5RQK+yIYh5ObiEKXtMByDt/6+LXH/5Rpf/RzRcvUz
+        rnPnsn3YOhfC39vUGQfX4IzVD1GS3kM4Q2ofeYDguXkAwXdLfETzRr3Tr/ekVtRDOkp6oDxYnju1
+        ICCh0YZg5fLz+xWcCmfPXWVq9x3KRKIPpsS8IWOarUJ3DthK8KgXVDS1WHk+AJx/umYBHXQhxiAq
+        PQj6d9Hq3qOjg0br/EJuNDCdoEWqW7fMh4y4tVs26nLkkXLioKs1+Z/+jvkqwP4Nf/JJU9pj9ECC
+        c01RdFmp5j8mLOd0ZHHRT4/16jjFladeIPUvJRCBehTybsSBCgSo+V2JX9dDXf/svLXTsTtFpe62
+        tjJfEc2rF63PFx/jlOYtLXrkDtOgv50G/90D5AxSTV7eU2u12kxTvijqlXDHfBSSj0YB7q/b4bIc
+        uN+CcFVLcq1aKRfiM1gGKHDL/SimfH8wJD6FpU+Gp/Z7PQnWCxSWCRFi+/D9+rUYB/AvqP6VYmlN
+        TZgzAXQsjm/iyVxDvt5yPWJv1vIiRn2XpqiiRlH7YEVvYfHmeplRkNa2L6Bb3qigp/a31sHe5ax7
+        1pgdzY5nnWZ+//z0YO/saHYx+zS7jCoaAGnMLs9nDX4u4uRVPfMZodM6OC5IrYOjNVrfODae5/Hl
+        9NX7B3uns/qsk9+vg7bHs/bsFIrhwV5n1pu18/sNXurOGvn9k3mpnpTmXH7fMFnEwqidggTH+jtT
+        q2+Rd271ovJHTz76ltlH6PrHT0H6S3LQss4vjaQD6L0fZRSRTz7H6STOJp+jZAK5ZHYOJ3HcvKzT
+        D04/+rYcvoo6nkA6kEBOZ90ohZzOjvP73XNeK4qXIm+c5/d7nK+GyCjH0NQRGSUu1ZNSmuA3HvqH
+        JqtoifOphRng07bTyTg0n1vRfGqtrmZgOfcuS7nFbtXAor7psSnfe8N0vKbmjdThJ288938D0edk
+        YYLPYdJ5CrYTKqx7WbzrPSBmtAm9rk8zQuz/5sBqUKpHOH931ozri19LG1DbZi6mTUs07PIaeC59
+        1PdZFd4jRN51l4LcEmZzGTDdYqXqKcyO2EXk41bzUBabSVmCN0lA+ATzbbecdmpvOK65DofZPByL
+        xh2xXCxwjB1QME/GzKa1hJRagNxWjbirLxGPSmkX77hSLIDEfLjN/h4y/rxTNNyInErxru/JBbUG
+        w4fBhNh3BF0atBKYdPggteew3TJopIRDfT/EHlUs6dBJUD9EBfEALn6mvy7oMbTy4v5JV6pblgei
+        fkdCV2taUS1Xi2pRK6gVXi7CQV4UFaWgKvxfsQRTZs0oCOnoPYF5CxUPgD9uC/+k3q8jjPDqF2ZQ
+        +Utd/g+Rv13Jyxl1tT4jw4orrs2BVVWuy4paUj/ysQaIcohzcvjhnByinBx+JCd+wMYDn95S/n4C
+        zktb6i3at2GH3Z70r37O0HkxWqTySf+DrY891OLVH279ix8fEcwZBNfAAr3DUvyJI11cU0judzu0
+        IMm+q+7qjTQ1uZvQgPiiEpN/3rjLC6iFClkrqJQef5jVk0gO7d4RlhzazPRc3x0F0mFo2zRgznZ5
+        ot1befy/UpGRGdq9Wk2u1WoAVxS5Uq19IANnvX4TuzuK+j/NomvKBxhMw6G99HLautpdDpS6CyBf
+        gGYkGGgYMWpba0Q8Gk/7UUFbFFBK+Esf++32frO5ZnI+vGzzrBGXaFIcB4vSvFIQJkrfu12ycRex
+        K/BScwm0S1txIzJhtniHMVP4IwHZmF8Hk9AO2CLLzq9yDqufYxJIp67Jn+7Eb3lKYnOV3zLFu5Mp
+        qY678uXnjWgthW7SISPORriegvdcm3iwBt6EN1L4I2q5HtkIL6XgjV9PJDIMfZo0llONv4KJXXfj
+        WJW0qGGvtRFcTYHrJ5spq6Wwn5gDBvOlA2k9ac8NoqQ70CEM693yVzrj5rTBeu2LrjT1XHCbyRyQ
+        ttGRR+lhr7nZA9JWuhyGThBuxqet1LOJecOnNZu7pC3V5i9Hk5tneqTNd04nbkClEbOpREwzWiEL
+        VNpqDTDyWW/zqGnDHV10k2rERonDK0uSm3CBZyJEXQoRhwHSHQkjMvEoQIDSNmoz3ywmDUsRE/WR
+        LBpQM85eAmQsXUJs0EuXDrtP788LIB4g4H6fe70EsxQnBDKO57oBTP055SLxCFSa6PNuI6muos59
+        6VNPmhCHjOmEiscKAlxbjkhIjHaSJ9IsJ5uo8ySSZrRLqSdfuDL/Lx1xh+hdQ1pxknfs9TSzjZNe
+        4yxpSDN7xDx6R2x7fok0o4fg0ZbrziNOT7PYa9Sb9aQhTV2zkzCqp7kCKmzwV8mPbDkfM01cV3wh
+        IS0eHSWg2qppiORfU9tetY6hLHlNANlkPE+pS+y5XiDF79bPAWnG+NcZ0RpFNC1z5oyB86Ucayyl
+        gk47CSgjTVnnJGHGKK+mAXa7OcMbaS77bZFoWr3NEWikuT30Qp45XA/iCOYNJAVLs/uv0HE335pK
+        SxybDPyafzwgnTInvN/cM22BtjvkTtukaW8opU1w5hETEFuMm7ZOfUK+wfxvi15pk3WJ7Up1O9h8
+        ayylrXkckjvKNuPTZj4qJZ/8PMNvZY2Dfntzj7SdTxyTWWAT6Zz6U9fxExcupa3cZ14Qut++bVa3
+        rCwFxF2Pf4MiNX7tnW7upj693YJ204xw22XOnjL7osJ0PprTK4XyU37v61f/J5kf9lab8r/sFUTD
+        C3tlLJ8+87+COMriuLKSUhTlPVb/UQ3yZU8mm+0U9K+xfMrYFon52NEtETcMpiG2KxWLfZa0v1bw
+        gN4HBTe4hlscL37Mpkbsrtss9SM1/8pr/ZgsoWQmQRdR61abkTbP5mIoPpt6k+1ImF8V+QETMKre
+        dn/qUS2UnhaZd1GXJOrnUBmJuaoUqpB85apSVV6Qk5M3Nrm1X0iH5wau6doYJYum7XaPzSmchRY/
+        MnMyfQuTpW8ViIjn1CR+IP2DL63oFDcgImmEFg/6oxGg+H7vpfAJCSw0EfHjlj/N1qhP6YDYvouq
+        SmEqK5p27ea14fnlxkeXWRt8MNsdcT1PXf4aS5taLOTfbR+zMZeuAeMxntnexeF81w4zYqW3aNql
+        Tda08A+OO/UZ9jCxt2jaUeFDxw+nPKVGb77cUscSb1+vanK5wPF3X/oJ7oc8oAtgJXfDnHFxxDw/
+        GIzc0MGWNssfbB5xLCyzKO5Kf4r5zZwY8VME2/FySv70tKy7/e3UK2Z9w7JMT9djrliXnxO+Aybt
+        9bvn+Rfd95LPWX7g1zscus2CYEX1v8y6YB43/Ec2niemF2SysZ78OpTfT4/YvZi41c2A3VIxg/ND
+        b0TMt5nDBWRc7DV/k8BadOx66KRgufkVT/74CLfEDqlWg1ZRWqlN72bOq6souIqC1TIGVssoWFcx
+        sK7iI5fQkUv4yAY6soEriII1HKyjbOg4GzrKho6zoVVQMSr4yChYx8EayrOG84zql6Geggqh4EKg
+        YA0Ho/6JuyeGRIGoLXBToA6B+4OKGkLFDWHo6MA6TpiGEqbhYqDsqji7OhpKOh5KBjqygY9soDIb
+        uMwaKoaGi4GTgXOBsqxmsIy6hZYRoujIGj6ygUadgUcdOjA+rop6p5qRrvCBM0ZGw07F405HLaJn
+        mATlQsW5QN0C9wo0+PDYU1F5VVxeHWVCx5lQ0ZQJteuPfnwayNfiR5TikuMGL5skWNVRdTQsU7mi
+        jkzZMJWaXDM1TTaHRo1a1CoZRgmZPGzZ7RWTCvFrhULjQa2SzhUrDe9DhlojSkWRDauigVZlTR4a
+        I122VM2s6pQYlkjl62Rs1e37yKiWNJwM3vAeZPBLIMrG1a9UZkWFdxFcMTWTUFKWqaIMZWM4InKV
+        DMuyYg5LlZJRNkdmGVFsy27fZ8VyOcOKvOE9yFBHVdUoWyXQpcYDVVdkYpR12TSpUdbUUc0oY/G9
+        ZbfXkiF+5TNS3HqABmausoIg3oMe06pSUgXF9FIZ9FS1slwj/EcBaaWiqURTVKOG0LNlt+9Mf7WM
+        7Fd7Iyqu+O/ABslvPnp0AqSL1T3UPD49/R+ufQ2oYlYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -390,12 +399,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:53:22 GMT
+      - Thu, 21 Nov 2019 15:39:42 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -405,9 +414,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - e16e706851190044f7d7589bdb4c5269
+      - 13e96ab7cba6c0102ce886f73c73070a
     status:
       code: 200
       message: OK
@@ -423,76 +432,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPbGLB5mSVAJtkNhAMJ3TvdWY6wBWhjbMaWc+mQ/74l
-        2QYRbEI6l2Zm8kBkVUmu+upilXx5yBF37OVqDznv1sV+rpZDru3j238G9nXR8ye5Qs5FMwz9FAd0
-        GFjIHY7JHQ19zEjekCJ/gmmuNkZOgAu5sefY2B8SO1dzQ8cp5CzPpb7n5GrUD4EeBkCdY39GgoB4
-        bpCrqZpRyAXWFNuhg4dhyIbCyWZzB1Es45GFLFQqyVrJLMlVhCuyoY7L0FLLtqYZpmoZZknRLYT0
-        slFVkFrRQTBsEzpEjuPdYnspGxMedBzGCl32pYbjhbbUj/ph2NxziHUPtCMUEEvqYHrr+decAajB
-        FPl4qZg3+h+2KNdUVZVCjqJJDEaQsCDLgfaXh9yawsAbYx1x2SQAXe9jsaI+sb3Ckt7PmeA2HqPQ
-        obnHwpOZOZTx3OrTiTMNu9HPTqgtz8Yslnu8KuSmXkAtL3QpVyE2lKGb5lhTLNm0kS7rplGVDbCZ
-        XFZsZGLbNPVyiUFHEQ1BQpDXtYnLzsJdKT7HPMgxAGPw4pZWnIcj1ixS7KKRgwNshT6h90XLmwE/
-        cmgC+BCEXNl5bhEZJpfDueOhdfMPQRAfFFDLlVKpahgKwETJDFwbzebr3VMUXI+Wg+EIheBU1EfE
-        2fCoeFZmpUfgJQH1/Htu+bgduYliaKZSSmw0jHG2fIwoGHBog8Ovy+AgiLmZZ5MxsbJ4XmYIEfBU
-        o0Rx6HMbZyCcOAPzbWjehA5og0bEIZTguBNMNBd42KFDkGvh6HhMHIr9KDhiN2TcRVClkAM8bGbv
-        xHHrQYCpdNrMCdnkIdEEQ8c9HzTBd3D8RZFNJI+vHoxH+WB5oD/K+YfS4/JY1R4PCjuz5n8SpUrO
-        pKhaSS9XqjIaWbaMx4oqsw65UjVM1sV6IEZzHsQoAidg2ubw7yzw+O8MUWvKjqIGoDLxvXCeaC3C
-        es9jPSbMnXBC3CICXySjENJycZQK21E4AW/9fVfg/ss0vvo5guXq53SdO5fto1aPC3/nYHdCp+CM
-        xocoie8gnCGrj33gYGl5CMF3g4IUzRv1zqDel1rRCOk4GZGKg+17cxsCEogOBCuTn12q4JA7e+4q
-        U7tXKBOJPpwj6xpNcLYK3SXDToJHo6CjqcXKswng+NOUUDzsQoxBVPoQ9O+i1Z2Px7VGq3chNxpp
-        OgFFqts3JICMuLNbNupy5JFy4qBPe/I//T3NV4HtP/AnnzalA4JrEhxrilKSFSP/MWG5hCMLi4E4
-        13fHabry2KfS4FICEbCPIe9GGKgAgJrfl/j1/FTXP++19jp256lSd1s7ma+YmlcvWp8vPsYprRtc
-        9NFtmgaD3TT47wFwLiDV5OUD1TTNhaZ8UdQr7o75KCQf9AJcX3fjy3LgQQvCVS3LsJKpFOKjiqwq
-        cMn9KKSCYDhCAYaqJ8NTB/2+BKUChgoh4tg9fL9+LcYB/Euq/tVieUNNWDMB64T/voknMw1ZqeX5
-        yNmu5UXM9SpNUxXVi9oHK3oDdZvnZ0aBqO2As+54oYKR2t9atYPLRfe8sThenCw6zfxh76x2cH68
-        uFh8WlxGHQ1gaSwue4sGO+Zx8l0j8xmh06qdFKRW7XgD1jeOjedxfDl89UHt4GxRX3Tyh3XQ9mTR
-        XpxBM6wddBb9RTt/2GCt7qKRPzxdtupJa4nl66bJAhZm7RQk+K2/M7SlHfLOTamo/NGTT2nH7MN1
-        /eOnoNJLctC6zi+NpBqMPowyCs8nn+N0EmeTz1EygVyy6MFBHDcvG/SD009pVwy/CzqWQDqQQM4W
-        3SiFnC1O8ofdHuvlzUueN3r5wz7Dq8EzygmQOjyjxK160hIBfuOpf2iyikqcT600A3zadTkZh+Zz
-        Fc2n1tNqBsq5dynlVrtVQxsHlk/mbO8tTccptq6lDjt447X/G4i+BCtN8CWb1BPY9kKFTS+LN7yH
-        yIr2nzf1aUYch/92oRqU6hFfsD8142bxa2tD7DjES9OmxQn7XAMvpY/GPqvCe4TIu+5SoBtEHCZD
-        mm6xUnWBZ0/swvNxq3kk882kLMGbiCK2wHzbLae92huOe6bhKBuHE07cE8vFAse8QwzmyVjZtNY4
-        pRZw7qpGPDSQkI8l0cU7nhQLIJEALrO/h4Td6uSEa55TcfrQ98QC28PR/XCGnFuUWhq0Ejbp6F5q
-        L9n2y6CREi4OgjDtVsWaDp2E64eowG/AxbfzNwU9ASprHp52pbpt+yDqKxK6ampFtWIU1aJWUKus
-        XYQfedVUlIKqsH/FMiyZNb3ApcN3CNYtmN8A/rgt/NP6oJ6CCOt+YQaVv9Tl35D87Upez6hP+zMy
-        LD/jxhpYVeW6rKhl9SNva4AoR+mYHH04JkepmBx9JCYBJZNhgG8wez4hHZe21F/Rd0GH3JwOrn7O
-        0Hk1W6Ty6eCDrZ92U4t1f7j1L358RBB3SKeAAr5NS/GnrnQxxZDcb/eoIMm+qu7rhVRY3M0wRQHv
-        TJN/SdznAmqlQlYFJejxh6meeHJo94/TkkObWL4XeGMqHYWOgylxd8sT7f6T2/9POjIyQ7tvmrJp
-        msCuKHLVMD8QgfP+oJl2deT9f5qia84mGM7DkbP2cNqm2l3GKHVXjKwAzUgwQBgT7NgbQDzoj4dR
-        Q1s1UiFhD30cttuHzeaGydn0ssOyRtzCSXNCV61lJweMt167XbJ1F7HL+aXmGtM+bcWN0Yw4/BnG
-        TOGPOcvW/DqchQ4lqyy7PEsPqp8TRKUzz2J3d+KnPCW+ucoumfzZSUGqk658+XkrtyZwN/GIIHcr
-        e0lg73sO8qEG3savC/zH2PZ8tJW9LLA3fj2V0CgMcEKsCMRfwcSet3Wuqihq2G9tZTYE5vrpdshM
-        gfcTccFggVSTNpP20iCKOACPYFr/hj3SGZNFg/XbF11p7nvgNrMlg2ijYx/jo35zuweIVrochS4N
-        t/OLVuo7yLpmy5rtQ0RLtdlz0ej6mRGi+Xp45lEsjYmDJWRZUYXMuUSrNcDI5/3ts4qGO77oJt0p
-        NkocXlmT3IITPBMh6lqIuAQ4vTE3IuG3AjiTaKM2CaxiQliLmGiMZGOKrTh7cSZ97RR8g166dMmd
-        uD/PGdMDBNzvc7+f8KzFCYKM43sehaU/g5wnHs4lAt3rNpJuI9W5LwPsSzPkogmeYX5bgTOb6xEJ
-        idFJ8oSIcrKJukwiIqJdjH35wpPZf+mYOUR/CmnFTR6vL4nINk77jfOEICJ7THx8ixxneQoR0SPw
-        aNvzlhFXElHsN+rNekIQoWt2EkRLIlYAhQP+KgWRLZdzisB1+csR0urWUcJkPjUNkoIpdpyn1tGV
-        Na+hkE0my5S6hp7nUyl+tn7JICLGXsyIahROWsfMnQDmazlWX0sFnXYSULoIWec0QUavPE0D5GZ7
-        htdFLAdtnmha/e0RqIvYHvkhyxyeD3EE6wYksIno/it0ve2XpvIaxhYBv2YvD0hnxA3vto8ULdD2
-        Rsxpm1j0hrJognMfWcCxw7yideoz9A3WfzuMEk3WRY4n1R26/dJYFq15EqJbTLbzi2Y+Lidv+zyD
-        b3UDg0F7+wjRzqeuRWywidTDwdxzg8SFy6KVB8Snofft23Z1K6Klf7vYvhKoqI9vV8ZuWwfuWtwc
-        KIsvKizio5W8Uqg85g++fg1+ktnPwVNS/peDAie8cFRG0fSZ/RX4r8x/n9RPiqK8R80f9aS8z5OJ
-        Zltg/WsUTRmbITEee7oR4oV0HqbtRcVinyf07xWc4jta8OgULmys+TFbGbG77lLgR2r+lSv8GCyu
-        ZCZAFxF1py1Ih2VzPhVbQ73JJiSsqorsJ03AqHvXXakHtVB+XGXeVV+SqJ/jykjMhlIwIPnKhmIo
-        L8jJyXOazNovhMP3qGd5ThokK9Jue8bWHI5Cm/0SazZ/C5OJl4oUEXvYQgGV/sEKKjxPN2CKpBE3
-        v70fzQDN93sahS1IoLxMET+m/Gk2RAOMh8gJvFRVMSxgOWnfLl5b7lpuvWGZta0Ha9wx0/PMYw+v
-        tLFNQva29gmZMOkaMB9hme1dHC7wnDAjVvor0j5trYrC37vePCBptxD7K9KeCh+6QThnKTV63uUG
-        uzZ/5vqpJpcrPvbEyyDh+yG35SjUb9fEnRTHxA/ocOyFblpps/6a5jHjhTILp7vSn2J9swSGf4Bg
-        N1zO0J8elk23v5n7xaw3V9bh6frE43V5D7F9L+lg0O3lX3TdS15i+YHv7DDWXQqCJ6r/ZeqCZdyw
-        T2s8D0yfZqKxmfw6mF1Pj8kdX7jVLUpuMF/BBaE/RtbbrOEomhRL1bKhIvaNnQpSZF1DY9m0KyNZ
-        H6lGpWRqml0yU1Tbcdh33B/kXx66QU6IhyVVBQbe3iRsbnEFmMpT/omIuOV69GVgKHqpauioImuK
-        rYJWI0VGYxXLCsKVkoJVS7OsFDB2HPY6MMpGOhbQ/x5Q8DNAGOMJ+6BNhX9O5qneaTyvVLKsZWgJ
-        hHexuFq1q2ZZlbGu6bKOsSojQ8eyOsbKWDM1rNjjNIvvNux1YFTLlXQwGOH9bV41+Pm3Gz1mep2i
-        ulpKV5QR3kPRSgmXEUZYNitVyF6GNpINw0aybpXG+sgaVW1VT1F9x2GvA4N9zCwdDU55Gziu2Nfc
-        aPL5Jh/PYG5+yYaeh8fH/wNNwfpuKE4AAA==
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBevPxlFgFHdwQ5onTvdrucIimw1pAwefho8X/fW5UE
+        Atwg2mozM/4QK1VfVe797iNVlYTHHHNGbu7gMefeOdTLHeSIY3n07p++dVN0vXGukHPIhEJ9QP1g
+        4JvEGYzYfRB6lDe5g4B4YxrkDkbE9mkhN3Jti3oDZuUOnNC2CznTdQLPtXMHgRdCe+hD65R6E+b7
+        zHX83IGqVQs537ymVmjTQRjyrnCxydQmAZUNMiyrZDiUS6ZallWtRmSVapZMKkrVVKzSSFeN8qhS
+        LZXVSqlWVsrKqAKCUYsFA2Lb7h215rJx4UHHQazQZU9q2G5oSb2oHrpNXZuZD9B2SHxmSh0a3Lne
+        jQBAq39NPDpXzB3+j5qB0FRTa4VcQMYxGX4CIaYN5S+PuSWFlULCdYSymA+6PsRiRXXp8oLL4GHK
+        BbfoiIR2kHsqrIwsqIzHVlcHzjTsWr1QaX41brHc01Uhd+36gemGTiBUiA1VNiomqdSqskVVTTaq
+        VJOHI10Dc1V0XTN0VSkpnLqABCFICPI6FnP4VYQrxdeY+jlOYExeXNKK03DIi8WAOmRoU5+aoceC
+        h6LpTgBP7CAhfABCLuw8NZkMg8vh1HbJsvkHIIgHCqiliqGXlEqlAtdlE3BtMpkuV18T/2Y47wxn
+        JASnCjzC7DWPikflVnoCLPMD13sQlo/Lwk1UVSnrNTWx0SDm2fQoCcCAAwscflkGm0DMTVyLjZiZ
+        hXmZIdKEo0aJ4tATNs5gOHEG7ttQvA1t0IYMmc0CRuNKMNE0heGnNiOOSaPzEbMD6kXBEbshRxdB
+        lUIO+LC4vRPHrfs+DaSTZi6VTR4TTShUPIhOY3oP518UGXLE6Oqx+iTvzU+MJzn/qD/Nz1Xtaa+w
+        NTT/U1qq5EqKqulGqVyRydC0ZDpSVJlXyOVKtcareA3EaM6FGCXgBFzbHP2dB544TkhgXvOzqACs
+        jD03nCZap2l9ELEeN0ztcMycIgFfZMMQ0nJxiNJ2GI7BW3/flrj/co2vfo5oufoZ17lz2T5snQvh
+        723qjINrcMbqhyhJ7yGcIauPPEDwtDyA4LslPqJ5o97p13tSK+ohHSU9UB4sz51aEJDQaEOwcvn5
+        rQpOhbPnrjK1+w5lItEHU2LekDHNVqE7B2wleNQLKpparDwfAM4/XbOADroQYxCVHgT9u2h179HR
+        QaN1fiE3GphO0CLVrVvmQ0bc2i0bdTnySDlx0NWa/E9/x3wVYP+GP/mkKe0xeiDBuaYouqxU8x8T
+        lnM6srjop8d6dZziylMvkPqXEohAPQp5N+JABQLU/K7Er+uhrn923trp2J2iUndbW5mviObVi9bn
+        i49xSvOWFj1yh2nQ306D/+4BcgapJi/vqbVabaYpXxT1SrhjPgrJR6MA99ftcFkO3G9BuKoluVat
+        lAvxGawAFLjlfhRTvj8YEp/CqifDU/u9ngRLBQorhAixffh+/VqMA/gXVP9KsbSmJsyZADoWxzfx
+        ZK4hX2q5HrE3a3kRo75LU1RRo6h9sKK3sG5zvcwoSGvbF9Atb1TQU/tb62DvctY9a8yOZsezTjO/
+        f356sHd2NLuYfZpdRhUNgDRml+ezBj8XcfKqnvmM0GkdHBek1sHRGq1vHBvP8/hy+ur9g73TWX3W
+        ye/XQdvjWXt2CsXwYK8z683a+f0GL3Vnjfz+ybxUT0pzLr9vmCxiYdROQYJj/Z2p1bfIO7d6Ufmj
+        Jx99y+wjdP3jpyD9JTloWeeXRtIB9N6PMorIJ5/jdBJnk89RMoFcMjuHkzhuXtbpB6cffVsOX0Ud
+        TyAdSCCns26UQk5nx/n97jmvFcVLkTfO8/s9zldDZJRjaOqIjBKX6kkpTfAbD/1Dk1W0xPnUwgzw
+        advpZByaz61oPrVWVzOwnHuXpdxit2pgUd/02JTvvWE6XlPzRurwkzee+7+B6HOyMMHnMOk8BdsJ
+        Fda9LN7wHhAz2n9e16cZIfZ/c2A1KNUjnL87a8b1xa+lDahtMxfTpiUadnkNPJc+6vusCu8RIu+6
+        S0FuCbO5DJhusVL1FGZH7CLycat5KIvNpCzBmyQgfIL5tltOO7U3HNdch8NsHo5F445YLhY4xg4o
+        mCdjZtNaQkotQG6rRtzVl4hHpbSLd1wpFkBiPtxmfw8Zf9QpGm5ETqV41/fkglqD4cNgQuw7gi4N
+        WglMOnyQ2nPYbhk0UsKhvh9ijyqWdOgkqB+igngAFz/OXxf0GFp5cf+kK9UtywNRvyOhqzWtqJar
+        RbWoFdQKLxfhIC+KilJQFf6vWIIps2YUhHT0nsC8hYoHwB+3hX9S79cRRnj1CzOo/KUu/4fI367k
+        5Yy6Wp+RYcUV1+bAqirXZUUtqR/5WANEOcQ5OfxwTg5RTg4/khM/YOOBT28pfz8B56Ut9Rbt27DD
+        bk/6Vz9n6LwYLVL5pP/B1sceavHqD7f+xY+PCOYMgmtggd5hKf7EkS6uKST3ux1akGTfVXf1Rpqa
+        3E1oQHxRick/b9zlBdRChawVVEqPP8zqSSSHdu8ISw5tZnqu744C6TC0bRowZ7s80e6tPP5fqcjI
+        DO1erSbXajWAK4pcqdY+kIGzXr+J3R1F/Z9m0TXlAwym4dBeejltXe0uB0rdBZAvQDMSDDSMGLWt
+        NSIejaf9qKAtCigl/KWP/XZ7v9lcMzkfXrZ51ohLNCmOg0VpXikIE6Xv3S7ZuIvYFXipuQTapa24
+        EZkwW7zDmCn8kYBszK+DSWgHbJFl51c5h9XPMQmkU9fkT3fitzwlsbnKb5ni3cmUVMdd+fLzRrSW
+        QjfpkBFnI1xPwXuuTTxYA2/CGyn8EbVcj2yEl1Lwxq8nEhmGPk0ay6nGX8HErrtxrEpa1LDX2giu
+        psD1k82U1VLYT8wBg/nSgbSetOcGUdId6BCG9W75K51xc9pgvfZFV5p6LrjNZA5I2+jIo/Sw19zs
+        AWkrXQ5DJwg349NW6tnEvOHTms1d0pZq8/eiyc0zPdLmO6cTN6DSiNlUIqYZrZAFKm21Bhj5rLd5
+        1LThji66STVio8ThlSXJTbjAMxGiLoWIwwDpjoQRmXgUIEBpG7WZbxaThqWIifpIFg2oGWcvATKW
+        LiE26KVLh92n9+cFEA8QcL/PvV6CWYoTAhnHc90Apv6ccpF4BCpN9Hm3kVRXUee+9KknTYhDxnRC
+        xWMFAa4tRyQkRjvJE2mWk03UeRJJM9ql1JMvXJn/l464Q/SuIa04yev1eprZxkmvcZY0pJk9Yh69
+        I7Y9v0Sa0UPwaMt15xGnp1nsNerNetKQpq7ZSRjV01wBFTb4q+RHtpyPmSauKz6OkBaPjhJQbdU0
+        RPKvqW2vWsdQlrwmgGwynqfUJfZcL5Did+vngDRj/MOMaI0impY5c8bA+VKONZZSQaedBJSRpqxz
+        kjBjlFfTALvdnOGNNJf9tkg0rd7mCDTS3B56Ic8crgdxBPMGkoKl2f1X6Libb02lJY5NBn7NPx6Q
+        TpkT3m/umbZA2x1yp23StDeU0iY484gJiC3GTVunPiHfYP63Ra+0ybrEdqW6HWy+NZbS1jwOyR1l
+        m/FpMx+Vkq99nuG3ssZBv725R9rOJ47JLLCJdE79qev4iQuX0lbuMy8I3W/fNqtbVpYC4q7Hv0GR
+        Gr/2Tjd3U5/ebkG7aUa47TJnT5l9UWE6H83plUL5Kb/39av/k8wPe6tN+V/2CqLhhb0ylk+f+V9B
+        HGVxXFlJKYryHqv/qAb5sieTzXYK+tdYPmVsi8R87OiWiBsG0xDblYrFPkvaXyt4QO+Dghtcwy2O
+        Fz9mUyN2122W+pGaf+W1fkyWUDKToIuodavNSJtnczEUn029yXYkzK+K/IAJGFVvuz/1qBZKT4vM
+        u6hLEvVzqIzEXFUKVUi+clWpKi/Iyckbm9zaL6TDcwPXdG2MkkXTdrvH5hTOQosfmTmZvoXJ0rcK
+        RMRzahI/kP7Bl1Z0ihsQkTRCiwf90QhQfL/3UviEBBaaiPhxy59ma9SndEBs30VVpTCVFU27dvPa
+        8Pxy46PLrA0+mO2OuJ6nLn+NpU0tFvLvto/ZmEvXgPEYz2zv4nC+a4cZsdJbNO3SJmta+AfHnfoM
+        e5jYWzTtqPCh44dTnlKjN19uqWOJt69XNblc4Pi7L/0E90Me0AWwkrthzrg4Yp4fDEZu6GBLm+UP
+        No84FpZZFHelP8X8Zk6M+CmC7Xg5JX96Wtbd/nbqFbO+YVmmp+sxV6zLzwnfAZP2+t3z/Ivue8nn
+        LD/w6x0O3WZBsKL6X2ZdMI8b/iMbzxPTCzLZWE9+Hcrvp0fsXkzc6mbAbqmYwfmhNyLm28zhAjIu
+        9pq/SWAtOnY9dFKw3PyKJ398hFtih1SrQasordSmdzPn1VUUXEXBahkDq2UUrKsYWFfxkUvoyCV8
+        ZAMd2cAVRMEaDtZRNnScDR1lQ8fZ0CqoGBV8ZBSs42AN5VnDeUb1y1BPQYVQcCFQsIaDUf/E3RND
+        okDUFrgpUIfA/UFFDaHihjB0dGAdJ0xDCdNwMVB2VZxdHQ0lHQ8lAx3ZwEc2UJkNXGYNFUPDxcDJ
+        wLlAWVYzWEbdQssIUXRkDR/ZQKPOwKMOHRgfV0W9U81IV/jAGSOjYaficaejFtEzTIJyoeJcoG6B
+        ewUafHjsqai8Ki6vjjKh40yoaMqE2vVHPz4N5GvxI0pxyXGDl00SrOqoOhqWqVxRR6ZsmEpNrpma
+        JptDo0YtapUMo4RMHrbs9opJhfihQqHxoFZJ54qVhvchQ60RpaLIhlXRQKuyJg+NkS5bqmZWdUoM
+        S6TydTK26vZ9ZFRLGk4Gb3gPMvglEGXj6lcqs6LCuwiumJpJKCnLVFGGsjEcEblKhmVZMYelSsko
+        myOzjCi2Zbfvs2K5nGFF3vAeZKijqmqUrRLoUuOBqisyMcq6bJrUKGvqqGaUsfjesttryRA/8Bkp
+        bj1AAzNXWUEQ70GPaVUpqYJieqkMeqpaWa4R/qOAtFLRVKIpqlFD6Nmy23emv1pG9qu9ERVX/Cdg
+        g+Q3Hz06AdLF6h5qHp+e/g88UKYkXVYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -503,12 +517,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:53:22 GMT
+      - Thu, 21 Nov 2019 15:39:43 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -518,9 +532,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - ab32172d422b45bc966350c6b849610f
+      - 0d1608d22b3cfe7f24beb543d3442fd4
     status:
       code: 200
       message: OK
@@ -536,76 +550,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPbGLB5mSVAJtkNhAMJ3TvdWY6wBWhjbMaWc+mQ/74l
-        2QYRbEI6l2Zm8kBkVUmu+upilXx5yBF37OVqDznv1sV+rpZDru3j238G9nXR8ye5Qs5FMwz9FAd0
-        GFjIHY7JHQ19zEjekCJ/gmmuNkZOgAu5sefY2B8SO1dzQ8cp5CzPpb7n5GrUD4EeBkCdY39GgoB4
-        bpCrqZpRyAXWFNuhg4dhyIbCyWZzB1Es45GFLFQqyVrJLMlVhCuyoY7L0FLLtqYZpmoZZknRLYT0
-        slFVkFrRQTBsEzpEjuPdYnspGxMedBzGCl32pYbjhbbUj/ph2NxziHUPtCMUEEvqYHrr+decAajB
-        FPl4qZg3+h+2KNdUVZVCjqJJDEaQsCDLgfaXh9yawsAbYx1x2SQAXe9jsaI+sb3Ckt7PmeA2HqPQ
-        obnHwpOZOZTx3OrTiTMNu9HPTqgtz8Yslnu8KuSmXkAtL3QpVyE2lKGb5lhTLNm0kS7rplGVDbCZ
-        XFZsZGLbNPVyiUFHEQ1BQpDXtYnLzsJdKT7HPMgxAGPw4pZWnIcj1ixS7KKRgwNshT6h90XLmwE/
-        cmgC+BCEXNl5bhEZJpfDueOhdfMPQRAfFFDLlVKpahgKwETJDFwbzebr3VMUXI+Wg+EIheBU1EfE
-        2fCoeFZmpUfgJQH1/Htu+bgduYliaKZSSmw0jHG2fIwoGHBog8Ovy+AgiLmZZ5MxsbJ4XmYIEfBU
-        o0Rx6HMbZyCcOAPzbWjehA5og0bEIZTguBNMNBd42KFDkGvh6HhMHIr9KDhiN2TcRVClkAM8bGbv
-        xHHrQYCpdNrMCdnkIdEEQ8c9HzTBd3D8RZFNJI+vHoxH+WB5oD/K+YfS4/JY1R4PCjuz5n8SpUrO
-        pKhaSS9XqjIaWbaMx4oqsw65UjVM1sV6IEZzHsQoAidg2ubw7yzw+O8MUWvKjqIGoDLxvXCeaC3C
-        es9jPSbMnXBC3CICXySjENJycZQK21E4AW/9fVfg/ss0vvo5guXq53SdO5fto1aPC3/nYHdCp+CM
-        xocoie8gnCGrj33gYGl5CMF3g4IUzRv1zqDel1rRCOk4GZGKg+17cxsCEogOBCuTn12q4JA7e+4q
-        U7tXKBOJPpwj6xpNcLYK3SXDToJHo6CjqcXKswng+NOUUDzsQoxBVPoQ9O+i1Z2Px7VGq3chNxpp
-        OgFFqts3JICMuLNbNupy5JFy4qBPe/I//T3NV4HtP/AnnzalA4JrEhxrilKSFSP/MWG5hCMLi4E4
-        13fHabry2KfS4FICEbCPIe9GGKgAgJrfl/j1/FTXP++19jp256lSd1s7ma+YmlcvWp8vPsYprRtc
-        9NFtmgaD3TT47wFwLiDV5OUD1TTNhaZ8UdQr7o75KCQf9AJcX3fjy3LgQQvCVS3LsJKpFOKjiqwq
-        cMn9KKSCYDhCAYaqJ8NTB/2+BKUChgoh4tg9fL9+LcYB/Euq/tVieUNNWDMB64T/voknMw1ZqeX5
-        yNmu5UXM9SpNUxXVi9oHK3oDdZvnZ0aBqO2As+54oYKR2t9atYPLRfe8sThenCw6zfxh76x2cH68
-        uFh8WlxGHQ1gaSwue4sGO+Zx8l0j8xmh06qdFKRW7XgD1jeOjedxfDl89UHt4GxRX3Tyh3XQ9mTR
-        XpxBM6wddBb9RTt/2GCt7qKRPzxdtupJa4nl66bJAhZm7RQk+K2/M7SlHfLOTamo/NGTT2nH7MN1
-        /eOnoNJLctC6zi+NpBqMPowyCs8nn+N0EmeTz1EygVyy6MFBHDcvG/SD009pVwy/CzqWQDqQQM4W
-        3SiFnC1O8ofdHuvlzUueN3r5wz7Dq8EzygmQOjyjxK160hIBfuOpf2iyikqcT600A3zadTkZh+Zz
-        Fc2n1tNqBsq5dynlVrtVQxsHlk/mbO8tTccptq6lDjt447X/G4i+BCtN8CWb1BPY9kKFTS+LN7yH
-        yIr2nzf1aUYch/92oRqU6hFfsD8142bxa2tD7DjES9OmxQn7XAMvpY/GPqvCe4TIu+5SoBtEHCZD
-        mm6xUnWBZ0/swvNxq3kk882kLMGbiCK2wHzbLae92huOe6bhKBuHE07cE8vFAse8QwzmyVjZtNY4
-        pRZw7qpGPDSQkI8l0cU7nhQLIJEALrO/h4Td6uSEa55TcfrQ98QC28PR/XCGnFuUWhq0Ejbp6F5q
-        L9n2y6CREi4OgjDtVsWaDp2E64eowG/AxbfzNwU9ASprHp52pbpt+yDqKxK6ampFtWIU1aJWUKus
-        XYQfedVUlIKqsH/FMiyZNb3ApcN3CNYtmN8A/rgt/NP6oJ6CCOt+YQaVv9Tl35D87Upez6hP+zMy
-        LD/jxhpYVeW6rKhl9SNva4AoR+mYHH04JkepmBx9JCYBJZNhgG8wez4hHZe21F/Rd0GH3JwOrn7O
-        0Hk1W6Ty6eCDrZ92U4t1f7j1L358RBB3SKeAAr5NS/GnrnQxxZDcb/eoIMm+qu7rhVRY3M0wRQHv
-        TJN/SdznAmqlQlYFJejxh6meeHJo94/TkkObWL4XeGMqHYWOgylxd8sT7f6T2/9POjIyQ7tvmrJp
-        msCuKHLVMD8QgfP+oJl2deT9f5qia84mGM7DkbP2cNqm2l3GKHVXjKwAzUgwQBgT7NgbQDzoj4dR
-        Q1s1UiFhD30cttuHzeaGydn0ssOyRtzCSXNCV61lJweMt167XbJ1F7HL+aXmGtM+bcWN0Yw4/BnG
-        TOGPOcvW/DqchQ4lqyy7PEsPqp8TRKUzz2J3d+KnPCW+ucoumfzZSUGqk658+XkrtyZwN/GIIHcr
-        e0lg73sO8qEG3savC/zH2PZ8tJW9LLA3fj2V0CgMcEKsCMRfwcSet3Wuqihq2G9tZTYE5vrpdshM
-        gfcTccFggVSTNpP20iCKOACPYFr/hj3SGZNFg/XbF11p7nvgNrMlg2ijYx/jo35zuweIVrochS4N
-        t/OLVuo7yLpmy5rtQ0RLtdlz0ej6mRGi+Xp45lEsjYmDJWRZUYXMuUSrNcDI5/3ts4qGO77oJt0p
-        NkocXlmT3IITPBMh6lqIuAQ4vTE3IuG3AjiTaKM2CaxiQliLmGiMZGOKrTh7cSZ97RR8g166dMmd
-        uD/PGdMDBNzvc7+f8KzFCYKM43sehaU/g5wnHs4lAt3rNpJuI9W5LwPsSzPkogmeYX5bgTOb6xEJ
-        idFJ8oSIcrKJukwiIqJdjH35wpPZf+mYOUR/CmnFTR6vL4nINk77jfOEICJ7THx8ixxneQoR0SPw
-        aNvzlhFXElHsN+rNekIQoWt2EkRLIlYAhQP+KgWRLZdzisB1+csR0urWUcJkPjUNkoIpdpyn1tGV
-        Na+hkE0my5S6hp7nUyl+tn7JICLGXsyIahROWsfMnQDmazlWX0sFnXYSULoIWec0QUavPE0D5GZ7
-        htdFLAdtnmha/e0RqIvYHvkhyxyeD3EE6wYksIno/it0ve2XpvIaxhYBv2YvD0hnxA3vto8ULdD2
-        Rsxpm1j0hrJognMfWcCxw7yideoz9A3WfzuMEk3WRY4n1R26/dJYFq15EqJbTLbzi2Y+Lidv+zyD
-        b3UDg0F7+wjRzqeuRWywidTDwdxzg8SFy6KVB8Snofft23Z1K6Klf7vYvhKoqI9vV8ZuWwfuWtwc
-        KIsvKizio5W8Uqg85g++fg1+ktnPwVNS/peDAie8cFRG0fSZ/RX4r8x/n9RPiqK8R80f9aS8z5OJ
-        Zltg/WsUTRmbITEee7oR4oV0HqbtRcVinyf07xWc4jta8OgULmys+TFbGbG77lLgR2r+lSv8GCyu
-        ZCZAFxF1py1Ih2VzPhVbQ73JJiSsqorsJ03AqHvXXakHtVB+XGXeVV+SqJ/jykjMhlIwIPnKhmIo
-        L8jJyXOazNovhMP3qGd5ThokK9Jue8bWHI5Cm/0SazZ/C5OJl4oUEXvYQgGV/sEKKjxPN2CKpBE3
-        v70fzQDN93sahS1IoLxMET+m/Gk2RAOMh8gJvFRVMSxgOWnfLl5b7lpuvWGZta0Ha9wx0/PMYw+v
-        tLFNQva29gmZMOkaMB9hme1dHC7wnDAjVvor0j5trYrC37vePCBptxD7K9KeCh+6QThnKTV63uUG
-        uzZ/5vqpJpcrPvbEyyDh+yG35SjUb9fEnRTHxA/ocOyFblpps/6a5jHjhTILp7vSn2J9swSGf4Bg
-        N1zO0J8elk23v5n7xaw3V9bh6frE43V5D7F9L+lg0O3lX3TdS15i+YHv7DDWXQqCJ6r/ZeqCZdyw
-        T2s8D0yfZqKxmfw6mF1Pj8kdX7jVLUpuMF/BBaE/RtbbrOEomhRL1bKhIvaNnQpSZF1DY9m0KyNZ
-        H6lGpWRqml0yU1Tbcdh33B/kXx66QU6IhyVVBQbe3iRsbnEFmMpT/omIuOV69GVgKHqpauioImuK
-        rYJWI0VGYxXLCsKVkoJVS7OsFDB2HPY6MMpGOhbQ/x5Q8DNAGOMJ+6BNhX9O5qneaTyvVLKsZWgJ
-        hHexuFq1q2ZZlbGu6bKOsSojQ8eyOsbKWDM1rNjjNIvvNux1YFTLlXQwGOH9bV41+Pm3Gz1mep2i
-        ulpKV5QR3kPRSgmXEUZYNitVyF6GNpINw0aybpXG+sgaVW1VT1F9x2GvA4N9zCwdDU55Gziu2Nfc
-        aPL5Jh/PYG5+yYaeh8fH/wNNwfpuKE4AAA==
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBevPxlFgFHdwQ5onTvdrucIimw1pAwefho8X/fW5UE
+        Atwg2mozM/4QK1VfVe797iNVlYTHHHNGbu7gMefeOdTLHeSIY3n07p++dVN0vXGukHPIhEJ9QP1g
+        4JvEGYzYfRB6lDe5g4B4YxrkDkbE9mkhN3Jti3oDZuUOnNC2CznTdQLPtXMHgRdCe+hD65R6E+b7
+        zHX83IGqVQs537ymVmjTQRjyrnCxydQmAZUNMiyrZDiUS6ZallWtRmSVapZMKkrVVKzSSFeN8qhS
+        LZXVSqlWVsrKqAKCUYsFA2Lb7h215rJx4UHHQazQZU9q2G5oSb2oHrpNXZuZD9B2SHxmSh0a3Lne
+        jQBAq39NPDpXzB3+j5qB0FRTa4VcQMYxGX4CIaYN5S+PuSWFlULCdYSymA+6PsRiRXXp8oLL4GHK
+        BbfoiIR2kHsqrIwsqIzHVlcHzjTsWr1QaX41brHc01Uhd+36gemGTiBUiA1VNiomqdSqskVVTTaq
+        VJOHI10Dc1V0XTN0VSkpnLqABCFICPI6FnP4VYQrxdeY+jlOYExeXNKK03DIi8WAOmRoU5+aoceC
+        h6LpTgBP7CAhfABCLuw8NZkMg8vh1HbJsvkHIIgHCqiliqGXlEqlAtdlE3BtMpkuV18T/2Y47wxn
+        JASnCjzC7DWPikflVnoCLPMD13sQlo/Lwk1UVSnrNTWx0SDm2fQoCcCAAwscflkGm0DMTVyLjZiZ
+        hXmZIdKEo0aJ4tATNs5gOHEG7ttQvA1t0IYMmc0CRuNKMNE0heGnNiOOSaPzEbMD6kXBEbshRxdB
+        lUIO+LC4vRPHrfs+DaSTZi6VTR4TTShUPIhOY3oP518UGXLE6Oqx+iTvzU+MJzn/qD/Nz1Xtaa+w
+        NTT/U1qq5EqKqulGqVyRydC0ZDpSVJlXyOVKtcareA3EaM6FGCXgBFzbHP2dB544TkhgXvOzqACs
+        jD03nCZap2l9ELEeN0ztcMycIgFfZMMQ0nJxiNJ2GI7BW3/flrj/co2vfo5oufoZ17lz2T5snQvh
+        723qjINrcMbqhyhJ7yGcIauPPEDwtDyA4LslPqJ5o97p13tSK+ohHSU9UB4sz51aEJDQaEOwcvn5
+        rQpOhbPnrjK1+w5lItEHU2LekDHNVqE7B2wleNQLKpparDwfAM4/XbOADroQYxCVHgT9u2h179HR
+        QaN1fiE3GphO0CLVrVvmQ0bc2i0bdTnySDlx0NWa/E9/x3wVYP+GP/mkKe0xeiDBuaYouqxU8x8T
+        lnM6srjop8d6dZziylMvkPqXEohAPQp5N+JABQLU/K7Er+uhrn923trp2J2iUndbW5mviObVi9bn
+        i49xSvOWFj1yh2nQ306D/+4BcgapJi/vqbVabaYpXxT1SrhjPgrJR6MA99ftcFkO3G9BuKoluVat
+        lAvxGawAFLjlfhRTvj8YEp/CqifDU/u9ngRLBQorhAixffh+/VqMA/gXVP9KsbSmJsyZADoWxzfx
+        ZK4hX2q5HrE3a3kRo75LU1RRo6h9sKK3sG5zvcwoSGvbF9Atb1TQU/tb62DvctY9a8yOZsezTjO/
+        f356sHd2NLuYfZpdRhUNgDRml+ezBj8XcfKqnvmM0GkdHBek1sHRGq1vHBvP8/hy+ur9g73TWX3W
+        ye/XQdvjWXt2CsXwYK8z683a+f0GL3Vnjfz+ybxUT0pzLr9vmCxiYdROQYJj/Z2p1bfIO7d6Ufmj
+        Jx99y+wjdP3jpyD9JTloWeeXRtIB9N6PMorIJ5/jdBJnk89RMoFcMjuHkzhuXtbpB6cffVsOX0Ud
+        TyAdSCCns26UQk5nx/n97jmvFcVLkTfO8/s9zldDZJRjaOqIjBKX6kkpTfAbD/1Dk1W0xPnUwgzw
+        advpZByaz61oPrVWVzOwnHuXpdxit2pgUd/02JTvvWE6XlPzRurwkzee+7+B6HOyMMHnMOk8BdsJ
+        Fda9LN7wHhAz2n9e16cZIfZ/c2A1KNUjnL87a8b1xa+lDahtMxfTpiUadnkNPJc+6vusCu8RIu+6
+        S0FuCbO5DJhusVL1FGZH7CLycat5KIvNpCzBmyQgfIL5tltOO7U3HNdch8NsHo5F445YLhY4xg4o
+        mCdjZtNaQkotQG6rRtzVl4hHpbSLd1wpFkBiPtxmfw8Zf9QpGm5ETqV41/fkglqD4cNgQuw7gi4N
+        WglMOnyQ2nPYbhk0UsKhvh9ijyqWdOgkqB+igngAFz/OXxf0GFp5cf+kK9UtywNRvyOhqzWtqJar
+        RbWoFdQKLxfhIC+KilJQFf6vWIIps2YUhHT0nsC8hYoHwB+3hX9S79cRRnj1CzOo/KUu/4fI367k
+        5Yy6Wp+RYcUV1+bAqirXZUUtqR/5WANEOcQ5OfxwTg5RTg4/khM/YOOBT28pfz8B56Ut9Rbt27DD
+        bk/6Vz9n6LwYLVL5pP/B1sceavHqD7f+xY+PCOYMgmtggd5hKf7EkS6uKST3ux1akGTfVXf1Rpqa
+        3E1oQHxRick/b9zlBdRChawVVEqPP8zqSSSHdu8ISw5tZnqu744C6TC0bRowZ7s80e6tPP5fqcjI
+        DO1erSbXajWAK4pcqdY+kIGzXr+J3R1F/Z9m0TXlAwym4dBeejltXe0uB0rdBZAvQDMSDDSMGLWt
+        NSIejaf9qKAtCigl/KWP/XZ7v9lcMzkfXrZ51ohLNCmOg0VpXikIE6Xv3S7ZuIvYFXipuQTapa24
+        EZkwW7zDmCn8kYBszK+DSWgHbJFl51c5h9XPMQmkU9fkT3fitzwlsbnKb5ni3cmUVMdd+fLzRrSW
+        QjfpkBFnI1xPwXuuTTxYA2/CGyn8EbVcj2yEl1Lwxq8nEhmGPk0ay6nGX8HErrtxrEpa1LDX2giu
+        psD1k82U1VLYT8wBg/nSgbSetOcGUdId6BCG9W75K51xc9pgvfZFV5p6LrjNZA5I2+jIo/Sw19zs
+        AWkrXQ5DJwg349NW6tnEvOHTms1d0pZq8/eiyc0zPdLmO6cTN6DSiNlUIqYZrZAFKm21Bhj5rLd5
+        1LThji66STVio8ThlSXJTbjAMxGiLoWIwwDpjoQRmXgUIEBpG7WZbxaThqWIifpIFg2oGWcvATKW
+        LiE26KVLh92n9+cFEA8QcL/PvV6CWYoTAhnHc90Apv6ccpF4BCpN9Hm3kVRXUee+9KknTYhDxnRC
+        xWMFAa4tRyQkRjvJE2mWk03UeRJJM9ql1JMvXJn/l464Q/SuIa04yev1eprZxkmvcZY0pJk9Yh69
+        I7Y9v0Sa0UPwaMt15xGnp1nsNerNetKQpq7ZSRjV01wBFTb4q+RHtpyPmSauKz6OkBaPjhJQbdU0
+        RPKvqW2vWsdQlrwmgGwynqfUJfZcL5Did+vngDRj/MOMaI0impY5c8bA+VKONZZSQaedBJSRpqxz
+        kjBjlFfTALvdnOGNNJf9tkg0rd7mCDTS3B56Ic8crgdxBPMGkoKl2f1X6Libb02lJY5NBn7NPx6Q
+        TpkT3m/umbZA2x1yp23StDeU0iY484gJiC3GTVunPiHfYP63Ra+0ybrEdqW6HWy+NZbS1jwOyR1l
+        m/FpMx+Vkq99nuG3ssZBv725R9rOJ47JLLCJdE79qev4iQuX0lbuMy8I3W/fNqtbVpYC4q7Hv0GR
+        Gr/2Tjd3U5/ebkG7aUa47TJnT5l9UWE6H83plUL5Kb/39av/k8wPe6tN+V/2CqLhhb0ylk+f+V9B
+        HGVxXFlJKYryHqv/qAb5sieTzXYK+tdYPmVsi8R87OiWiBsG0xDblYrFPkvaXyt4QO+Dghtcwy2O
+        Fz9mUyN2122W+pGaf+W1fkyWUDKToIuodavNSJtnczEUn029yXYkzK+K/IAJGFVvuz/1qBZKT4vM
+        u6hLEvVzqIzEXFUKVUi+clWpKi/Iyckbm9zaL6TDcwPXdG2MkkXTdrvH5hTOQosfmTmZvoXJ0rcK
+        RMRzahI/kP7Bl1Z0ihsQkTRCiwf90QhQfL/3UviEBBaaiPhxy59ma9SndEBs30VVpTCVFU27dvPa
+        8Pxy46PLrA0+mO2OuJ6nLn+NpU0tFvLvto/ZmEvXgPEYz2zv4nC+a4cZsdJbNO3SJmta+AfHnfoM
+        e5jYWzTtqPCh44dTnlKjN19uqWOJt69XNblc4Pi7L/0E90Me0AWwkrthzrg4Yp4fDEZu6GBLm+UP
+        No84FpZZFHelP8X8Zk6M+CmC7Xg5JX96Wtbd/nbqFbO+YVmmp+sxV6zLzwnfAZP2+t3z/Ivue8nn
+        LD/w6x0O3WZBsKL6X2ZdMI8b/iMbzxPTCzLZWE9+Hcrvp0fsXkzc6mbAbqmYwfmhNyLm28zhAjIu
+        9pq/SWAtOnY9dFKw3PyKJ398hFtih1SrQasordSmdzPn1VUUXEXBahkDq2UUrKsYWFfxkUvoyCV8
+        ZAMd2cAVRMEaDtZRNnScDR1lQ8fZ0CqoGBV8ZBSs42AN5VnDeUb1y1BPQYVQcCFQsIaDUf/E3RND
+        okDUFrgpUIfA/UFFDaHihjB0dGAdJ0xDCdNwMVB2VZxdHQ0lHQ8lAx3ZwEc2UJkNXGYNFUPDxcDJ
+        wLlAWVYzWEbdQssIUXRkDR/ZQKPOwKMOHRgfV0W9U81IV/jAGSOjYaficaejFtEzTIJyoeJcoG6B
+        ewUafHjsqai8Ki6vjjKh40yoaMqE2vVHPz4N5GvxI0pxyXGDl00SrOqoOhqWqVxRR6ZsmEpNrpma
+        JptDo0YtapUMo4RMHrbs9opJhfihQqHxoFZJ54qVhvchQ60RpaLIhlXRQKuyJg+NkS5bqmZWdUoM
+        S6TydTK26vZ9ZFRLGk4Gb3gPMvglEGXj6lcqs6LCuwiumJpJKCnLVFGGsjEcEblKhmVZMYelSsko
+        myOzjCi2Zbfvs2K5nGFF3vAeZKijqmqUrRLoUuOBqisyMcq6bJrUKGvqqGaUsfjesttryRA/8Bkp
+        bj1AAzNXWUEQ70GPaVUpqYJieqkMeqpaWa4R/qOAtFLRVKIpqlFD6Nmy23emv1pG9qu9ERVX/Cdg
+        g+Q3Hz06AdLF6h5qHp+e/g88UKYkXVYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -616,12 +635,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:53:33 GMT
+      - Thu, 21 Nov 2019 15:39:59 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -631,9 +650,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - a5b887bd73ae2d037b4375f6b2b82dca
+      - 53aa3ac5f67492269eb2e08d856f9bc9
     status:
       code: 200
       message: OK
@@ -649,76 +668,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPbGLB5mSVAJtkNhAMJ3TvdWY6wBWhjbMaWc+mQ/74l
-        2QYRbEI6l2Zm8kBkVUmu+upilXx5yBF37OVqDznv1sV+rpZDru3j238G9nXR8ye5Qs5FMwz9FAd0
-        GFjIHY7JHQ19zEjekCJ/gmmuNkZOgAu5sefY2B8SO1dzQ8cp5CzPpb7n5GrUD4EeBkCdY39GgoB4
-        bpCrqZpRyAXWFNuhg4dhyIbCyWZzB1Es45GFLFQqyVrJLMlVhCuyoY7L0FLLtqYZpmoZZknRLYT0
-        slFVkFrRQTBsEzpEjuPdYnspGxMedBzGCl32pYbjhbbUj/ph2NxziHUPtCMUEEvqYHrr+decAajB
-        FPl4qZg3+h+2KNdUVZVCjqJJDEaQsCDLgfaXh9yawsAbYx1x2SQAXe9jsaI+sb3Ckt7PmeA2HqPQ
-        obnHwpOZOZTx3OrTiTMNu9HPTqgtz8Yslnu8KuSmXkAtL3QpVyE2lKGb5lhTLNm0kS7rplGVDbCZ
-        XFZsZGLbNPVyiUFHEQ1BQpDXtYnLzsJdKT7HPMgxAGPw4pZWnIcj1ixS7KKRgwNshT6h90XLmwE/
-        cmgC+BCEXNl5bhEZJpfDueOhdfMPQRAfFFDLlVKpahgKwETJDFwbzebr3VMUXI+Wg+EIheBU1EfE
-        2fCoeFZmpUfgJQH1/Htu+bgduYliaKZSSmw0jHG2fIwoGHBog8Ovy+AgiLmZZ5MxsbJ4XmYIEfBU
-        o0Rx6HMbZyCcOAPzbWjehA5og0bEIZTguBNMNBd42KFDkGvh6HhMHIr9KDhiN2TcRVClkAM8bGbv
-        xHHrQYCpdNrMCdnkIdEEQ8c9HzTBd3D8RZFNJI+vHoxH+WB5oD/K+YfS4/JY1R4PCjuz5n8SpUrO
-        pKhaSS9XqjIaWbaMx4oqsw65UjVM1sV6IEZzHsQoAidg2ubw7yzw+O8MUWvKjqIGoDLxvXCeaC3C
-        es9jPSbMnXBC3CICXySjENJycZQK21E4AW/9fVfg/ss0vvo5guXq53SdO5fto1aPC3/nYHdCp+CM
-        xocoie8gnCGrj33gYGl5CMF3g4IUzRv1zqDel1rRCOk4GZGKg+17cxsCEogOBCuTn12q4JA7e+4q
-        U7tXKBOJPpwj6xpNcLYK3SXDToJHo6CjqcXKswng+NOUUDzsQoxBVPoQ9O+i1Z2Px7VGq3chNxpp
-        OgFFqts3JICMuLNbNupy5JFy4qBPe/I//T3NV4HtP/AnnzalA4JrEhxrilKSFSP/MWG5hCMLi4E4
-        13fHabry2KfS4FICEbCPIe9GGKgAgJrfl/j1/FTXP++19jp256lSd1s7ma+YmlcvWp8vPsYprRtc
-        9NFtmgaD3TT47wFwLiDV5OUD1TTNhaZ8UdQr7o75KCQf9AJcX3fjy3LgQQvCVS3LsJKpFOKjiqwq
-        cMn9KKSCYDhCAYaqJ8NTB/2+BKUChgoh4tg9fL9+LcYB/Euq/tVieUNNWDMB64T/voknMw1ZqeX5
-        yNmu5UXM9SpNUxXVi9oHK3oDdZvnZ0aBqO2As+54oYKR2t9atYPLRfe8sThenCw6zfxh76x2cH68
-        uFh8WlxGHQ1gaSwue4sGO+Zx8l0j8xmh06qdFKRW7XgD1jeOjedxfDl89UHt4GxRX3Tyh3XQ9mTR
-        XpxBM6wddBb9RTt/2GCt7qKRPzxdtupJa4nl66bJAhZm7RQk+K2/M7SlHfLOTamo/NGTT2nH7MN1
-        /eOnoNJLctC6zi+NpBqMPowyCs8nn+N0EmeTz1EygVyy6MFBHDcvG/SD009pVwy/CzqWQDqQQM4W
-        3SiFnC1O8ofdHuvlzUueN3r5wz7Dq8EzygmQOjyjxK160hIBfuOpf2iyikqcT600A3zadTkZh+Zz
-        Fc2n1tNqBsq5dynlVrtVQxsHlk/mbO8tTccptq6lDjt447X/G4i+BCtN8CWb1BPY9kKFTS+LN7yH
-        yIr2nzf1aUYch/92oRqU6hFfsD8142bxa2tD7DjES9OmxQn7XAMvpY/GPqvCe4TIu+5SoBtEHCZD
-        mm6xUnWBZ0/swvNxq3kk882kLMGbiCK2wHzbLae92huOe6bhKBuHE07cE8vFAse8QwzmyVjZtNY4
-        pRZw7qpGPDSQkI8l0cU7nhQLIJEALrO/h4Td6uSEa55TcfrQ98QC28PR/XCGnFuUWhq0Ejbp6F5q
-        L9n2y6CREi4OgjDtVsWaDp2E64eowG/AxbfzNwU9ASprHp52pbpt+yDqKxK6ampFtWIU1aJWUKus
-        XYQfedVUlIKqsH/FMiyZNb3ApcN3CNYtmN8A/rgt/NP6oJ6CCOt+YQaVv9Tl35D87Upez6hP+zMy
-        LD/jxhpYVeW6rKhl9SNva4AoR+mYHH04JkepmBx9JCYBJZNhgG8wez4hHZe21F/Rd0GH3JwOrn7O
-        0Hk1W6Ty6eCDrZ92U4t1f7j1L358RBB3SKeAAr5NS/GnrnQxxZDcb/eoIMm+qu7rhVRY3M0wRQHv
-        TJN/SdznAmqlQlYFJejxh6meeHJo94/TkkObWL4XeGMqHYWOgylxd8sT7f6T2/9POjIyQ7tvmrJp
-        msCuKHLVMD8QgfP+oJl2deT9f5qia84mGM7DkbP2cNqm2l3GKHVXjKwAzUgwQBgT7NgbQDzoj4dR
-        Q1s1UiFhD30cttuHzeaGydn0ssOyRtzCSXNCV61lJweMt167XbJ1F7HL+aXmGtM+bcWN0Yw4/BnG
-        TOGPOcvW/DqchQ4lqyy7PEsPqp8TRKUzz2J3d+KnPCW+ucoumfzZSUGqk658+XkrtyZwN/GIIHcr
-        e0lg73sO8qEG3savC/zH2PZ8tJW9LLA3fj2V0CgMcEKsCMRfwcSet3Wuqihq2G9tZTYE5vrpdshM
-        gfcTccFggVSTNpP20iCKOACPYFr/hj3SGZNFg/XbF11p7nvgNrMlg2ijYx/jo35zuweIVrochS4N
-        t/OLVuo7yLpmy5rtQ0RLtdlz0ej6mRGi+Xp45lEsjYmDJWRZUYXMuUSrNcDI5/3ts4qGO77oJt0p
-        NkocXlmT3IITPBMh6lqIuAQ4vTE3IuG3AjiTaKM2CaxiQliLmGiMZGOKrTh7cSZ97RR8g166dMmd
-        uD/PGdMDBNzvc7+f8KzFCYKM43sehaU/g5wnHs4lAt3rNpJuI9W5LwPsSzPkogmeYX5bgTOb6xEJ
-        idFJ8oSIcrKJukwiIqJdjH35wpPZf+mYOUR/CmnFTR6vL4nINk77jfOEICJ7THx8ixxneQoR0SPw
-        aNvzlhFXElHsN+rNekIQoWt2EkRLIlYAhQP+KgWRLZdzisB1+csR0urWUcJkPjUNkoIpdpyn1tGV
-        Na+hkE0my5S6hp7nUyl+tn7JICLGXsyIahROWsfMnQDmazlWX0sFnXYSULoIWec0QUavPE0D5GZ7
-        htdFLAdtnmha/e0RqIvYHvkhyxyeD3EE6wYksIno/it0ve2XpvIaxhYBv2YvD0hnxA3vto8ULdD2
-        Rsxpm1j0hrJognMfWcCxw7yideoz9A3WfzuMEk3WRY4n1R26/dJYFq15EqJbTLbzi2Y+Lidv+zyD
-        b3UDg0F7+wjRzqeuRWywidTDwdxzg8SFy6KVB8Snofft23Z1K6Klf7vYvhKoqI9vV8ZuWwfuWtwc
-        KIsvKizio5W8Uqg85g++fg1+ktnPwVNS/peDAie8cFRG0fSZ/RX4r8x/n9RPiqK8R80f9aS8z5OJ
-        Zltg/WsUTRmbITEee7oR4oV0HqbtRcVinyf07xWc4jta8OgULmys+TFbGbG77lLgR2r+lSv8GCyu
-        ZCZAFxF1py1Ih2VzPhVbQ73JJiSsqorsJ03AqHvXXakHtVB+XGXeVV+SqJ/jykjMhlIwIPnKhmIo
-        L8jJyXOazNovhMP3qGd5ThokK9Jue8bWHI5Cm/0SazZ/C5OJl4oUEXvYQgGV/sEKKjxPN2CKpBE3
-        v70fzQDN93sahS1IoLxMET+m/Gk2RAOMh8gJvFRVMSxgOWnfLl5b7lpuvWGZta0Ha9wx0/PMYw+v
-        tLFNQva29gmZMOkaMB9hme1dHC7wnDAjVvor0j5trYrC37vePCBptxD7K9KeCh+6QThnKTV63uUG
-        uzZ/5vqpJpcrPvbEyyDh+yG35SjUb9fEnRTHxA/ocOyFblpps/6a5jHjhTILp7vSn2J9swSGf4Bg
-        N1zO0J8elk23v5n7xaw3V9bh6frE43V5D7F9L+lg0O3lX3TdS15i+YHv7DDWXQqCJ6r/ZeqCZdyw
-        T2s8D0yfZqKxmfw6mF1Pj8kdX7jVLUpuMF/BBaE/RtbbrOEomhRL1bKhIvaNnQpSZF1DY9m0KyNZ
-        H6lGpWRqml0yU1Tbcdh33B/kXx66QU6IhyVVBQbe3iRsbnEFmMpT/omIuOV69GVgKHqpauioImuK
-        rYJWI0VGYxXLCsKVkoJVS7OsFDB2HPY6MMpGOhbQ/x5Q8DNAGOMJ+6BNhX9O5qneaTyvVLKsZWgJ
-        hHexuFq1q2ZZlbGu6bKOsSojQ8eyOsbKWDM1rNjjNIvvNux1YFTLlXQwGOH9bV41+Pm3Gz1mep2i
-        ulpKV5QR3kPRSgmXEUZYNitVyF6GNpINw0aybpXG+sgaVW1VT1F9x2GvA4N9zCwdDU55Gziu2Nfc
-        aPL5Jh/PYG5+yYaeh8fH/wNNwfpuKE4AAA==
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBevPxlFgFHdwQ5onTvdrucIimw1pAwefho8X/fW5UE
+        Atwg2mozM/4QK1VfVe797iNVlYTHHHNGbu7gMefeOdTLHeSIY3n07p++dVN0vXGukHPIhEJ9QP1g
+        4JvEGYzYfRB6lDe5g4B4YxrkDkbE9mkhN3Jti3oDZuUOnNC2CznTdQLPtXMHgRdCe+hD65R6E+b7
+        zHX83IGqVQs537ymVmjTQRjyrnCxydQmAZUNMiyrZDiUS6ZallWtRmSVapZMKkrVVKzSSFeN8qhS
+        LZXVSqlWVsrKqAKCUYsFA2Lb7h215rJx4UHHQazQZU9q2G5oSb2oHrpNXZuZD9B2SHxmSh0a3Lne
+        jQBAq39NPDpXzB3+j5qB0FRTa4VcQMYxGX4CIaYN5S+PuSWFlULCdYSymA+6PsRiRXXp8oLL4GHK
+        BbfoiIR2kHsqrIwsqIzHVlcHzjTsWr1QaX41brHc01Uhd+36gemGTiBUiA1VNiomqdSqskVVTTaq
+        VJOHI10Dc1V0XTN0VSkpnLqABCFICPI6FnP4VYQrxdeY+jlOYExeXNKK03DIi8WAOmRoU5+aoceC
+        h6LpTgBP7CAhfABCLuw8NZkMg8vh1HbJsvkHIIgHCqiliqGXlEqlAtdlE3BtMpkuV18T/2Y47wxn
+        JASnCjzC7DWPikflVnoCLPMD13sQlo/Lwk1UVSnrNTWx0SDm2fQoCcCAAwscflkGm0DMTVyLjZiZ
+        hXmZIdKEo0aJ4tATNs5gOHEG7ttQvA1t0IYMmc0CRuNKMNE0heGnNiOOSaPzEbMD6kXBEbshRxdB
+        lUIO+LC4vRPHrfs+DaSTZi6VTR4TTShUPIhOY3oP518UGXLE6Oqx+iTvzU+MJzn/qD/Nz1Xtaa+w
+        NTT/U1qq5EqKqulGqVyRydC0ZDpSVJlXyOVKtcareA3EaM6FGCXgBFzbHP2dB544TkhgXvOzqACs
+        jD03nCZap2l9ELEeN0ztcMycIgFfZMMQ0nJxiNJ2GI7BW3/flrj/co2vfo5oufoZ17lz2T5snQvh
+        723qjINrcMbqhyhJ7yGcIauPPEDwtDyA4LslPqJ5o97p13tSK+ohHSU9UB4sz51aEJDQaEOwcvn5
+        rQpOhbPnrjK1+w5lItEHU2LekDHNVqE7B2wleNQLKpparDwfAM4/XbOADroQYxCVHgT9u2h179HR
+        QaN1fiE3GphO0CLVrVvmQ0bc2i0bdTnySDlx0NWa/E9/x3wVYP+GP/mkKe0xeiDBuaYouqxU8x8T
+        lnM6srjop8d6dZziylMvkPqXEohAPQp5N+JABQLU/K7Er+uhrn923trp2J2iUndbW5mviObVi9bn
+        i49xSvOWFj1yh2nQ306D/+4BcgapJi/vqbVabaYpXxT1SrhjPgrJR6MA99ftcFkO3G9BuKoluVat
+        lAvxGawAFLjlfhRTvj8YEp/CqifDU/u9ngRLBQorhAixffh+/VqMA/gXVP9KsbSmJsyZADoWxzfx
+        ZK4hX2q5HrE3a3kRo75LU1RRo6h9sKK3sG5zvcwoSGvbF9Atb1TQU/tb62DvctY9a8yOZsezTjO/
+        f356sHd2NLuYfZpdRhUNgDRml+ezBj8XcfKqnvmM0GkdHBek1sHRGq1vHBvP8/hy+ur9g73TWX3W
+        ye/XQdvjWXt2CsXwYK8z683a+f0GL3Vnjfz+ybxUT0pzLr9vmCxiYdROQYJj/Z2p1bfIO7d6Ufmj
+        Jx99y+wjdP3jpyD9JTloWeeXRtIB9N6PMorIJ5/jdBJnk89RMoFcMjuHkzhuXtbpB6cffVsOX0Ud
+        TyAdSCCns26UQk5nx/n97jmvFcVLkTfO8/s9zldDZJRjaOqIjBKX6kkpTfAbD/1Dk1W0xPnUwgzw
+        advpZByaz61oPrVWVzOwnHuXpdxit2pgUd/02JTvvWE6XlPzRurwkzee+7+B6HOyMMHnMOk8BdsJ
+        Fda9LN7wHhAz2n9e16cZIfZ/c2A1KNUjnL87a8b1xa+lDahtMxfTpiUadnkNPJc+6vusCu8RIu+6
+        S0FuCbO5DJhusVL1FGZH7CLycat5KIvNpCzBmyQgfIL5tltOO7U3HNdch8NsHo5F445YLhY4xg4o
+        mCdjZtNaQkotQG6rRtzVl4hHpbSLd1wpFkBiPtxmfw8Zf9QpGm5ETqV41/fkglqD4cNgQuw7gi4N
+        WglMOnyQ2nPYbhk0UsKhvh9ijyqWdOgkqB+igngAFz/OXxf0GFp5cf+kK9UtywNRvyOhqzWtqJar
+        RbWoFdQKLxfhIC+KilJQFf6vWIIps2YUhHT0nsC8hYoHwB+3hX9S79cRRnj1CzOo/KUu/4fI367k
+        5Yy6Wp+RYcUV1+bAqirXZUUtqR/5WANEOcQ5OfxwTg5RTg4/khM/YOOBT28pfz8B56Ut9Rbt27DD
+        bk/6Vz9n6LwYLVL5pP/B1sceavHqD7f+xY+PCOYMgmtggd5hKf7EkS6uKST3ux1akGTfVXf1Rpqa
+        3E1oQHxRick/b9zlBdRChawVVEqPP8zqSSSHdu8ISw5tZnqu744C6TC0bRowZ7s80e6tPP5fqcjI
+        DO1erSbXajWAK4pcqdY+kIGzXr+J3R1F/Z9m0TXlAwym4dBeejltXe0uB0rdBZAvQDMSDDSMGLWt
+        NSIejaf9qKAtCigl/KWP/XZ7v9lcMzkfXrZ51ohLNCmOg0VpXikIE6Xv3S7ZuIvYFXipuQTapa24
+        EZkwW7zDmCn8kYBszK+DSWgHbJFl51c5h9XPMQmkU9fkT3fitzwlsbnKb5ni3cmUVMdd+fLzRrSW
+        QjfpkBFnI1xPwXuuTTxYA2/CGyn8EbVcj2yEl1Lwxq8nEhmGPk0ay6nGX8HErrtxrEpa1LDX2giu
+        psD1k82U1VLYT8wBg/nSgbSetOcGUdId6BCG9W75K51xc9pgvfZFV5p6LrjNZA5I2+jIo/Sw19zs
+        AWkrXQ5DJwg349NW6tnEvOHTms1d0pZq8/eiyc0zPdLmO6cTN6DSiNlUIqYZrZAFKm21Bhj5rLd5
+        1LThji66STVio8ThlSXJTbjAMxGiLoWIwwDpjoQRmXgUIEBpG7WZbxaThqWIifpIFg2oGWcvATKW
+        LiE26KVLh92n9+cFEA8QcL/PvV6CWYoTAhnHc90Apv6ccpF4BCpN9Hm3kVRXUee+9KknTYhDxnRC
+        xWMFAa4tRyQkRjvJE2mWk03UeRJJM9ql1JMvXJn/l464Q/SuIa04yev1eprZxkmvcZY0pJk9Yh69
+        I7Y9v0Sa0UPwaMt15xGnp1nsNerNetKQpq7ZSRjV01wBFTb4q+RHtpyPmSauKz6OkBaPjhJQbdU0
+        RPKvqW2vWsdQlrwmgGwynqfUJfZcL5Did+vngDRj/MOMaI0impY5c8bA+VKONZZSQaedBJSRpqxz
+        kjBjlFfTALvdnOGNNJf9tkg0rd7mCDTS3B56Ic8crgdxBPMGkoKl2f1X6Libb02lJY5NBn7NPx6Q
+        TpkT3m/umbZA2x1yp23StDeU0iY484gJiC3GTVunPiHfYP63Ra+0ybrEdqW6HWy+NZbS1jwOyR1l
+        m/FpMx+Vkq99nuG3ssZBv725R9rOJ47JLLCJdE79qev4iQuX0lbuMy8I3W/fNqtbVpYC4q7Hv0GR
+        Gr/2Tjd3U5/ebkG7aUa47TJnT5l9UWE6H83plUL5Kb/39av/k8wPe6tN+V/2CqLhhb0ylk+f+V9B
+        HGVxXFlJKYryHqv/qAb5sieTzXYK+tdYPmVsi8R87OiWiBsG0xDblYrFPkvaXyt4QO+Dghtcwy2O
+        Fz9mUyN2122W+pGaf+W1fkyWUDKToIuodavNSJtnczEUn029yXYkzK+K/IAJGFVvuz/1qBZKT4vM
+        u6hLEvVzqIzEXFUKVUi+clWpKi/Iyckbm9zaL6TDcwPXdG2MkkXTdrvH5hTOQosfmTmZvoXJ0rcK
+        RMRzahI/kP7Bl1Z0ihsQkTRCiwf90QhQfL/3UviEBBaaiPhxy59ma9SndEBs30VVpTCVFU27dvPa
+        8Pxy46PLrA0+mO2OuJ6nLn+NpU0tFvLvto/ZmEvXgPEYz2zv4nC+a4cZsdJbNO3SJmta+AfHnfoM
+        e5jYWzTtqPCh44dTnlKjN19uqWOJt69XNblc4Pi7L/0E90Me0AWwkrthzrg4Yp4fDEZu6GBLm+UP
+        No84FpZZFHelP8X8Zk6M+CmC7Xg5JX96Wtbd/nbqFbO+YVmmp+sxV6zLzwnfAZP2+t3z/Ivue8nn
+        LD/w6x0O3WZBsKL6X2ZdMI8b/iMbzxPTCzLZWE9+Hcrvp0fsXkzc6mbAbqmYwfmhNyLm28zhAjIu
+        9pq/SWAtOnY9dFKw3PyKJ398hFtih1SrQasordSmdzPn1VUUXEXBahkDq2UUrKsYWFfxkUvoyCV8
+        ZAMd2cAVRMEaDtZRNnScDR1lQ8fZ0CqoGBV8ZBSs42AN5VnDeUb1y1BPQYVQcCFQsIaDUf/E3RND
+        okDUFrgpUIfA/UFFDaHihjB0dGAdJ0xDCdNwMVB2VZxdHQ0lHQ8lAx3ZwEc2UJkNXGYNFUPDxcDJ
+        wLlAWVYzWEbdQssIUXRkDR/ZQKPOwKMOHRgfV0W9U81IV/jAGSOjYaficaejFtEzTIJyoeJcoG6B
+        ewUafHjsqai8Ki6vjjKh40yoaMqE2vVHPz4N5GvxI0pxyXGDl00SrOqoOhqWqVxRR6ZsmEpNrpma
+        JptDo0YtapUMo4RMHrbs9opJhfihQqHxoFZJ54qVhvchQ60RpaLIhlXRQKuyJg+NkS5bqmZWdUoM
+        S6TydTK26vZ9ZFRLGk4Gb3gPMvglEGXj6lcqs6LCuwiumJpJKCnLVFGGsjEcEblKhmVZMYelSsko
+        myOzjCi2Zbfvs2K5nGFF3vAeZKijqmqUrRLoUuOBqisyMcq6bJrUKGvqqGaUsfjesttryRA/8Bkp
+        bj1AAzNXWUEQ70GPaVUpqYJieqkMeqpaWa4R/qOAtFLRVKIpqlFD6Nmy23emv1pG9qu9ERVX/Cdg
+        g+Q3Hz06AdLF6h5qHp+e/g88UKYkXVYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -729,12 +753,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:53:44 GMT
+      - Thu, 21 Nov 2019 15:40:10 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -744,9 +768,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 50d558fe39c5574cf16c20122f2353c8
+      - 89a00f47f569a6709b2c898c04349d49
     status:
       code: 200
       message: OK
@@ -762,76 +786,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPbGLB5mSVAJtkNhAMJ3TvdWY6wBWhjbMaWc+mQ/74l
-        2QYRbEI6l2Zm8kBkVUmu+upilXx5yBF37OVqDznv1sV+rpZDru3j238G9nXR8ye5Qs5FMwz9FAd0
-        GFjIHY7JHQ19zEjekCJ/gmmuNkZOgAu5sefY2B8SO1dzQ8cp5CzPpb7n5GrUD4EeBkCdY39GgoB4
-        bpCrqZpRyAXWFNuhg4dhyIbCyWZzB1Es45GFLFQqyVrJLMlVhCuyoY7L0FLLtqYZpmoZZknRLYT0
-        slFVkFrRQTBsEzpEjuPdYnspGxMedBzGCl32pYbjhbbUj/ph2NxziHUPtCMUEEvqYHrr+decAajB
-        FPl4qZg3+h+2KNdUVZVCjqJJDEaQsCDLgfaXh9yawsAbYx1x2SQAXe9jsaI+sb3Ckt7PmeA2HqPQ
-        obnHwpOZOZTx3OrTiTMNu9HPTqgtz8Yslnu8KuSmXkAtL3QpVyE2lKGb5lhTLNm0kS7rplGVDbCZ
-        XFZsZGLbNPVyiUFHEQ1BQpDXtYnLzsJdKT7HPMgxAGPw4pZWnIcj1ixS7KKRgwNshT6h90XLmwE/
-        cmgC+BCEXNl5bhEZJpfDueOhdfMPQRAfFFDLlVKpahgKwETJDFwbzebr3VMUXI+Wg+EIheBU1EfE
-        2fCoeFZmpUfgJQH1/Htu+bgduYliaKZSSmw0jHG2fIwoGHBog8Ovy+AgiLmZZ5MxsbJ4XmYIEfBU
-        o0Rx6HMbZyCcOAPzbWjehA5og0bEIZTguBNMNBd42KFDkGvh6HhMHIr9KDhiN2TcRVClkAM8bGbv
-        xHHrQYCpdNrMCdnkIdEEQ8c9HzTBd3D8RZFNJI+vHoxH+WB5oD/K+YfS4/JY1R4PCjuz5n8SpUrO
-        pKhaSS9XqjIaWbaMx4oqsw65UjVM1sV6IEZzHsQoAidg2ubw7yzw+O8MUWvKjqIGoDLxvXCeaC3C
-        es9jPSbMnXBC3CICXySjENJycZQK21E4AW/9fVfg/ss0vvo5guXq53SdO5fto1aPC3/nYHdCp+CM
-        xocoie8gnCGrj33gYGl5CMF3g4IUzRv1zqDel1rRCOk4GZGKg+17cxsCEogOBCuTn12q4JA7e+4q
-        U7tXKBOJPpwj6xpNcLYK3SXDToJHo6CjqcXKswng+NOUUDzsQoxBVPoQ9O+i1Z2Px7VGq3chNxpp
-        OgFFqts3JICMuLNbNupy5JFy4qBPe/I//T3NV4HtP/AnnzalA4JrEhxrilKSFSP/MWG5hCMLi4E4
-        13fHabry2KfS4FICEbCPIe9GGKgAgJrfl/j1/FTXP++19jp256lSd1s7ma+YmlcvWp8vPsYprRtc
-        9NFtmgaD3TT47wFwLiDV5OUD1TTNhaZ8UdQr7o75KCQf9AJcX3fjy3LgQQvCVS3LsJKpFOKjiqwq
-        cMn9KKSCYDhCAYaqJ8NTB/2+BKUChgoh4tg9fL9+LcYB/Euq/tVieUNNWDMB64T/voknMw1ZqeX5
-        yNmu5UXM9SpNUxXVi9oHK3oDdZvnZ0aBqO2As+54oYKR2t9atYPLRfe8sThenCw6zfxh76x2cH68
-        uFh8WlxGHQ1gaSwue4sGO+Zx8l0j8xmh06qdFKRW7XgD1jeOjedxfDl89UHt4GxRX3Tyh3XQ9mTR
-        XpxBM6wddBb9RTt/2GCt7qKRPzxdtupJa4nl66bJAhZm7RQk+K2/M7SlHfLOTamo/NGTT2nH7MN1
-        /eOnoNJLctC6zi+NpBqMPowyCs8nn+N0EmeTz1EygVyy6MFBHDcvG/SD009pVwy/CzqWQDqQQM4W
-        3SiFnC1O8ofdHuvlzUueN3r5wz7Dq8EzygmQOjyjxK160hIBfuOpf2iyikqcT600A3zadTkZh+Zz
-        Fc2n1tNqBsq5dynlVrtVQxsHlk/mbO8tTccptq6lDjt447X/G4i+BCtN8CWb1BPY9kKFTS+LN7yH
-        yIr2nzf1aUYch/92oRqU6hFfsD8142bxa2tD7DjES9OmxQn7XAMvpY/GPqvCe4TIu+5SoBtEHCZD
-        mm6xUnWBZ0/swvNxq3kk882kLMGbiCK2wHzbLae92huOe6bhKBuHE07cE8vFAse8QwzmyVjZtNY4
-        pRZw7qpGPDSQkI8l0cU7nhQLIJEALrO/h4Td6uSEa55TcfrQ98QC28PR/XCGnFuUWhq0Ejbp6F5q
-        L9n2y6CREi4OgjDtVsWaDp2E64eowG/AxbfzNwU9ASprHp52pbpt+yDqKxK6ampFtWIU1aJWUKus
-        XYQfedVUlIKqsH/FMiyZNb3ApcN3CNYtmN8A/rgt/NP6oJ6CCOt+YQaVv9Tl35D87Upez6hP+zMy
-        LD/jxhpYVeW6rKhl9SNva4AoR+mYHH04JkepmBx9JCYBJZNhgG8wez4hHZe21F/Rd0GH3JwOrn7O
-        0Hk1W6Ty6eCDrZ92U4t1f7j1L358RBB3SKeAAr5NS/GnrnQxxZDcb/eoIMm+qu7rhVRY3M0wRQHv
-        TJN/SdznAmqlQlYFJejxh6meeHJo94/TkkObWL4XeGMqHYWOgylxd8sT7f6T2/9POjIyQ7tvmrJp
-        msCuKHLVMD8QgfP+oJl2deT9f5qia84mGM7DkbP2cNqm2l3GKHVXjKwAzUgwQBgT7NgbQDzoj4dR
-        Q1s1UiFhD30cttuHzeaGydn0ssOyRtzCSXNCV61lJweMt167XbJ1F7HL+aXmGtM+bcWN0Yw4/BnG
-        TOGPOcvW/DqchQ4lqyy7PEsPqp8TRKUzz2J3d+KnPCW+ucoumfzZSUGqk658+XkrtyZwN/GIIHcr
-        e0lg73sO8qEG3savC/zH2PZ8tJW9LLA3fj2V0CgMcEKsCMRfwcSet3Wuqihq2G9tZTYE5vrpdshM
-        gfcTccFggVSTNpP20iCKOACPYFr/hj3SGZNFg/XbF11p7nvgNrMlg2ijYx/jo35zuweIVrochS4N
-        t/OLVuo7yLpmy5rtQ0RLtdlz0ej6mRGi+Xp45lEsjYmDJWRZUYXMuUSrNcDI5/3ts4qGO77oJt0p
-        NkocXlmT3IITPBMh6lqIuAQ4vTE3IuG3AjiTaKM2CaxiQliLmGiMZGOKrTh7cSZ97RR8g166dMmd
-        uD/PGdMDBNzvc7+f8KzFCYKM43sehaU/g5wnHs4lAt3rNpJuI9W5LwPsSzPkogmeYX5bgTOb6xEJ
-        idFJ8oSIcrKJukwiIqJdjH35wpPZf+mYOUR/CmnFTR6vL4nINk77jfOEICJ7THx8ixxneQoR0SPw
-        aNvzlhFXElHsN+rNekIQoWt2EkRLIlYAhQP+KgWRLZdzisB1+csR0urWUcJkPjUNkoIpdpyn1tGV
-        Na+hkE0my5S6hp7nUyl+tn7JICLGXsyIahROWsfMnQDmazlWX0sFnXYSULoIWec0QUavPE0D5GZ7
-        htdFLAdtnmha/e0RqIvYHvkhyxyeD3EE6wYksIno/it0ve2XpvIaxhYBv2YvD0hnxA3vto8ULdD2
-        Rsxpm1j0hrJognMfWcCxw7yideoz9A3WfzuMEk3WRY4n1R26/dJYFq15EqJbTLbzi2Y+Lidv+zyD
-        b3UDg0F7+wjRzqeuRWywidTDwdxzg8SFy6KVB8Snofft23Z1K6Klf7vYvhKoqI9vV8ZuWwfuWtwc
-        KIsvKizio5W8Uqg85g++fg1+ktnPwVNS/peDAie8cFRG0fSZ/RX4r8x/n9RPiqK8R80f9aS8z5OJ
-        Zltg/WsUTRmbITEee7oR4oV0HqbtRcVinyf07xWc4jta8OgULmys+TFbGbG77lLgR2r+lSv8GCyu
-        ZCZAFxF1py1Ih2VzPhVbQ73JJiSsqorsJ03AqHvXXakHtVB+XGXeVV+SqJ/jykjMhlIwIPnKhmIo
-        L8jJyXOazNovhMP3qGd5ThokK9Jue8bWHI5Cm/0SazZ/C5OJl4oUEXvYQgGV/sEKKjxPN2CKpBE3
-        v70fzQDN93sahS1IoLxMET+m/Gk2RAOMh8gJvFRVMSxgOWnfLl5b7lpuvWGZta0Ha9wx0/PMYw+v
-        tLFNQva29gmZMOkaMB9hme1dHC7wnDAjVvor0j5trYrC37vePCBptxD7K9KeCh+6QThnKTV63uUG
-        uzZ/5vqpJpcrPvbEyyDh+yG35SjUb9fEnRTHxA/ocOyFblpps/6a5jHjhTILp7vSn2J9swSGf4Bg
-        N1zO0J8elk23v5n7xaw3V9bh6frE43V5D7F9L+lg0O3lX3TdS15i+YHv7DDWXQqCJ6r/ZeqCZdyw
-        T2s8D0yfZqKxmfw6mF1Pj8kdX7jVLUpuMF/BBaE/RtbbrOEomhRL1bKhIvaNnQpSZF1DY9m0KyNZ
-        H6lGpWRqml0yU1Tbcdh33B/kXx66QU6IhyVVBQbe3iRsbnEFmMpT/omIuOV69GVgKHqpauioImuK
-        rYJWI0VGYxXLCsKVkoJVS7OsFDB2HPY6MMpGOhbQ/x5Q8DNAGOMJ+6BNhX9O5qneaTyvVLKsZWgJ
-        hHexuFq1q2ZZlbGu6bKOsSojQ8eyOsbKWDM1rNjjNIvvNux1YFTLlXQwGOH9bV41+Pm3Gz1mep2i
-        ulpKV5QR3kPRSgmXEUZYNitVyF6GNpINw0aybpXG+sgaVW1VT1F9x2GvA4N9zCwdDU55Gziu2Nfc
-        aPL5Jh/PYG5+yYaeh8fH/wNNwfpuKE4AAA==
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBevPxlFgFHdwQ5onTvdrucIimw1pAwefho8X/fW5UE
+        Atwg2mozM/4QK1VfVe797iNVlYTHHHNGbu7gMefeOdTLHeSIY3n07p++dVN0vXGukHPIhEJ9QP1g
+        4JvEGYzYfRB6lDe5g4B4YxrkDkbE9mkhN3Jti3oDZuUOnNC2CznTdQLPtXMHgRdCe+hD65R6E+b7
+        zHX83IGqVQs537ymVmjTQRjyrnCxydQmAZUNMiyrZDiUS6ZallWtRmSVapZMKkrVVKzSSFeN8qhS
+        LZXVSqlWVsrKqAKCUYsFA2Lb7h215rJx4UHHQazQZU9q2G5oSb2oHrpNXZuZD9B2SHxmSh0a3Lne
+        jQBAq39NPDpXzB3+j5qB0FRTa4VcQMYxGX4CIaYN5S+PuSWFlULCdYSymA+6PsRiRXXp8oLL4GHK
+        BbfoiIR2kHsqrIwsqIzHVlcHzjTsWr1QaX41brHc01Uhd+36gemGTiBUiA1VNiomqdSqskVVTTaq
+        VJOHI10Dc1V0XTN0VSkpnLqABCFICPI6FnP4VYQrxdeY+jlOYExeXNKK03DIi8WAOmRoU5+aoceC
+        h6LpTgBP7CAhfABCLuw8NZkMg8vh1HbJsvkHIIgHCqiliqGXlEqlAtdlE3BtMpkuV18T/2Y47wxn
+        JASnCjzC7DWPikflVnoCLPMD13sQlo/Lwk1UVSnrNTWx0SDm2fQoCcCAAwscflkGm0DMTVyLjZiZ
+        hXmZIdKEo0aJ4tATNs5gOHEG7ttQvA1t0IYMmc0CRuNKMNE0heGnNiOOSaPzEbMD6kXBEbshRxdB
+        lUIO+LC4vRPHrfs+DaSTZi6VTR4TTShUPIhOY3oP518UGXLE6Oqx+iTvzU+MJzn/qD/Nz1Xtaa+w
+        NTT/U1qq5EqKqulGqVyRydC0ZDpSVJlXyOVKtcareA3EaM6FGCXgBFzbHP2dB544TkhgXvOzqACs
+        jD03nCZap2l9ELEeN0ztcMycIgFfZMMQ0nJxiNJ2GI7BW3/flrj/co2vfo5oufoZ17lz2T5snQvh
+        723qjINrcMbqhyhJ7yGcIauPPEDwtDyA4LslPqJ5o97p13tSK+ohHSU9UB4sz51aEJDQaEOwcvn5
+        rQpOhbPnrjK1+w5lItEHU2LekDHNVqE7B2wleNQLKpparDwfAM4/XbOADroQYxCVHgT9u2h179HR
+        QaN1fiE3GphO0CLVrVvmQ0bc2i0bdTnySDlx0NWa/E9/x3wVYP+GP/mkKe0xeiDBuaYouqxU8x8T
+        lnM6srjop8d6dZziylMvkPqXEohAPQp5N+JABQLU/K7Er+uhrn923trp2J2iUndbW5mviObVi9bn
+        i49xSvOWFj1yh2nQ306D/+4BcgapJi/vqbVabaYpXxT1SrhjPgrJR6MA99ftcFkO3G9BuKoluVat
+        lAvxGawAFLjlfhRTvj8YEp/CqifDU/u9ngRLBQorhAixffh+/VqMA/gXVP9KsbSmJsyZADoWxzfx
+        ZK4hX2q5HrE3a3kRo75LU1RRo6h9sKK3sG5zvcwoSGvbF9Atb1TQU/tb62DvctY9a8yOZsezTjO/
+        f356sHd2NLuYfZpdRhUNgDRml+ezBj8XcfKqnvmM0GkdHBek1sHRGq1vHBvP8/hy+ur9g73TWX3W
+        ye/XQdvjWXt2CsXwYK8z683a+f0GL3Vnjfz+ybxUT0pzLr9vmCxiYdROQYJj/Z2p1bfIO7d6Ufmj
+        Jx99y+wjdP3jpyD9JTloWeeXRtIB9N6PMorIJ5/jdBJnk89RMoFcMjuHkzhuXtbpB6cffVsOX0Ud
+        TyAdSCCns26UQk5nx/n97jmvFcVLkTfO8/s9zldDZJRjaOqIjBKX6kkpTfAbD/1Dk1W0xPnUwgzw
+        advpZByaz61oPrVWVzOwnHuXpdxit2pgUd/02JTvvWE6XlPzRurwkzee+7+B6HOyMMHnMOk8BdsJ
+        Fda9LN7wHhAz2n9e16cZIfZ/c2A1KNUjnL87a8b1xa+lDahtMxfTpiUadnkNPJc+6vusCu8RIu+6
+        S0FuCbO5DJhusVL1FGZH7CLycat5KIvNpCzBmyQgfIL5tltOO7U3HNdch8NsHo5F445YLhY4xg4o
+        mCdjZtNaQkotQG6rRtzVl4hHpbSLd1wpFkBiPtxmfw8Zf9QpGm5ETqV41/fkglqD4cNgQuw7gi4N
+        WglMOnyQ2nPYbhk0UsKhvh9ijyqWdOgkqB+igngAFz/OXxf0GFp5cf+kK9UtywNRvyOhqzWtqJar
+        RbWoFdQKLxfhIC+KilJQFf6vWIIps2YUhHT0nsC8hYoHwB+3hX9S79cRRnj1CzOo/KUu/4fI367k
+        5Yy6Wp+RYcUV1+bAqirXZUUtqR/5WANEOcQ5OfxwTg5RTg4/khM/YOOBT28pfz8B56Ut9Rbt27DD
+        bk/6Vz9n6LwYLVL5pP/B1sceavHqD7f+xY+PCOYMgmtggd5hKf7EkS6uKST3ux1akGTfVXf1Rpqa
+        3E1oQHxRick/b9zlBdRChawVVEqPP8zqSSSHdu8ISw5tZnqu744C6TC0bRowZ7s80e6tPP5fqcjI
+        DO1erSbXajWAK4pcqdY+kIGzXr+J3R1F/Z9m0TXlAwym4dBeejltXe0uB0rdBZAvQDMSDDSMGLWt
+        NSIejaf9qKAtCigl/KWP/XZ7v9lcMzkfXrZ51ohLNCmOg0VpXikIE6Xv3S7ZuIvYFXipuQTapa24
+        EZkwW7zDmCn8kYBszK+DSWgHbJFl51c5h9XPMQmkU9fkT3fitzwlsbnKb5ni3cmUVMdd+fLzRrSW
+        QjfpkBFnI1xPwXuuTTxYA2/CGyn8EbVcj2yEl1Lwxq8nEhmGPk0ay6nGX8HErrtxrEpa1LDX2giu
+        psD1k82U1VLYT8wBg/nSgbSetOcGUdId6BCG9W75K51xc9pgvfZFV5p6LrjNZA5I2+jIo/Sw19zs
+        AWkrXQ5DJwg349NW6tnEvOHTms1d0pZq8/eiyc0zPdLmO6cTN6DSiNlUIqYZrZAFKm21Bhj5rLd5
+        1LThji66STVio8ThlSXJTbjAMxGiLoWIwwDpjoQRmXgUIEBpG7WZbxaThqWIifpIFg2oGWcvATKW
+        LiE26KVLh92n9+cFEA8QcL/PvV6CWYoTAhnHc90Apv6ccpF4BCpN9Hm3kVRXUee+9KknTYhDxnRC
+        xWMFAa4tRyQkRjvJE2mWk03UeRJJM9ql1JMvXJn/l464Q/SuIa04yev1eprZxkmvcZY0pJk9Yh69
+        I7Y9v0Sa0UPwaMt15xGnp1nsNerNetKQpq7ZSRjV01wBFTb4q+RHtpyPmSauKz6OkBaPjhJQbdU0
+        RPKvqW2vWsdQlrwmgGwynqfUJfZcL5Did+vngDRj/MOMaI0impY5c8bA+VKONZZSQaedBJSRpqxz
+        kjBjlFfTALvdnOGNNJf9tkg0rd7mCDTS3B56Ic8crgdxBPMGkoKl2f1X6Libb02lJY5NBn7NPx6Q
+        TpkT3m/umbZA2x1yp23StDeU0iY484gJiC3GTVunPiHfYP63Ra+0ybrEdqW6HWy+NZbS1jwOyR1l
+        m/FpMx+Vkq99nuG3ssZBv725R9rOJ47JLLCJdE79qev4iQuX0lbuMy8I3W/fNqtbVpYC4q7Hv0GR
+        Gr/2Tjd3U5/ebkG7aUa47TJnT5l9UWE6H83plUL5Kb/39av/k8wPe6tN+V/2CqLhhb0ylk+f+V9B
+        HGVxXFlJKYryHqv/qAb5sieTzXYK+tdYPmVsi8R87OiWiBsG0xDblYrFPkvaXyt4QO+Dghtcwy2O
+        Fz9mUyN2122W+pGaf+W1fkyWUDKToIuodavNSJtnczEUn029yXYkzK+K/IAJGFVvuz/1qBZKT4vM
+        u6hLEvVzqIzEXFUKVUi+clWpKi/Iyckbm9zaL6TDcwPXdG2MkkXTdrvH5hTOQosfmTmZvoXJ0rcK
+        RMRzahI/kP7Bl1Z0ihsQkTRCiwf90QhQfL/3UviEBBaaiPhxy59ma9SndEBs30VVpTCVFU27dvPa
+        8Pxy46PLrA0+mO2OuJ6nLn+NpU0tFvLvto/ZmEvXgPEYz2zv4nC+a4cZsdJbNO3SJmta+AfHnfoM
+        e5jYWzTtqPCh44dTnlKjN19uqWOJt69XNblc4Pi7L/0E90Me0AWwkrthzrg4Yp4fDEZu6GBLm+UP
+        No84FpZZFHelP8X8Zk6M+CmC7Xg5JX96Wtbd/nbqFbO+YVmmp+sxV6zLzwnfAZP2+t3z/Ivue8nn
+        LD/w6x0O3WZBsKL6X2ZdMI8b/iMbzxPTCzLZWE9+Hcrvp0fsXkzc6mbAbqmYwfmhNyLm28zhAjIu
+        9pq/SWAtOnY9dFKw3PyKJ398hFtih1SrQasordSmdzPn1VUUXEXBahkDq2UUrKsYWFfxkUvoyCV8
+        ZAMd2cAVRMEaDtZRNnScDR1lQ8fZ0CqoGBV8ZBSs42AN5VnDeUb1y1BPQYVQcCFQsIaDUf/E3RND
+        okDUFrgpUIfA/UFFDaHihjB0dGAdJ0xDCdNwMVB2VZxdHQ0lHQ8lAx3ZwEc2UJkNXGYNFUPDxcDJ
+        wLlAWVYzWEbdQssIUXRkDR/ZQKPOwKMOHRgfV0W9U81IV/jAGSOjYaficaejFtEzTIJyoeJcoG6B
+        ewUafHjsqai8Ki6vjjKh40yoaMqE2vVHPz4N5GvxI0pxyXGDl00SrOqoOhqWqVxRR6ZsmEpNrpma
+        JptDo0YtapUMo4RMHrbs9opJhfihQqHxoFZJ54qVhvchQ60RpaLIhlXRQKuyJg+NkS5bqmZWdUoM
+        S6TydTK26vZ9ZFRLGk4Gb3gPMvglEGXj6lcqs6LCuwiumJpJKCnLVFGGsjEcEblKhmVZMYelSsko
+        myOzjCi2Zbfvs2K5nGFF3vAeZKijqmqUrRLoUuOBqisyMcq6bJrUKGvqqGaUsfjesttryRA/8Bkp
+        bj1AAzNXWUEQ70GPaVUpqYJieqkMeqpaWa4R/qOAtFLRVKIpqlFD6Nmy23emv1pG9qu9ERVX/Cdg
+        g+Q3Hz06AdLF6h5qHp+e/g88UKYkXVYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -842,12 +871,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:53:55 GMT
+      - Thu, 21 Nov 2019 15:40:20 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -857,9 +886,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 6d2558ce6d01a126d8b6ac7be0bbe259
+      - 9f1fdc6002e1f43d0afb37a2ce605997
     status:
       code: 200
       message: OK
@@ -875,76 +904,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPbGLB5mSVAJtkNhAMJ3TvdWY6wBWhjbMaWc+mQ/74l
-        2QYRbEI6l2Zm8kBkVUmu+upilXx5yBF37OVqDznv1sV+rpZDru3j238G9nXR8ye5Qs5FMwz9FAd0
-        GFjIHY7JHQ19zEjekCJ/gmmuNkZOgAu5sefY2B8SO1dzQ8cp5CzPpb7n5GrUD4EeBkCdY39GgoB4
-        bpCrqZpRyAXWFNuhg4dhyIbCyWZzB1Es45GFLFQqyVrJLMlVhCuyoY7L0FLLtqYZpmoZZknRLYT0
-        slFVkFrRQTBsEzpEjuPdYnspGxMedBzGCl32pYbjhbbUj/ph2NxziHUPtCMUEEvqYHrr+decAajB
-        FPl4qZg3+h+2KNdUVZVCjqJJDEaQsCDLgfaXh9yawsAbYx1x2SQAXe9jsaI+sb3Ckt7PmeA2HqPQ
-        obnHwpOZOZTx3OrTiTMNu9HPTqgtz8Yslnu8KuSmXkAtL3QpVyE2lKGb5lhTLNm0kS7rplGVDbCZ
-        XFZsZGLbNPVyiUFHEQ1BQpDXtYnLzsJdKT7HPMgxAGPw4pZWnIcj1ixS7KKRgwNshT6h90XLmwE/
-        cmgC+BCEXNl5bhEZJpfDueOhdfMPQRAfFFDLlVKpahgKwETJDFwbzebr3VMUXI+Wg+EIheBU1EfE
-        2fCoeFZmpUfgJQH1/Htu+bgduYliaKZSSmw0jHG2fIwoGHBog8Ovy+AgiLmZZ5MxsbJ4XmYIEfBU
-        o0Rx6HMbZyCcOAPzbWjehA5og0bEIZTguBNMNBd42KFDkGvh6HhMHIr9KDhiN2TcRVClkAM8bGbv
-        xHHrQYCpdNrMCdnkIdEEQ8c9HzTBd3D8RZFNJI+vHoxH+WB5oD/K+YfS4/JY1R4PCjuz5n8SpUrO
-        pKhaSS9XqjIaWbaMx4oqsw65UjVM1sV6IEZzHsQoAidg2ubw7yzw+O8MUWvKjqIGoDLxvXCeaC3C
-        es9jPSbMnXBC3CICXySjENJycZQK21E4AW/9fVfg/ss0vvo5guXq53SdO5fto1aPC3/nYHdCp+CM
-        xocoie8gnCGrj33gYGl5CMF3g4IUzRv1zqDel1rRCOk4GZGKg+17cxsCEogOBCuTn12q4JA7e+4q
-        U7tXKBOJPpwj6xpNcLYK3SXDToJHo6CjqcXKswng+NOUUDzsQoxBVPoQ9O+i1Z2Px7VGq3chNxpp
-        OgFFqts3JICMuLNbNupy5JFy4qBPe/I//T3NV4HtP/AnnzalA4JrEhxrilKSFSP/MWG5hCMLi4E4
-        13fHabry2KfS4FICEbCPIe9GGKgAgJrfl/j1/FTXP++19jp256lSd1s7ma+YmlcvWp8vPsYprRtc
-        9NFtmgaD3TT47wFwLiDV5OUD1TTNhaZ8UdQr7o75KCQf9AJcX3fjy3LgQQvCVS3LsJKpFOKjiqwq
-        cMn9KKSCYDhCAYaqJ8NTB/2+BKUChgoh4tg9fL9+LcYB/Euq/tVieUNNWDMB64T/voknMw1ZqeX5
-        yNmu5UXM9SpNUxXVi9oHK3oDdZvnZ0aBqO2As+54oYKR2t9atYPLRfe8sThenCw6zfxh76x2cH68
-        uFh8WlxGHQ1gaSwue4sGO+Zx8l0j8xmh06qdFKRW7XgD1jeOjedxfDl89UHt4GxRX3Tyh3XQ9mTR
-        XpxBM6wddBb9RTt/2GCt7qKRPzxdtupJa4nl66bJAhZm7RQk+K2/M7SlHfLOTamo/NGTT2nH7MN1
-        /eOnoNJLctC6zi+NpBqMPowyCs8nn+N0EmeTz1EygVyy6MFBHDcvG/SD009pVwy/CzqWQDqQQM4W
-        3SiFnC1O8ofdHuvlzUueN3r5wz7Dq8EzygmQOjyjxK160hIBfuOpf2iyikqcT600A3zadTkZh+Zz
-        Fc2n1tNqBsq5dynlVrtVQxsHlk/mbO8tTccptq6lDjt447X/G4i+BCtN8CWb1BPY9kKFTS+LN7yH
-        yIr2nzf1aUYch/92oRqU6hFfsD8142bxa2tD7DjES9OmxQn7XAMvpY/GPqvCe4TIu+5SoBtEHCZD
-        mm6xUnWBZ0/swvNxq3kk882kLMGbiCK2wHzbLae92huOe6bhKBuHE07cE8vFAse8QwzmyVjZtNY4
-        pRZw7qpGPDSQkI8l0cU7nhQLIJEALrO/h4Td6uSEa55TcfrQ98QC28PR/XCGnFuUWhq0Ejbp6F5q
-        L9n2y6CREi4OgjDtVsWaDp2E64eowG/AxbfzNwU9ASprHp52pbpt+yDqKxK6ampFtWIU1aJWUKus
-        XYQfedVUlIKqsH/FMiyZNb3ApcN3CNYtmN8A/rgt/NP6oJ6CCOt+YQaVv9Tl35D87Upez6hP+zMy
-        LD/jxhpYVeW6rKhl9SNva4AoR+mYHH04JkepmBx9JCYBJZNhgG8wez4hHZe21F/Rd0GH3JwOrn7O
-        0Hk1W6Ty6eCDrZ92U4t1f7j1L358RBB3SKeAAr5NS/GnrnQxxZDcb/eoIMm+qu7rhVRY3M0wRQHv
-        TJN/SdznAmqlQlYFJejxh6meeHJo94/TkkObWL4XeGMqHYWOgylxd8sT7f6T2/9POjIyQ7tvmrJp
-        msCuKHLVMD8QgfP+oJl2deT9f5qia84mGM7DkbP2cNqm2l3GKHVXjKwAzUgwQBgT7NgbQDzoj4dR
-        Q1s1UiFhD30cttuHzeaGydn0ssOyRtzCSXNCV61lJweMt167XbJ1F7HL+aXmGtM+bcWN0Yw4/BnG
-        TOGPOcvW/DqchQ4lqyy7PEsPqp8TRKUzz2J3d+KnPCW+ucoumfzZSUGqk658+XkrtyZwN/GIIHcr
-        e0lg73sO8qEG3savC/zH2PZ8tJW9LLA3fj2V0CgMcEKsCMRfwcSet3Wuqihq2G9tZTYE5vrpdshM
-        gfcTccFggVSTNpP20iCKOACPYFr/hj3SGZNFg/XbF11p7nvgNrMlg2ijYx/jo35zuweIVrochS4N
-        t/OLVuo7yLpmy5rtQ0RLtdlz0ej6mRGi+Xp45lEsjYmDJWRZUYXMuUSrNcDI5/3ts4qGO77oJt0p
-        NkocXlmT3IITPBMh6lqIuAQ4vTE3IuG3AjiTaKM2CaxiQliLmGiMZGOKrTh7cSZ97RR8g166dMmd
-        uD/PGdMDBNzvc7+f8KzFCYKM43sehaU/g5wnHs4lAt3rNpJuI9W5LwPsSzPkogmeYX5bgTOb6xEJ
-        idFJ8oSIcrKJukwiIqJdjH35wpPZf+mYOUR/CmnFTR6vL4nINk77jfOEICJ7THx8ixxneQoR0SPw
-        aNvzlhFXElHsN+rNekIQoWt2EkRLIlYAhQP+KgWRLZdzisB1+csR0urWUcJkPjUNkoIpdpyn1tGV
-        Na+hkE0my5S6hp7nUyl+tn7JICLGXsyIahROWsfMnQDmazlWX0sFnXYSULoIWec0QUavPE0D5GZ7
-        htdFLAdtnmha/e0RqIvYHvkhyxyeD3EE6wYksIno/it0ve2XpvIaxhYBv2YvD0hnxA3vto8ULdD2
-        Rsxpm1j0hrJognMfWcCxw7yideoz9A3WfzuMEk3WRY4n1R26/dJYFq15EqJbTLbzi2Y+Lidv+zyD
-        b3UDg0F7+wjRzqeuRWywidTDwdxzg8SFy6KVB8Snofft23Z1K6Klf7vYvhKoqI9vV8ZuWwfuWtwc
-        KIsvKizio5W8Uqg85g++fg1+ktnPwVNS/peDAie8cFRG0fSZ/RX4r8x/n9RPiqK8R80f9aS8z5OJ
-        Zltg/WsUTRmbITEee7oR4oV0HqbtRcVinyf07xWc4jta8OgULmys+TFbGbG77lLgR2r+lSv8GCyu
-        ZCZAFxF1py1Ih2VzPhVbQ73JJiSsqorsJ03AqHvXXakHtVB+XGXeVV+SqJ/jykjMhlIwIPnKhmIo
-        L8jJyXOazNovhMP3qGd5ThokK9Jue8bWHI5Cm/0SazZ/C5OJl4oUEXvYQgGV/sEKKjxPN2CKpBE3
-        v70fzQDN93sahS1IoLxMET+m/Gk2RAOMh8gJvFRVMSxgOWnfLl5b7lpuvWGZta0Ha9wx0/PMYw+v
-        tLFNQva29gmZMOkaMB9hme1dHC7wnDAjVvor0j5trYrC37vePCBptxD7K9KeCh+6QThnKTV63uUG
-        uzZ/5vqpJpcrPvbEyyDh+yG35SjUb9fEnRTHxA/ocOyFblpps/6a5jHjhTILp7vSn2J9swSGf4Bg
-        N1zO0J8elk23v5n7xaw3V9bh6frE43V5D7F9L+lg0O3lX3TdS15i+YHv7DDWXQqCJ6r/ZeqCZdyw
-        T2s8D0yfZqKxmfw6mF1Pj8kdX7jVLUpuMF/BBaE/RtbbrOEomhRL1bKhIvaNnQpSZF1DY9m0KyNZ
-        H6lGpWRqml0yU1Tbcdh33B/kXx66QU6IhyVVBQbe3iRsbnEFmMpT/omIuOV69GVgKHqpauioImuK
-        rYJWI0VGYxXLCsKVkoJVS7OsFDB2HPY6MMpGOhbQ/x5Q8DNAGOMJ+6BNhX9O5qneaTyvVLKsZWgJ
-        hHexuFq1q2ZZlbGu6bKOsSojQ8eyOsbKWDM1rNjjNIvvNux1YFTLlXQwGOH9bV41+Pm3Gz1mep2i
-        ulpKV5QR3kPRSgmXEUZYNitVyF6GNpINw0aybpXG+sgaVW1VT1F9x2GvA4N9zCwdDU55Gziu2Nfc
-        aPL5Jh/PYG5+yYaeh8fH/wNNwfpuKE4AAA==
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBevPxlFgFHdwQ5onTvdrucIimw1pAwefho8X/fW5UE
+        Atwg2mozM/4QK1VfVe797iNVlYTHHHNGbu7gMefeOdTLHeSIY3n07p++dVN0vXGukHPIhEJ9QP1g
+        4JvEGYzYfRB6lDe5g4B4YxrkDkbE9mkhN3Jti3oDZuUOnNC2CznTdQLPtXMHgRdCe+hD65R6E+b7
+        zHX83IGqVQs537ymVmjTQRjyrnCxydQmAZUNMiyrZDiUS6ZallWtRmSVapZMKkrVVKzSSFeN8qhS
+        LZXVSqlWVsrKqAKCUYsFA2Lb7h215rJx4UHHQazQZU9q2G5oSb2oHrpNXZuZD9B2SHxmSh0a3Lne
+        jQBAq39NPDpXzB3+j5qB0FRTa4VcQMYxGX4CIaYN5S+PuSWFlULCdYSymA+6PsRiRXXp8oLL4GHK
+        BbfoiIR2kHsqrIwsqIzHVlcHzjTsWr1QaX41brHc01Uhd+36gemGTiBUiA1VNiomqdSqskVVTTaq
+        VJOHI10Dc1V0XTN0VSkpnLqABCFICPI6FnP4VYQrxdeY+jlOYExeXNKK03DIi8WAOmRoU5+aoceC
+        h6LpTgBP7CAhfABCLuw8NZkMg8vh1HbJsvkHIIgHCqiliqGXlEqlAtdlE3BtMpkuV18T/2Y47wxn
+        JASnCjzC7DWPikflVnoCLPMD13sQlo/Lwk1UVSnrNTWx0SDm2fQoCcCAAwscflkGm0DMTVyLjZiZ
+        hXmZIdKEo0aJ4tATNs5gOHEG7ttQvA1t0IYMmc0CRuNKMNE0heGnNiOOSaPzEbMD6kXBEbshRxdB
+        lUIO+LC4vRPHrfs+DaSTZi6VTR4TTShUPIhOY3oP518UGXLE6Oqx+iTvzU+MJzn/qD/Nz1Xtaa+w
+        NTT/U1qq5EqKqulGqVyRydC0ZDpSVJlXyOVKtcareA3EaM6FGCXgBFzbHP2dB544TkhgXvOzqACs
+        jD03nCZap2l9ELEeN0ztcMycIgFfZMMQ0nJxiNJ2GI7BW3/flrj/co2vfo5oufoZ17lz2T5snQvh
+        723qjINrcMbqhyhJ7yGcIauPPEDwtDyA4LslPqJ5o97p13tSK+ohHSU9UB4sz51aEJDQaEOwcvn5
+        rQpOhbPnrjK1+w5lItEHU2LekDHNVqE7B2wleNQLKpparDwfAM4/XbOADroQYxCVHgT9u2h179HR
+        QaN1fiE3GphO0CLVrVvmQ0bc2i0bdTnySDlx0NWa/E9/x3wVYP+GP/mkKe0xeiDBuaYouqxU8x8T
+        lnM6srjop8d6dZziylMvkPqXEohAPQp5N+JABQLU/K7Er+uhrn923trp2J2iUndbW5mviObVi9bn
+        i49xSvOWFj1yh2nQ306D/+4BcgapJi/vqbVabaYpXxT1SrhjPgrJR6MA99ftcFkO3G9BuKoluVat
+        lAvxGawAFLjlfhRTvj8YEp/CqifDU/u9ngRLBQorhAixffh+/VqMA/gXVP9KsbSmJsyZADoWxzfx
+        ZK4hX2q5HrE3a3kRo75LU1RRo6h9sKK3sG5zvcwoSGvbF9Atb1TQU/tb62DvctY9a8yOZsezTjO/
+        f356sHd2NLuYfZpdRhUNgDRml+ezBj8XcfKqnvmM0GkdHBek1sHRGq1vHBvP8/hy+ur9g73TWX3W
+        ye/XQdvjWXt2CsXwYK8z683a+f0GL3Vnjfz+ybxUT0pzLr9vmCxiYdROQYJj/Z2p1bfIO7d6Ufmj
+        Jx99y+wjdP3jpyD9JTloWeeXRtIB9N6PMorIJ5/jdBJnk89RMoFcMjuHkzhuXtbpB6cffVsOX0Ud
+        TyAdSCCns26UQk5nx/n97jmvFcVLkTfO8/s9zldDZJRjaOqIjBKX6kkpTfAbD/1Dk1W0xPnUwgzw
+        advpZByaz61oPrVWVzOwnHuXpdxit2pgUd/02JTvvWE6XlPzRurwkzee+7+B6HOyMMHnMOk8BdsJ
+        Fda9LN7wHhAz2n9e16cZIfZ/c2A1KNUjnL87a8b1xa+lDahtMxfTpiUadnkNPJc+6vusCu8RIu+6
+        S0FuCbO5DJhusVL1FGZH7CLycat5KIvNpCzBmyQgfIL5tltOO7U3HNdch8NsHo5F445YLhY4xg4o
+        mCdjZtNaQkotQG6rRtzVl4hHpbSLd1wpFkBiPtxmfw8Zf9QpGm5ETqV41/fkglqD4cNgQuw7gi4N
+        WglMOnyQ2nPYbhk0UsKhvh9ijyqWdOgkqB+igngAFz/OXxf0GFp5cf+kK9UtywNRvyOhqzWtqJar
+        RbWoFdQKLxfhIC+KilJQFf6vWIIps2YUhHT0nsC8hYoHwB+3hX9S79cRRnj1CzOo/KUu/4fI367k
+        5Yy6Wp+RYcUV1+bAqirXZUUtqR/5WANEOcQ5OfxwTg5RTg4/khM/YOOBT28pfz8B56Ut9Rbt27DD
+        bk/6Vz9n6LwYLVL5pP/B1sceavHqD7f+xY+PCOYMgmtggd5hKf7EkS6uKST3ux1akGTfVXf1Rpqa
+        3E1oQHxRick/b9zlBdRChawVVEqPP8zqSSSHdu8ISw5tZnqu744C6TC0bRowZ7s80e6tPP5fqcjI
+        DO1erSbXajWAK4pcqdY+kIGzXr+J3R1F/Z9m0TXlAwym4dBeejltXe0uB0rdBZAvQDMSDDSMGLWt
+        NSIejaf9qKAtCigl/KWP/XZ7v9lcMzkfXrZ51ohLNCmOg0VpXikIE6Xv3S7ZuIvYFXipuQTapa24
+        EZkwW7zDmCn8kYBszK+DSWgHbJFl51c5h9XPMQmkU9fkT3fitzwlsbnKb5ni3cmUVMdd+fLzRrSW
+        QjfpkBFnI1xPwXuuTTxYA2/CGyn8EbVcj2yEl1Lwxq8nEhmGPk0ay6nGX8HErrtxrEpa1LDX2giu
+        psD1k82U1VLYT8wBg/nSgbSetOcGUdId6BCG9W75K51xc9pgvfZFV5p6LrjNZA5I2+jIo/Sw19zs
+        AWkrXQ5DJwg349NW6tnEvOHTms1d0pZq8/eiyc0zPdLmO6cTN6DSiNlUIqYZrZAFKm21Bhj5rLd5
+        1LThji66STVio8ThlSXJTbjAMxGiLoWIwwDpjoQRmXgUIEBpG7WZbxaThqWIifpIFg2oGWcvATKW
+        LiE26KVLh92n9+cFEA8QcL/PvV6CWYoTAhnHc90Apv6ccpF4BCpN9Hm3kVRXUee+9KknTYhDxnRC
+        xWMFAa4tRyQkRjvJE2mWk03UeRJJM9ql1JMvXJn/l464Q/SuIa04yev1eprZxkmvcZY0pJk9Yh69
+        I7Y9v0Sa0UPwaMt15xGnp1nsNerNetKQpq7ZSRjV01wBFTb4q+RHtpyPmSauKz6OkBaPjhJQbdU0
+        RPKvqW2vWsdQlrwmgGwynqfUJfZcL5Did+vngDRj/MOMaI0impY5c8bA+VKONZZSQaedBJSRpqxz
+        kjBjlFfTALvdnOGNNJf9tkg0rd7mCDTS3B56Ic8crgdxBPMGkoKl2f1X6Libb02lJY5NBn7NPx6Q
+        TpkT3m/umbZA2x1yp23StDeU0iY484gJiC3GTVunPiHfYP63Ra+0ybrEdqW6HWy+NZbS1jwOyR1l
+        m/FpMx+Vkq99nuG3ssZBv725R9rOJ47JLLCJdE79qev4iQuX0lbuMy8I3W/fNqtbVpYC4q7Hv0GR
+        Gr/2Tjd3U5/ebkG7aUa47TJnT5l9UWE6H83plUL5Kb/39av/k8wPe6tN+V/2CqLhhb0ylk+f+V9B
+        HGVxXFlJKYryHqv/qAb5sieTzXYK+tdYPmVsi8R87OiWiBsG0xDblYrFPkvaXyt4QO+Dghtcwy2O
+        Fz9mUyN2122W+pGaf+W1fkyWUDKToIuodavNSJtnczEUn029yXYkzK+K/IAJGFVvuz/1qBZKT4vM
+        u6hLEvVzqIzEXFUKVUi+clWpKi/Iyckbm9zaL6TDcwPXdG2MkkXTdrvH5hTOQosfmTmZvoXJ0rcK
+        RMRzahI/kP7Bl1Z0ihsQkTRCiwf90QhQfL/3UviEBBaaiPhxy59ma9SndEBs30VVpTCVFU27dvPa
+        8Pxy46PLrA0+mO2OuJ6nLn+NpU0tFvLvto/ZmEvXgPEYz2zv4nC+a4cZsdJbNO3SJmta+AfHnfoM
+        e5jYWzTtqPCh44dTnlKjN19uqWOJt69XNblc4Pi7L/0E90Me0AWwkrthzrg4Yp4fDEZu6GBLm+UP
+        No84FpZZFHelP8X8Zk6M+CmC7Xg5JX96Wtbd/nbqFbO+YVmmp+sxV6zLzwnfAZP2+t3z/Ivue8nn
+        LD/w6x0O3WZBsKL6X2ZdMI8b/iMbzxPTCzLZWE9+Hcrvp0fsXkzc6mbAbqmYwfmhNyLm28zhAjIu
+        9pq/SWAtOnY9dFKw3PyKJ398hFtih1SrQasordSmdzPn1VUUXEXBahkDq2UUrKsYWFfxkUvoyCV8
+        ZAMd2cAVRMEaDtZRNnScDR1lQ8fZ0CqoGBV8ZBSs42AN5VnDeUb1y1BPQYVQcCFQsIaDUf/E3RND
+        okDUFrgpUIfA/UFFDaHihjB0dGAdJ0xDCdNwMVB2VZxdHQ0lHQ8lAx3ZwEc2UJkNXGYNFUPDxcDJ
+        wLlAWVYzWEbdQssIUXRkDR/ZQKPOwKMOHRgfV0W9U81IV/jAGSOjYaficaejFtEzTIJyoeJcoG6B
+        ewUafHjsqai8Ki6vjjKh40yoaMqE2vVHPz4N5GvxI0pxyXGDl00SrOqoOhqWqVxRR6ZsmEpNrpma
+        JptDo0YtapUMo4RMHrbs9opJhfihQqHxoFZJ54qVhvchQ60RpaLIhlXRQKuyJg+NkS5bqmZWdUoM
+        S6TydTK26vZ9ZFRLGk4Gb3gPMvglEGXj6lcqs6LCuwiumJpJKCnLVFGGsjEcEblKhmVZMYelSsko
+        myOzjCi2Zbfvs2K5nGFF3vAeZKijqmqUrRLoUuOBqisyMcq6bJrUKGvqqGaUsfjesttryRA/8Bkp
+        bj1AAzNXWUEQ70GPaVUpqYJieqkMeqpaWa4R/qOAtFLRVKIpqlFD6Nmy23emv1pG9qu9ERVX/Cdg
+        g+Q3Hz06AdLF6h5qHp+e/g88UKYkXVYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -955,12 +989,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:54:05 GMT
+      - Thu, 21 Nov 2019 15:40:31 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -970,9 +1004,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - e0a8f23c0221b0c8ee4dd331e0885b8e
+      - 20ddae924e6b2e846765bb34829b9bdf
     status:
       code: 200
       message: OK
@@ -988,76 +1022,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPfAJuXWQJkkt1AOJDQvdOd5QhbEG2MzdgySTrkv29J
-        tkEEQ0jn0sxMHoisKslVX12ski8POeKN/Fz1IeffejjIVXPIcwJ8+8/QuSn6wThXyHlogqGf4pAO
-        Qht5gxG5o1GAGckfUBSMMc1VR8gNcSE38l0HBwPi5Kpe5LqFnO17NPDdXJUGEdCjEKhTHExIGBLf
-        C3NVVTMLudC+xk7k4kEUsaFwssnURRTLeGgjG+m6rOmWLlcQLsumOipBSy05mmZaqm1aumLYCBkl
-        s6IgtWyAYNghdIBc17/FzkI2JjzoOEgUuuxJddePHKkX98Owqe8S+x5oRygkttTG9NYPbjgDUMNr
-        FOCFYv7wf9imXFNVVQo5isYJGGHKgmwX2l8ecisKA2+CdczlkBB0vU/EivvE9hJLej9lgjt4hCKX
-        5h4LT2bmUCZzq08n3mjYtX52Qm1xNmax3ONVIXfth9T2I49yFRJDmYZljTTFli0HGbJhmRXZBJvJ
-        JcVBFnYsyyjpDDqKaAQS5oLI84jHzsJdKTnHNMwxABPwkpZWnEZD1ixS7KGhi0NsRwGh90XbnwA/
-        cmkK+ACEXNp5ahMZJpejqeujVfMPQJAAFFBLZV2vmKYCMFEyAddGk+myu6SDuii8GS4GwxGKwKlo
-        gIi75lHJrMxKj8BLQuoH99zySTt2E8XULEVPbTRIcLYDjCgYcOCAw6+K5iKIuYnvkBGxs3iYnC8z
-        hAh4plHiOAy4jTcgnDoD821oziIXtEFD4hJKcNIJJpoKPOzQJcizcXw8Ii7FQRwciRsy7iKoUsgB
-        Hg6zd+q4tTDEVDpt5IRs8pBqgqHjng8a4zs4/qLIFpJHVw/mo3ywODAe5fyD/rg4VrXHg8LOrPmf
-        RKnSMymqphulckVGQ9uR8UhRZdYhlyumxbpYD8RozocYReAETNsc/p0FHv+dIGpfs6O4AaiMAz+a
-        plqLsN7zWE8IUzcaE6+IwBfJMIK0XBxmwnYUjcFbf98VuP8yja9+jmG5+jlb5/Zl66jZ5cLfudgb
-        02twRvNDlMR3EM6Q1UcBcLC0PIDgm6EwQ/N6rd2v9aRmPEI6Tkdk4uAE/tSBgASiC8HK5GeXKjjk
-        zp672qjdK5SJRR9MkX2DxnizCp0Fw06Cx6Ogo6ElyrMJ4PjTNaF40IEYg6gMIOjfRau7AI+q9Wb3
-        Qq7Xs3QCilRzZiSEjLizW9ZrcuyRcuqgT3vyP/09y1eB7T/wJ582pAOCqxIca4qiy4qZ/5iwXMCx
-        CYu+ONd3x2m28jigUv9SAhFwgCHvxhioAICa35f49YNM1z/vNvc6dqeZUneaO5mvmJlXL5qfLz7G
-        Ke0ZLgboNkuD/m4a/PcAOOeQavLygWpZ1lxTvijqFXfHfBySD0YBrq+78W1y4H4TwlUtybCSKReS
-        o7KsKnDJ/SikwnAwRCGGqmeDp/Z7PQlKBQwVQsyxe/h+/VpMAviXTP0rxdKamrBmAtYx/30TT2Ya
-        slLLD5C7XcuLhOtVmmYqahS1D1Z0BnWbH2yMAlHbPmfd8UIFI7W/NasHl/POeX1+PD+Ztxv5w+5Z
-        9eD8eH4x/zS/jDvqwFKfX3bndXbM4+S7RuY3hE6zelKQmtXjNVjfODaex/Hl8NX61YOzeW3ezh/W
-        QNuTeWt+Bs2oetCe9+at/GGdtTrzev7wdNGqpa0Flq+bZhOwMGu7IMFv7Z2h1XfIOzO9qPzRk4++
-        Y/bhuv7xU5D+khy0qvNLI6kKow/jjMLzyecknSTZ5HOcTCCXzLtwkMTNywb94PSj74rhd0HHEkgb
-        EsjZvBOnkLP5Sf6w02W9vHnJ80Y3f9hjeNV5RjkBUptnlKRVS1siwG889Q9NVnGJ86mZZYBPuy4n
-        k9B8rqL51HxazUA59y6l3HK3auDg0A7IlO29Zel4je0bqc0O3njt/waiL8DKEnzBJnUFtr1QYd3L
-        kg3vAbLj/ed1fRoxx+G/PagGpVrMF+5Pzbhe/DraALsu8bO0aXLCPtfAC+njsc+q8B4h8q67FGiG
-        iMtkyNItUaom8OyJXXg+bjaOZL6ZtEnwBqKILTDfdstpr/aGk57raLgZhxNO3BPLJQInvAMM5tmw
-        smmucEpN4NxVjWRoKKEAS6KLt30pEUAiIVxmf48Iu9XJCTc8p+Lsoe+JBXYGw/vBBLm3KLM0aKZs
-        0tG91Fqw7ZdBYyU8HIZR1q2KFR3aKdcPUYHfgEtu568LegJU1jw87Ug1xwlA1FckdNXSimrZLKpF
-        raBWWLsIP/KyqSgFVWH/iiVYMmtGgUuH7xCsWzC/AfxxW/intX4tAxHW/cIMKn+pyb8h+duVvJpR
-        n/ZvyLD8jGtrYFWVa7KiltSPvK0BohxlY3L04ZgcZWJy9JGYhJSMByGeYfZ8QjYuLam3pO+CDpmd
-        9q9+3qDzcrZY5dP+B1s/66YW6/5w61/8+Igg3oBeAwr4NivFn3rSxTWG5H67RwXJ5qvqvl5IhcXd
-        BFMU8s4s+RfEfS6glipsqqAEPf4w1RNPDq3ecVZyaBE78EN/RKWjyHUxJd5ueaLVe3L7/0nHhszQ
-        6lmWbFkWsCuKXDGtD0TgvNdvZF0def+fpuiasgkG02jorjyctq52hzFKnSUjK0A3JBggjAh2nTUg
-        HozHw7ihLRuZkLCHPg5brcNGY83kbHrZZVkjaeG0OabL1qKTA8Zbr90u2bqL2OH8UmOFaZ+24kZo
-        Qlz+DONG4Y85y9b8OphELiXLLLs4SxeqnxNEpTPfZnd3kqc8Jb65yi6Z/NlJQaqTjnz5eSu3JnA3
-        8JAgbyu7LrD3fBcFUANv4zcE/mPs+AHayl4S2Ou/nkpoGIU4JZYF4q9gYt/fOldFFDXqNbcymwJz
-        7XQ7ZJbA+4l4YLBQqkrrSXthEEUcgIcwbTBjj3QmZNFgvdZFR5oGPrjNZMEg2ug4wPio19juAaKV
-        LoeRR6Pt/KKVei6yb9iyZvsQ0VIt9lw0unlmhGi+Lp74FEsj4mIJ2XZcIXMu0Wp1MPJ5b/usouGO
-        Lzppd4aNUodXViS34QTPRIi6EiIeAU5/xI1I+K0AziTaqEVCu5gSViImHiM5mGI7yV6cyVg5Bd+g
-        ly49cifuz3PG7AAB9/vc66U8K3GCIOMEvk9h6c8g54mHc4lAdzv1tNvMdO7LEAfSBHlojCeY31bg
-        zNZqREJidNM8IaKcbqIukoiIaAfjQL7wZfZfOmYO0buGtOKlj9frIrL10179PCWIyB6TAN8i112c
-        QkT0CDza8f1FxOkiir16rVFLCSJ0jXaKqC5iBVC44K9SGNtyMacIXIe/HCEtbx2lTNZT0yApvMau
-        +9Q6hrLiNRSyyXiRUlfQ8wMqJc/WLxhExNiLGXGNwkmrmHljwHwlxxorqaDdSgPKECFrn6bIGOWn
-        aYDMtmd4Q8Sy3+KJptnbHoGGiO1RELHM4QcQR7BuQAKbiO6/Is/ffmkqrWBsE/Br9vKAdEa86G77
-        SNECLX/InLaBRW8oiSY4D5ANHDvMK1qnNkHfYP23wyjRZB3k+lLNpdsvjSXRmicRusVkO79o5uNS
-        +rbPM/hW1jDot7aPEO186tnEAZtIXRxOfS9MXbgkWrlPAhr5375tV7csWvq3i+0rgbL6+HZl7LZ1
-        4K7FzYEy/6LCIj5eySuF8mP+4OvX8CeZ/Rw8JeV/OShwwgtHbSiaPrO/Av+V+e+T+klRlPeo+eOe
-        jPd5NqLZElj/GkXThs2QBI893QjxIzqNsvaiErHPU/r3Ck7xHS349BoubKz5MVsZibvuUuDHav6V
-        K/wELK7kRoAuYupOW5Auy+Z8KraGepNNSFhVFdlPloBx9667Ug9qofS4zLzLvjRRP8e1ITGbSsGE
-        5Cubiqm8ICenz2kya78QjsCnvu27WZAsSbvtGdtTOIoc9kvsyfQtTCZeKjJE7GIbhVT6Byuo8DTb
-        gBmSxtz89n48AzTf72kUtiCB8jJD/ITyp9kQDTEeIDf0M1XFsIDlpH27eG25a7n1huWmbT1Y446Y
-        nmc+e3ilhR0Ssbe1T8iYSVeH+QjLbO/icKHvRhtipbck7dPWqij8vedPQ5J1C7G3JO2p8JEXRlOW
-        UuPnXWbYc/gz1081uVzysSde+infD7ktR6F+uyHeuDgiQUgHIz/yskqb1dc0jxkvlFk425X+FOub
-        BTD8AwS74XKG/vSwrLv9bBoUN725sgpPJyA+r8u7iO17SQf9Tjf/oute+hLLD3xnh7HuUhA8Uf0v
-        Uxcs4oZ9WuN5YHp0Ixrrya+N2fX0mNzxhVvNpmSG+QoujIIRst9mDUfRuKhXSqaK2Dd2ykiRDQ2N
-        ZMspD2VjqJpl3dI0R7cyVNtx2HfcH+RfHpohN8IDXVWBgbfXCetbXCGm8jX/RETS8nz6MjAUQ6+Y
-        BirLmuKooNVQkdFIxbKCcFlXsGprtp0Bxo7DXgdGyczGAvrfAwp+BghjPGYftCnzz8k81TuL55VK
-        lrQNWgLhXSyuVpyKVVJlbGiGbGCsysg0sKyOsDLSLA0rzijL4rsNex0YlVI5GwxGeH+bV0x+/u1G
-        T5hep6ih6tmKMsJ7KFrWcQlhhGWrXIHsZWpD2TQdJBu2PjKG9rDiqEaG6jsOex0Y7GNm2WhwytvA
-        ccW+5kbTzzcFeAJz80s29Dw8Pv4fZAst5ShOAAA=
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBevPxlFgFHdwQ5onTvdrucIimw1pAwefho8X/fW5UE
+        Atwg2mozM/4QK1VfVe797iNVlYTHHHNGbu7gMefeOdTLHeSIY3n07p++dVN0vXGukHPIhEJ9QP1g
+        4JvEGYzYfRB6lDe5g4B4YxrkDkbE9mkhN3Jti3oDZuUOnNC2CznTdQLPtXMHgRdCe+hD65R6E+b7
+        zHX83IGqVQs537ymVmjTQRjyrnCxydQmAZUNMiyrZDiUS6ZallWtRmSVapZMKkrVVKzSSFeN8qhS
+        LZXVSqlWVsrKqAKCUYsFA2Lb7h215rJx4UHHQazQZU9q2G5oSb2oHrpNXZuZD9B2SHxmSh0a3Lne
+        jQBAq39NPDpXzB3+j5qB0FRTa4VcQMYxGX4CIaYN5S+PuSWFlULCdYSymA+6PsRiRXXp8oLL4GHK
+        BbfoiIR2kHsqrIwsqIzHVlcHzjTsWr1QaX41brHc01Uhd+36gemGTiBUiA1VNiomqdSqskVVTTaq
+        VJOHI10Dc1V0XTN0VSkpnLqABCFICPI6FnP4VYQrxdeY+jlOYExeXNKK03DIi8WAOmRoU5+aoceC
+        h6LpTgBP7CAhfABCLuw8NZkMg8vh1HbJsvkHIIgHCqiliqGXlEqlAtdlE3BtMpkuV18T/2Y47wxn
+        JASnCjzC7DWPikflVnoCLPMD13sQlo/Lwk1UVSnrNTWx0SDm2fQoCcCAAwscflkGm0DMTVyLjZiZ
+        hXmZIdKEo0aJ4tATNs5gOHEG7ttQvA1t0IYMmc0CRuNKMNE0heGnNiOOSaPzEbMD6kXBEbshRxdB
+        lUIO+LC4vRPHrfs+DaSTZi6VTR4TTShUPIhOY3oP518UGXLE6Oqx+iTvzU+MJzn/qD/Nz1Xtaa+w
+        NTT/U1qq5EqKqulGqVyRydC0ZDpSVJlXyOVKtcareA3EaM6FGCXgBFzbHP2dB544TkhgXvOzqACs
+        jD03nCZap2l9ELEeN0ztcMycIgFfZMMQ0nJxiNJ2GI7BW3/flrj/co2vfo5oufoZ17lz2T5snQvh
+        723qjINrcMbqhyhJ7yGcIauPPEDwtDyA4LslPqJ5o97p13tSK+ohHSU9UB4sz51aEJDQaEOwcvn5
+        rQpOhbPnrjK1+w5lItEHU2LekDHNVqE7B2wleNQLKpparDwfAM4/XbOADroQYxCVHgT9u2h179HR
+        QaN1fiE3GphO0CLVrVvmQ0bc2i0bdTnySDlx0NWa/E9/x3wVYP+GP/mkKe0xeiDBuaYouqxU8x8T
+        lnM6srjop8d6dZziylMvkPqXEohAPQp5N+JABQLU/K7Er+uhrn923trp2J2iUndbW5mviObVi9bn
+        i49xSvOWFj1yh2nQ306D/+4BcgapJi/vqbVabaYpXxT1SrhjPgrJR6MA99ftcFkO3G9BuKoluVat
+        lAvxGawAFLjlfhRTvj8YEp/CqifDU/u9ngRLBQorhAixffh+/VqMA/gXVP9KsbSmJsyZADoWxzfx
+        ZK4hX2q5HrE3a3kRo75LU1RRo6h9sKK3sG5zvcwoSGvbF9Atb1TQU/tb62DvctY9a8yOZsezTjO/
+        f356sHd2NLuYfZpdRhUNgDRml+ezBj8XcfKqnvmM0GkdHBek1sHRGq1vHBvP8/hy+ur9g73TWX3W
+        ye/XQdvjWXt2CsXwYK8z683a+f0GL3Vnjfz+ybxUT0pzLr9vmCxiYdROQYJj/Z2p1bfIO7d6Ufmj
+        Jx99y+wjdP3jpyD9JTloWeeXRtIB9N6PMorIJ5/jdBJnk89RMoFcMjuHkzhuXtbpB6cffVsOX0Ud
+        TyAdSCCns26UQk5nx/n97jmvFcVLkTfO8/s9zldDZJRjaOqIjBKX6kkpTfAbD/1Dk1W0xPnUwgzw
+        advpZByaz61oPrVWVzOwnHuXpdxit2pgUd/02JTvvWE6XlPzRurwkzee+7+B6HOyMMHnMOk8BdsJ
+        Fda9LN7wHhAz2n9e16cZIfZ/c2A1KNUjnL87a8b1xa+lDahtMxfTpiUadnkNPJc+6vusCu8RIu+6
+        S0FuCbO5DJhusVL1FGZH7CLycat5KIvNpCzBmyQgfIL5tltOO7U3HNdch8NsHo5F445YLhY4xg4o
+        mCdjZtNaQkotQG6rRtzVl4hHpbSLd1wpFkBiPtxmfw8Zf9QpGm5ETqV41/fkglqD4cNgQuw7gi4N
+        WglMOnyQ2nPYbhk0UsKhvh9ijyqWdOgkqB+igngAFz/OXxf0GFp5cf+kK9UtywNRvyOhqzWtqJar
+        RbWoFdQKLxfhIC+KilJQFf6vWIIps2YUhHT0nsC8hYoHwB+3hX9S79cRRnj1CzOo/KUu/4fI367k
+        5Yy6Wp+RYcUV1+bAqirXZUUtqR/5WANEOcQ5OfxwTg5RTg4/khM/YOOBT28pfz8B56Ut9Rbt27DD
+        bk/6Vz9n6LwYLVL5pP/B1sceavHqD7f+xY+PCOYMgmtggd5hKf7EkS6uKST3ux1akGTfVXf1Rpqa
+        3E1oQHxRick/b9zlBdRChawVVEqPP8zqSSSHdu8ISw5tZnqu744C6TC0bRowZ7s80e6tPP5fqcjI
+        DO1erSbXajWAK4pcqdY+kIGzXr+J3R1F/Z9m0TXlAwym4dBeejltXe0uB0rdBZAvQDMSDDSMGLWt
+        NSIejaf9qKAtCigl/KWP/XZ7v9lcMzkfXrZ51ohLNCmOg0VpXikIE6Xv3S7ZuIvYFXipuQTapa24
+        EZkwW7zDmCn8kYBszK+DSWgHbJFl51c5h9XPMQmkU9fkT3fitzwlsbnKb5ni3cmUVMdd+fLzRrSW
+        QjfpkBFnI1xPwXuuTTxYA2/CGyn8EbVcj2yEl1Lwxq8nEhmGPk0ay6nGX8HErrtxrEpa1LDX2giu
+        psD1k82U1VLYT8wBg/nSgbSetOcGUdId6BCG9W75K51xc9pgvfZFV5p6LrjNZA5I2+jIo/Sw19zs
+        AWkrXQ5DJwg349NW6tnEvOHTms1d0pZq8/eiyc0zPdLmO6cTN6DSiNlUIqYZrZAFKm21Bhj5rLd5
+        1LThji66STVio8ThlSXJTbjAMxGiLoWIwwDpjoQRmXgUIEBpG7WZbxaThqWIifpIFg2oGWcvATKW
+        LiE26KVLh92n9+cFEA8QcL/PvV6CWYoTAhnHc90Apv6ccpF4BCpN9Hm3kVRXUee+9KknTYhDxnRC
+        xWMFAa4tRyQkRjvJE2mWk03UeRJJM9ql1JMvXJn/l464Q/SuIa04yev1eprZxkmvcZY0pJk9Yh69
+        I7Y9v0Sa0UPwaMt15xGnp1nsNerNetKQpq7ZSRjV01wBFTb4q+RHtpyPmSauKz6OkBaPjhJQbdU0
+        RPKvqW2vWsdQlrwmgGwynqfUJfZcL5Did+vngDRj/MOMaI0impY5c8bA+VKONZZSQaedBJSRpqxz
+        kjBjlFfTALvdnOGNNJf9tkg0rd7mCDTS3B56Ic8crgdxBPMGkoKl2f1X6Libb02lJY5NBn7NPx6Q
+        TpkT3m/umbZA2x1yp23StDeU0iY484gJiC3GTVunPiHfYP63Ra+0ybrEdqW6HWy+NZbS1jwOyR1l
+        m/FpMx+Vkq99nuG3ssZBv725R9rOJ47JLLCJdE79qev4iQuX0lbuMy8I3W/fNqtbVpYC4q7Hv0GR
+        Gr/2Tjd3U5/ebkG7aUa47TJnT5l9UWE6H83plUL5Kb/39av/k8wPe6tN+V/2CqLhhb0ylk+f+V9B
+        HGVxXFlJKYryHqv/qAb5sieTzXYK+tdYPmVsi8R87OiWiBsG0xDblYrFPkvaXyt4QO+Dghtcwy2O
+        Fz9mUyN2122W+pGaf+W1fkyWUDKToIuodavNSJtnczEUn029yXYkzK+K/IAJGFVvuz/1qBZKT4vM
+        u6hLEvVzqIzEXFUKVUi+clWpKi/Iyckbm9zaL6TDcwPXdG2MkkXTdrvH5hTOQosfmTmZvoXJ0rcK
+        RMRzahI/kP7Bl1Z0ihsQkTRCiwf90QhQfL/3UviEBBaaiPhxy59ma9SndEBs30VVpTCVFU27dvPa
+        8Pxy46PLrA0+mO2OuJ6nLn+NpU0tFvLvto/ZmEvXgPEYz2zv4nC+a4cZsdJbNO3SJmta+AfHnfoM
+        e5jYWzTtqPCh44dTnlKjN19uqWOJt69XNblc4Pi7L/0E90Me0AWwkrthzrg4Yp4fDEZu6GBLm+UP
+        No84FpZZFHelP8X8Zk6M+CmC7Xg5JX96Wtbd/nbqFbO+YVmmp+sxV6zLzwnfAZP2+t3z/Ivue8nn
+        LD/w6x0O3WZBsKL6X2ZdMI8b/iMbzxPTCzLZWE9+Hcrvp0fsXkzc6mbAbqmYwfmhNyLm28zhAjIu
+        9pq/SWAtOnY9dFKw3PyKJ398hFtih1SrQasordSmdzPn1VUUXEXBahkDq2UUrKsYWFfxkUvoyCV8
+        ZAMd2cAVRMEaDtZRNnScDR1lQ8fZ0CqoGBV8ZBSs42AN5VnDeUb1y1BPQYVQcCFQsIaDUf/E3RND
+        okDUFrgpUIfA/UFFDaHihjB0dGAdJ0xDCdNwMVB2VZxdHQ0lHQ8lAx3ZwEc2UJkNXGYNFUPDxcDJ
+        wLlAWVYzWEbdQssIUXRkDR/ZQKPOwKMOHRgfV0W9U81IV/jAGSOjYaficaejFtEzTIJyoeJcoG6B
+        ewUafHjsqai8Ki6vjjKh40yoaMqE2vVHPz4N5GvxI0pxyXGDl00SrOqoOhqWqVxRR6ZsmEpNrpma
+        JptDo0YtapUMo4RMHrbs9opJhfihQqHxoFZJ54qVhvchQ60RpaLIhlXRQKuyJg+NkS5bqmZWdUoM
+        S6TydTK26vZ9ZFRLGk4Gb3gPMvglEGXj6lcqs6LCuwiumJpJKCnLVFGGsjEcEblKhmVZMYelSsko
+        myOzjCi2Zbfvs2K5nGFF3vAeZKijqmqUrRLoUuOBqisyMcq6bJrUKGvqqGaUsfjesttryRA/8Bkp
+        bj1AAzNXWUEQ70GPaVUpqYJieqkMeqpaWa4R/qOAtFLRVKIpqlFD6Nmy23emv1pG9qu9ERVX/Cdg
+        g+Q3Hz06AdLF6h5qHp+e/g88UKYkXVYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -1068,12 +1107,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:54:16 GMT
+      - Thu, 21 Nov 2019 15:40:41 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1083,9 +1122,245 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 022f547213687d0eff04567786f6192e
+      - 93dd5d1b548416e9f0a711770d46242a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/219
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBevPxlFgFHdwQ5onTvdrucIimw1pAwefho8X/fW5UE
+        Atwg2mozM/4QK1VfVe797iNVlYTHHHNGbu7gMefeOdTLHeSIY3n07p++dVN0vXGukHPIhEJ9QP1g
+        4JvEGYzYfRB6lDe5g4B4YxrkDkbE9mkhN3Jti3oDZuUOnNC2CznTdQLPtXMHgRdCe+hD65R6E+b7
+        zHX83IGqVQs537ymVmjTQRjyrnCxydQmAZUNMiyrZDiUS6ZallWtRmSVapZMKkrVVKzSSFeN8qhS
+        LZXVSqlWVsrKqAKCUYsFA2Lb7h215rJx4UHHQazQZU9q2G5oSb2oHrpNXZuZD9B2SHxmSh0a3Lne
+        jQBAq39NPDpXzB3+j5qB0FRTa4VcQMYxGX4CIaYN5S+PuSWFlULCdYSymA+6PsRiRXXp8oLL4GHK
+        BbfoiIR2kHsqrIwsqIzHVlcHzjTsWr1QaX41brHc01Uhd+36gemGTiBUiA1VNiomqdSqskVVTTaq
+        VJOHI10Dc1V0XTN0VSkpnLqABCFICPI6FnP4VYQrxdeY+jlOYExeXNKK03DIi8WAOmRoU5+aoceC
+        h6LpTgBP7CAhfABCLuw8NZkMg8vh1HbJsvkHIIgHCqiliqGXlEqlAtdlE3BtMpkuV18T/2Y47wxn
+        JASnCjzC7DWPikflVnoCLPMD13sQlo/Lwk1UVSnrNTWx0SDm2fQoCcCAAwscflkGm0DMTVyLjZiZ
+        hXmZIdKEo0aJ4tATNs5gOHEG7ttQvA1t0IYMmc0CRuNKMNE0heGnNiOOSaPzEbMD6kXBEbshRxdB
+        lUIO+LC4vRPHrfs+DaSTZi6VTR4TTShUPIhOY3oP518UGXLE6Oqx+iTvzU+MJzn/qD/Nz1Xtaa+w
+        NTT/U1qq5EqKqulGqVyRydC0ZDpSVJlXyOVKtcareA3EaM6FGCXgBFzbHP2dB544TkhgXvOzqACs
+        jD03nCZap2l9ELEeN0ztcMycIgFfZMMQ0nJxiNJ2GI7BW3/flrj/co2vfo5oufoZ17lz2T5snQvh
+        723qjINrcMbqhyhJ7yGcIauPPEDwtDyA4LslPqJ5o97p13tSK+ohHSU9UB4sz51aEJDQaEOwcvn5
+        rQpOhbPnrjK1+w5lItEHU2LekDHNVqE7B2wleNQLKpparDwfAM4/XbOADroQYxCVHgT9u2h179HR
+        QaN1fiE3GphO0CLVrVvmQ0bc2i0bdTnySDlx0NWa/E9/x3wVYP+GP/mkKe0xeiDBuaYouqxU8x8T
+        lnM6srjop8d6dZziylMvkPqXEohAPQp5N+JABQLU/K7Er+uhrn923trp2J2iUndbW5mviObVi9bn
+        i49xSvOWFj1yh2nQ306D/+4BcgapJi/vqbVabaYpXxT1SrhjPgrJR6MA99ftcFkO3G9BuKoluVat
+        lAvxGawAFLjlfhRTvj8YEp/CqifDU/u9ngRLBQorhAixffh+/VqMA/gXVP9KsbSmJsyZADoWxzfx
+        ZK4hX2q5HrE3a3kRo75LU1RRo6h9sKK3sG5zvcwoSGvbF9Atb1TQU/tb62DvctY9a8yOZsezTjO/
+        f356sHd2NLuYfZpdRhUNgDRml+ezBj8XcfKqnvmM0GkdHBek1sHRGq1vHBvP8/hy+ur9g73TWX3W
+        ye/XQdvjWXt2CsXwYK8z683a+f0GL3Vnjfz+ybxUT0pzLr9vmCxiYdROQYJj/Z2p1bfIO7d6Ufmj
+        Jx99y+wjdP3jpyD9JTloWeeXRtIB9N6PMorIJ5/jdBJnk89RMoFcMjuHkzhuXtbpB6cffVsOX0Ud
+        TyAdSCCns26UQk5nx/n97jmvFcVLkTfO8/s9zldDZJRjaOqIjBKX6kkpTfAbD/1Dk1W0xPnUwgzw
+        advpZByaz61oPrVWVzOwnHuXpdxit2pgUd/02JTvvWE6XlPzRurwkzee+7+B6HOyMMHnMOk8BdsJ
+        Fda9LN7wHhAz2n9e16cZIfZ/c2A1KNUjnL87a8b1xa+lDahtMxfTpiUadnkNPJc+6vusCu8RIu+6
+        S0FuCbO5DJhusVL1FGZH7CLycat5KIvNpCzBmyQgfIL5tltOO7U3HNdch8NsHo5F445YLhY4xg4o
+        mCdjZtNaQkotQG6rRtzVl4hHpbSLd1wpFkBiPtxmfw8Zf9QpGm5ETqV41/fkglqD4cNgQuw7gi4N
+        WglMOnyQ2nPYbhk0UsKhvh9ijyqWdOgkqB+igngAFz/OXxf0GFp5cf+kK9UtywNRvyOhqzWtqJar
+        RbWoFdQKLxfhIC+KilJQFf6vWIIps2YUhHT0nsC8hYoHwB+3hX9S79cRRnj1CzOo/KUu/4fI367k
+        5Yy6Wp+RYcUV1+bAqirXZUUtqR/5WANEOcQ5OfxwTg5RTg4/khM/YOOBT28pfz8B56Ut9Rbt27DD
+        bk/6Vz9n6LwYLVL5pP/B1sceavHqD7f+xY+PCOYMgmtggd5hKf7EkS6uKST3ux1akGTfVXf1Rpqa
+        3E1oQHxRick/b9zlBdRChawVVEqPP8zqSSSHdu8ISw5tZnqu744C6TC0bRowZ7s80e6tPP5fqcjI
+        DO1erSbXajWAK4pcqdY+kIGzXr+J3R1F/Z9m0TXlAwym4dBeejltXe0uB0rdBZAvQDMSDDSMGLWt
+        NSIejaf9qKAtCigl/KWP/XZ7v9lcMzkfXrZ51ohLNCmOg0VpXikIE6Xv3S7ZuIvYFXipuQTapa24
+        EZkwW7zDmCn8kYBszK+DSWgHbJFl51c5h9XPMQmkU9fkT3fitzwlsbnKb5ni3cmUVMdd+fLzRrSW
+        QjfpkBFnI1xPwXuuTTxYA2/CGyn8EbVcj2yEl1Lwxq8nEhmGPk0ay6nGX8HErrtxrEpa1LDX2giu
+        psD1k82U1VLYT8wBg/nSgbSetOcGUdId6BCG9W75K51xc9pgvfZFV5p6LrjNZA5I2+jIo/Sw19zs
+        AWkrXQ5DJwg349NW6tnEvOHTms1d0pZq8/eiyc0zPdLmO6cTN6DSiNlUIqYZrZAFKm21Bhj5rLd5
+        1LThji66STVio8ThlSXJTbjAMxGiLoWIwwDpjoQRmXgUIEBpG7WZbxaThqWIifpIFg2oGWcvATKW
+        LiE26KVLh92n9+cFEA8QcL/PvV6CWYoTAhnHc90Apv6ccpF4BCpN9Hm3kVRXUee+9KknTYhDxnRC
+        xWMFAa4tRyQkRjvJE2mWk03UeRJJM9ql1JMvXJn/l464Q/SuIa04yev1eprZxkmvcZY0pJk9Yh69
+        I7Y9v0Sa0UPwaMt15xGnp1nsNerNetKQpq7ZSRjV01wBFTb4q+RHtpyPmSauKz6OkBaPjhJQbdU0
+        RPKvqW2vWsdQlrwmgGwynqfUJfZcL5Did+vngDRj/MOMaI0impY5c8bA+VKONZZSQaedBJSRpqxz
+        kjBjlFfTALvdnOGNNJf9tkg0rd7mCDTS3B56Ic8crgdxBPMGkoKl2f1X6Libb02lJY5NBn7NPx6Q
+        TpkT3m/umbZA2x1yp23StDeU0iY484gJiC3GTVunPiHfYP63Ra+0ybrEdqW6HWy+NZbS1jwOyR1l
+        m/FpMx+Vkq99nuG3ssZBv725R9rOJ47JLLCJdE79qev4iQuX0lbuMy8I3W/fNqtbVpYC4q7Hv0GR
+        Gr/2Tjd3U5/ebkG7aUa47TJnT5l9UWE6H83plUL5Kb/39av/k8wPe6tN+V/2CqLhhb0ylk+f+V9B
+        HGVxXFlJKYryHqv/qAb5sieTzXYK+tdYPmVsi8R87OiWiBsG0xDblYrFPkvaXyt4QO+Dghtcwy2O
+        Fz9mUyN2122W+pGaf+W1fkyWUDKToIuodavNSJtnczEUn029yXYkzK+K/IAJGFVvuz/1qBZKT4vM
+        u6hLEvVzqIzEXFUKVUi+clWpKi/Iyckbm9zaL6TDcwPXdG2MkkXTdrvH5hTOQosfmTmZvoXJ0rcK
+        RMRzahI/kP7Bl1Z0ihsQkTRCiwf90QhQfL/3UviEBBaaiPhxy59ma9SndEBs30VVpTCVFU27dvPa
+        8Pxy46PLrA0+mO2OuJ6nLn+NpU0tFvLvto/ZmEvXgPEYz2zv4nC+a4cZsdJbNO3SJmta+AfHnfoM
+        e5jYWzTtqPCh44dTnlKjN19uqWOJt69XNblc4Pi7L/0E90Me0AWwkrthzrg4Yp4fDEZu6GBLm+UP
+        No84FpZZFHelP8X8Zk6M+CmC7Xg5JX96Wtbd/nbqFbO+YVmmp+sxV6zLzwnfAZP2+t3z/Ivue8nn
+        LD/w6x0O3WZBsKL6X2ZdMI8b/iMbzxPTCzLZWE9+Hcrvp0fsXkzc6mbAbqmYwfmhNyLm28zhAjIu
+        9pq/SWAtOnY9dFKw3PyKJ398hFtih1SrQasordSmdzPn1VUUXEXBahkDq2UUrKsYWFfxkUvoyCV8
+        ZAMd2cAVRMEaDtZRNnScDR1lQ8fZ0CqoGBV8ZBSs42AN5VnDeUb1y1BPQYVQcCFQsIaDUf/E3RND
+        okDUFrgpUIfA/UFFDaHihjB0dGAdJ0xDCdNwMVB2VZxdHQ0lHQ8lAx3ZwEc2UJkNXGYNFUPDxcDJ
+        wLlAWVYzWEbdQssIUXRkDR/ZQKPOwKMOHRgfV0W9U81IV/jAGSOjYaficaejFtEzTIJyoeJcoG6B
+        ewUafHjsqai8Ki6vjjKh40yoaMqE2vVHPz4N5GvxI0pxyXGDl00SrOqoOhqWqVxRR6ZsmEpNrpma
+        JptDo0YtapUMo4RMHrbs9opJhfihQqHxoFZJ54qVhvchQ60RpaLIhlXRQKuyJg+NkS5bqmZWdUoM
+        S6TydTK26vZ9ZFRLGk4Gb3gPMvglEGXj6lcqs6LCuwiumJpJKCnLVFGGsjEcEblKhmVZMYelSsko
+        myOzjCi2Zbfvs2K5nGFF3vAeZKijqmqUrRLoUuOBqisyMcq6bJrUKGvqqGaUsfjesttryRA/8Bkp
+        bj1AAzNXWUEQ70GPaVUpqYJieqkMeqpaWa4R/qOAtFLRVKIpqlFD6Nmy23emv1pG9qu9ERVX/Cdg
+        g+Q3Hz06AdLF6h5qHp+e/g88UKYkXVYAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:40:52 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-c-ca-central-1-prod
+      X-Request-Uuid:
+      - 014be2fbd890057a5c351862df5a0e46
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/219
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBevPxlFgFHdwQ5onTvdrucIimw1pAwefho8X/fW5UE
+        Atwg2mozM/4QK1VfVe797iNVlYTHHHNGbu7gMefeOdTLHeSIY3n07p++dVN0vXGukHPIhEJ9QP1g
+        4JvEGYzYfRB6lDe5g4B4YxrkDkbE9mkhN3Jti3oDZuUOnNC2CznTdQLPtXMHgRdCe+hD65R6E+b7
+        zHX83IGqVQs537ymVmjTQRjyrnCxydQmAZUNMiyrZDiUS6ZallWtRmSVapZMKkrVVKzSSFeN8qhS
+        LZXVSqlWVsrKqAKCUYsFA2Lb7h215rJx4UHHQazQZU9q2G5oSb2oHrpNXZuZD9B2SHxmSh0a3Lne
+        jQBAq39NPDpXzB3+j5qB0FRTa4VcQMYxGX4CIaYN5S+PuSWFlULCdYSymA+6PsRiRXXp8oLL4GHK
+        BbfoiIR2kHsqrIwsqIzHVlcHzjTsWr1QaX41brHc01Uhd+36gemGTiBUiA1VNiomqdSqskVVTTaq
+        VJOHI10Dc1V0XTN0VSkpnLqABCFImPNCx2EOv4pwpfgaUz/HCYzJi0tacRoOebEYUIcMbepTM/RY
+        8FA03QngiR0khA9AyIWdpyaTYXA5nNouWTb/AATxQAG1VDH0klKpVOC6bAKuTSbTeTV4E6hL/Jvh
+        vDOckRCcKvAIs9c8Kh6VW+kJsMwPXO9BWD4uCzdRVaWs19TERoOYZ9OjJAADDixw+GXRbAIxN3Et
+        NmImghFyvswQacJRo0Rx6AkbZzCcOAP3bSjehjZoQ4bMZgGjcSWYaJrC8FObEcek0fmI2QH1ouCI
+        3ZCji6BKIQd8WNzeiePWfZ8G0kkzl8omj4kmFCoeRKcxvYfzL4oMOWJ09Vh9kvfmJ8aTnH/Un+bn
+        qva0V9gamv8pLVVyJUXVdKNUrshkaFoyHSmqzCvkcqVa41W8BmI050KMEnACrm2O/s4DTxwnJDCv
+        +VlUAFbGnhtOE63TtD6IWI8bpnY4Zk6RgC+yYQhpuThEaTsMx+Ctv29L3H+5xlc/R7Rc/Yzr3Lls
+        H7bOhfD3NnXGwTU4Y/VDlKT3EM6Q1UceIHhaHkDw3RIf0bxR7/TrPakV9ZCOkh4oD5bnTi0ISGi0
+        IVi5/PxWBafC2XNXmdp9hzKR6IMpMW/ImGar0J0DthI86gUVTS1Wng8A55+uWUAHXYgxiEoPgv5d
+        tLr36Oig0Tq/kBsNTCdokerWLfMhI27tlo26HHmknDjoak3+p79jvgqwf8OffNKU9hg9kOBcUxRd
+        Vqr5jwnLOR1ZXPTTY706TnHlqRdI/UsJRKAehbwbcaACAWp+V+LX9VDXPztv7XTsTlGpu62tzFdE
+        8+pF6/PFxzileUuLHrnDNOhvp8F/9wA5g1STl/fUWq0205Qvinol3DEfheSjUYD763a4LAfutyBc
+        1ZJcq1bKhfgMVgAK3HI/iinfHwyJT2HVk+Gp/V5PgqUChRVChNg+fL9+LcYB/Auqf6VYWlMT5kwA
+        HYvjm3gy15AvtVyP2Ju1vIhR36UpqqhR1D5Y0VtYt7leZhSkte0L6JY3Kuip/a11sHc56541Zkez
+        41mnmd8/Pz3YOzuaXcw+zS6jigZAGrPL81mDn4s4eVXPfEbotA6OC1Lr4GiN1jeOjed5fDl99f7B
+        3umsPuvk9+ug7fGsPTuFYniw15n1Zu38foOXurNGfv9kXqonpTmX3zdMFrEwaqcgwbH+ztTqW+Sd
+        W72o/NGTj75l9hG6/vFTkP6SHLSs80sj6QB670cZReSTz3E6ibPJ5yiZQC6ZncNJHDcv6/SD04++
+        LYevoo4nkA4kkNNZN0ohp7Pj/H73nNeK4qXIG+f5/R7nqyEyyjE0dURGiUv1pJQm+I2H/qHJKlri
+        fGphBvi07XQyDs3nVjSfWqurGVjOvctSbrFbNbCob3psyvfeMB2vqXkjdfjJG8/930D0OVmY4HOY
+        dJ6C7YQK614Wb3gPiBntP6/r04wQ+785sBqU6hHO35014/ri19IG1LaZi2nTEg27vAaeSx/1fVaF
+        9wiRd92lILeE2VwGTLdYqXoKsyN2Efm41TyUxWZSluBNEhA+wXzbLaed2huOa67DYTYPx6JxRywX
+        CxxjBxTMkzGzaS0hpRYgt1Uj7upLxKNS2sU7rhQLIDEfbrO/h4w/6hQNNyKnUrzre3JBrcHwYTAh
+        9h1BlwatBCYdPkjtOWy3DBop4VDfD7FHFUs6dBLUD1FBPICLH+evC3oMrby4f9KV6pblgajfkdDV
+        mlZUy9WiWtQKaoWXi3CQF0VFKagK/1cswZRZMwpCOnpPYN5CxQPgj9vCP6n36wgjvPqFGVT+Upf/
+        Q+RvV/JyRl2tz8iw4oprc2BVleuyopbUj3ysAaIc4pwcfjgnhygnhx/JiR+w8cCnt5S/n4Dz0pZ6
+        i/Zt2GG3J/2rnzN0XowWqXzS/2DrYw+1ePWHW//ix0cEcwbBNbBA77AUf+JIF9cUkvvdDi1Isu+q
+        u3ojTU3uJjQgvqjE5J837vICaqFC1goqpccfZvUkkkO7d4QlhzYzPdd3R4F0GNo2DZizXZ5o91Ye
+        /69UZGSGdq9Wk2u1GsAVRa5Uax/IwFmv38TujqL+T7PomvIBBtNwaC+9nLaudpcDpe4CyBegGQkG
+        GkaM2tYaEY/G035U0BYFlBL+0sd+u73fbK6ZnA8v2zxrxCWaFMfBojSvFISJ0vdul2zcRewKvNRc
+        Au3SVtyITJgt3mHMFP5IQDbm18EktAO2yLLzq5zD6ueYBNKpa/KnO/FbnpLYXOW3TPHuZEqq4658
+        +XkjWkuhm3TIiLMRrqfgPdcmHqyBN+GNFP6IWq5HNsJLKXjj1xOJDEOfJo3lVOOvYGLX3ThWJS1q
+        2GttBFdT4PrJZspqKewn5oDBfOlAWk/ac4Mo6Q50CMN6t/yVzrg5bbBe+6IrTT0X3GYyB6RtdORR
+        ethrbvaAtJUuh6EThJvxaSv1bGLe8GnN5i5pS7X5e9Hk5pkeafOd04kbUGnEbCoR04xWyAKVtloD
+        jHzW2zxq2nBHF92kGrFR4vDKkuQmXOCZCFGXQsRhgHRHwohMPAoQoLSN2sw3i0nDUsREfSSLBtSM
+        s5cAGUuXEBv00qXD7tP78wKIBwi43+deL8EsxQmBjOO5bgBTf065SDwClSb6vNtIqquoc1/61JMm
+        xCFjOqHisYIA15YjEhKjneSJNMvJJuo8iaQZ7VLqyReuzP9LR9wheteQVpzk9Xo9zWzjpNc4SxrS
+        zB4xj94R255fIs3oIXi05brziNPTLPYa9WY9aUhT1+wkjOpproAKG/xV8iNbzsdME9cVH0dIi0dH
+        Cai2ahoi+dfUtletYyhLXhNANhnPU+oSe64XSPG79XNAmjH+YUa0RhFNy5w5Y+B8KccaS6mg004C
+        ykhT1jlJmDHKq2mA3W7O8Eaay35bJJpWb3MEGmluD72QZw7XgziCeQNJwdLs/it03M23ptISxyYD
+        v+YfD0inzAnvN/dMW6DtDrnTNmnaG0ppE5x5xATEFuOmrVOfkG8w/9uiV9pkXWK7Ut0ONt8aS2lr
+        HofkjrLN+LSZj0rJ1z7P8FtZ46Df3twjbecTx2QW2EQ6p/7UdfzEhUtpK/eZF4Tut2+b1S0rSwFx
+        1+PfoEiNX3unm7upT2+3oN00I9x2mbOnzL6oMJ2P5vRKofyU3/v61f9J5oe91ab8L3sF0fDCXhnL
+        p8/8ryCOsjiurKQURXmP1X9Ug3zZk8lmOwX9ayyfMrZFYj52dEvEDYNpiO1KxWKfJe2vFTyg90HB
+        Da7hFseLH7OpEbvrNkv9SM2/8lo/JksomUnQRdS61WakzbO5GIrPpt5kOxLmV0V+wASMqrfdn3pU
+        C6WnReZd1CWJ+jlURmKuKoUqJF+5qlSVF+Tk5I1Nbu0X0uG5gWu6NkbJomm73WNzCmehxY/MnEzf
+        wmTpWwUi4jk1iR9I/+BLKzrFDYhIGqHFg/5oBCi+33spfEICC01E/LjlT7M16lM6ILbvoqpSmMqK
+        pl27eW14frnx0WXWBh/Mdkdcz1OXv8bSphYL+Xfbx2zMpWvAeIxntndxON+1w4xY6S2admmTNS38
+        g+NOfYY9TOwtmnZU+NDxwylPqdGbL7fUscTb16uaXC5w/N2XfoL7IQ/oAljJ3TBnXBwxzw8GIzd0
+        sKXN8gebRxwLyyyKu9KfYn4zJ0b8FMF2vJySPz0t625/O/WKWd+wLNPT9Zgr1uXnhO+ASXv97nn+
+        Rfe95HOWH/j1DodusyBYUf0vsy6Yxw3/kY3niekFmWysJ78O5ffTI3YvJm51M2C3VMzg/NAbEfNt
+        5nABGRd7zd8ksBYdux46KVhufsWTPz7CLbFDqtWgVZRWatO7mfPqKgquomC1jIHVMgrWVQysq/jI
+        JXTkEj6ygY5s4AqiYA0H6ygbOs6GjrKh42xoFVSMCj4yCtZxsIbyrOE8o/plqKegQii4EChYw8Go
+        f+LuiSFRIGoL3BSoQ+D+oKKGUHFDGDo6sI4TpqGEabgYKLsqzq6OhpKOh5KBjmzgIxuozAYus4aK
+        oeFi4GTgXKAsqxkso26hZYQoOrKGj2ygUWfgUYcOjI+rot6pZqQrfOCMkdGwU/G401GL6BkmQblQ
+        cS5Qt8C9Ag0+PPZUVF4Vl1dHmdBxJlQ0ZULt+qMfnwbytfgRpbjkuMHLJglWdVQdDctUrqgjUzZM
+        pSbXTE2TzaFRoxa1SoZRQiYPW3Z7xaRC/FCh0HhQq6RzxUrD+5Ch1ohSUWTDqmigVVmTh8ZIly1V
+        M6s6JYYlUvk6GVt1+z4yqiUNJ4M3vAcZ/BKIsnH1K5VZUeFdBFdMzSSUlGWqKEPZGI6IXCXDsqyY
+        w1KlZJTNkVlGFNuy2/dZsVzOsCJveA8y1FFVNcpWCXSp8UDVFZkYZV02TWqUNXVUM8pYfG/Z7bVk
+        iB/4jBS3HqCBmausIIj3oMe0qpRUQTG9VAY9Va0s1wj/UUBaqWgq0RTVqCH0bNntO9NfLSP71d6I
+        iiv+E7BB8puPHp0A6WJ1DzWPT0//B6KkRTBdVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:41:02 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-c-ca-central-1-prod
+      X-Request-Uuid:
+      - 2854953f42a48d4b7305910f6773b828
     status:
       code: 200
       message: OK
@@ -1105,11 +1380,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/110/pause
+    uri: https://cloud.tenable.com/scans/219/pause
   response:
     body:
       string: ''
@@ -1121,7 +1396,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Wed, 17 Jul 2019 15:54:16 GMT
+      - Thu, 21 Nov 2019 15:41:03 GMT
       Expires:
       - '0'
       Pragma:
@@ -1129,8 +1404,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -1138,9 +1413,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 8edfff7d61bd9b69c43b51778d451ee0
+      - 09f1b4902ca8aeb1782f2b3f32d606e4
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1158,76 +1433,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPfAJuXWQJkkt1AOJDQvdOd5QhbEG2MzdgySTrkv29J
-        tkEEQ0jn0sxMHoisKslVX12ski8POeKN/Fz1IeffejjIVXPIcwJ8+8/QuSn6wThXyHlogqGf4pAO
-        Qht5gxG5o1GAGckfUBSMMc1VR8gNcSE38l0HBwPi5Kpe5LqFnO17NPDdXJUGEdCjEKhTHExIGBLf
-        C3NVVTMLudC+xk7k4kEUsaFwssnURRTLeGgjG+m6rOmWLlcQLsumOipBSy05mmZaqm1aumLYCBkl
-        s6IgtWyAYNghdIBc17/FzkI2JjzoOEgUuuxJddePHKkX98Owqe8S+x5oRygkttTG9NYPbjgDUMNr
-        FOCFYv7wf9imXFNVVQo5isYJGGHKgmwX2l8ecisKA2+CdczlkBB0vU/EivvE9hJLej9lgjt4hCKX
-        5h4LT2bmUCZzq08n3mjYtX52Qm1xNmax3ONVIXfth9T2I49yFRJDmYZljTTFli0HGbJhmRXZBJvJ
-        JcVBFnYsyyjpDDqKaAQS5qYoConHzsJdKTnHNMwxABPwkpZWnEZD1ixS7KGhi0NsRwGh90XbnwA/
-        cmkK+ACEXNp5ahMZJpejqeujVfMPQJAAFFBLZV2vmKYCMFEyAddGk+myu1QGdVF4M1wMhiMUgVPR
-        ABF3zaOSWZmVHoGXhNQP7rnlk3bsJoqpWYqe2miQ4GwHGFEw4MABh18VzUUQcxPfISNiZ/EwOV9m
-        CBHwTKPEcRhwG29AOHUG5tvQnEUuaIOGxCWU4KQTTDQVeNihS5Bn4/h4RFyKgzg4Ejdk3EVQpZAD
-        PBxm79Rxa2GIqXTayAnZ5CHVBEPHPR80xndw/EWRLSSPrh7MR/lgcWA8yvkH/XFxrGqPB4WdWfM/
-        iVKlZ1JUTTdK5YqMhrYj45GiyqxDLldMi3WxHojRnA8xisAJmLY5/DsLPP47QdS+ZkdxA1AZB340
-        TbUWYb3nsZ4Qpm40Jl4RgS+SYQRpuTjMhO0oGoO3/r4rcP9lGl/9HMNy9XO2zu3L1lGzy4W/c7E3
-        ptfgjOaHKInvIJwhq48C4GBpeQDBN0Nhhub1Wrtf60nNeIR0nI7IxMEJ/KkDAQlEF4KVyc8uVXDI
-        nT13tVG7VygTiz6YIvsGjfFmFToLhp0Ej0dBR0NLlGcTwPGna0LxoAMxBlEZQNC/i1Z3AR5V683u
-        hVyvZ+kEFKnmzEgIGXFnt6zX5Ngj5dRBn/bkf/p7lq8C23/gTz5tSAcEVyU41hRFlxUz/zFhuYBj
-        ExZ9ca7vjtNs5XFApf6lBCLgAEPejTFQAQA1vy/x6weZrn/ebe517E4zpe40dzJfMTOvXjQ/X3yM
-        U9ozXAzQbZYG/d00+O8BcM4h1eTlA9WyrLmmfFHUK+6O+TgkH4wCXF9349vkwP0mhKtakmElUy4k
-        R2VZVeCS+1FIheFgiEIMVc8GT+33ehKUChgqhJhj9/D9+rWYBPAvmfpXiqU1NWHNBKxj/vsmnsw0
-        ZKWWHyB3u5YXCderNM1U1ChqH6zoDOo2P9gYBaK2fc6644UKRmp/a1YPLued8/r8eH4ybzfyh92z
-        6sH58fxi/ml+GXfUgaU+v+zO6+yYx8l3jcxvCJ1m9aQgNavHa7C+cWw8j+PL4av1qwdn89q8nT+s
-        gbYn89b8DJpR9aA9781b+cM6a3Xm9fzh6aJVS1sLLF83zSZgYdZ2QYLf2jtDq++Qd2Z6UfmjJx99
-        x+zDdf3jpyD9JTloVeeXRlIVRh/GGYXnk89JOkmyyec4mUAumXfhIImblw36welH3xXD74KOJZA2
-        JJCzeSdOIWfzk/xhp8t6efOS541u/rDH8KrzjHICpDbPKEmrlrZEgN946h+arOIS51MzywCfdl1O
-        JqH5XEXzqfm0moFy7l1KueVu1cDBoR2QKdt7y9LxGts3UpsdvPHa/w1EX4CVJfiCTeoKbHuhwrqX
-        JRveA2TH+8/r+jRijsN/e1ANSrWYL9yfmnG9+HW0AXZd4mdp0+SEfa6BF9LHY59V4T1C5F13KdAM
-        EZfJkKVbolRN4NkTu/B83GwcyXwzaZPgDUQRW2C+7ZbTXu0NJz3X0XAzDiecuCeWSwROeAcYzLNh
-        ZdNc4ZSawLmrGsnQUEIBlkQXb/tSIoBEQrjM/h4RdquTE254TsXZQ98TC+wMhveDCXJvUWZp0EzZ
-        pKN7qbVg2y+Dxkp4OAyjrFsVKzq0U64fogK/AZfczl8X9ASorHl42pFqjhOAqK9I6KqlFdWyWVSL
-        WkGtsHYRfuRlU1EKqsL+FUuwZNaMApcO3yFYt2B+A/jjtvBPa/1aBiKs+4UZVP5Sk39D8rcreTWj
-        Pu3fkGH5GdfWwKoq12RFLakfeVsDRDnKxuTowzE5ysTk6CMxCSkZD0I8w+z5hGxcWlJvSd8FHTI7
-        7V/9vEHn5Wyxyqf9D7Z+1k0t1v3h1r/48RFBvAG9BhTwbVaKP/Wki2sMyf12jwqSzVfVfb2QCou7
-        CaYo5J1Z8i+I+1xALVXYVEEJevxhqieeHFq946zk0CJ24If+iEpHketiSrzd8kSr9+T2/5OODZmh
-        1bMs2bIsYFcUuWJaH4jAea/fyLo68v4/TdE1ZRMMptHQXXk4bV3tDmOUOktGVoBuSDBAGBHsOmtA
-        PBiPh3FDWzYyIWEPfRy2WoeNxprJ2fSyy7JG0sJpc0yXrUUnB4y3XrtdsnUXscP5pcYK0z5txY3Q
-        hLj8GcaNwh9zlq35dTCJXEqWWXZxli5UPyeISme+ze7uJE95SnxzlV0y+bOTglQnHfny81ZuTeBu
-        4CFB3lZ2XWDv+S4KoAbexm8I/MfY8QO0lb0ksNd/PZXQMApxSiwLxF/BxL6/da6KKGrUa25lNgXm
-        2ul2yCyB9xPxwGChVJXWk/bCIIo4AA9h2mDGHulMyKLBeq2LjjQNfHCbyYJBtNFxgPFRr7HdA0Qr
-        XQ4jj0bb+UUr9Vxk37BlzfYhoqVa7LlodPPMCNF8XTzxKZZGxMUSsu24QuZcotXqYOTz3vZZRcMd
-        X3TS7gwbpQ6vrEhuwwmeiRB1JUQ8Apz+iBuR8FsBnEm0UYuEdjElrERMPEZyMMV2kr04k7FyCr5B
-        L1165E7cn+eM2QEC7ve510t5VuIEQcYJfJ/C0p9BzhMP5xKB7nbqabeZ6dyXIQ6kCfLQGE8wv63A
-        ma3ViITE6KZ5QkQ53URdJBER0Q7GgXzhy+y/dMwconcNacVLH6/XRWTrp736eUoQkT0mAb5Frrs4
-        hYjoEXi04/uLiNNFFHv1WqOWEkToGu0UUV3ECqBwwV+lMLblYk4RuA5/OUJa3jpKmaynpkFSeI1d
-        96l1DGXFayhkk/Eipa6g5wdUSp6tXzCIiLEXM+IahZNWMfPGgPlKjjVWUkG7lQaUIULWPk2RMcpP
-        0wCZbc/whohlv8UTTbO3PQINEdujIGKZww8gjmDdgAQ2Ed1/RZ6//dJUWsHYJuDX7OUB6Yx40d32
-        kaIFWv6QOW0Di95QEk1wHiAbOHaYV7RObYK+wfpvh1GiyTrI9aWaS7dfGkuiNU8idIvJdn7RzMel
-        9G2fZ/CtrGHQb20fIdr51LOJAzaRujic+l6YunBJtHKfBDTyv33brm5ZtPRvF9tXAmX18e3K2G3r
-        wF2LmwNl/kWFRXy8klcK5cf8wdev4U8y+zl4Ssr/clDghBeO2lA0fWZ/Bf4r898n9ZOiKO9R88c9
-        Ge/zbESzJbD+NYqmDZshCR57uhHiR3QaZe1FJWKfp/TvFZziO1rw6TVc2FjzY7YyEnfdpcCP1fwr
-        V/gJWFzJjQBdxNSdtiBdls35VGwN9SabkLCqKrKfLAHj7l13pR7UQulxmXmXfWmifo5rQ2I2lYIJ
-        yVc2FVN5QU5On9Nk1n4hHIFPfdt3syBZknbbM7ancBQ57JfYk+lbmEy8VGSI2MU2Cqn0D1ZQ4Wm2
-        ATMkjbn57f14Bmi+39MobEEC5WWG+AnlT7MhGmI8QG7oZ6qKYQHLSft28dpy13LrDctN23qwxh0x
-        Pc989vBKCzskYm9rn5Axk64O8xGW2d7F4ULfjTbESm9J2qetVVH4e8+fhiTrFmJvSdpT4SMvjKYs
-        pcbPu8yw5/Bnrp9qcrnkY0+89FO+H3JbjkL9dkO8cXFEgpAORn7kZZU2q69pHjNeKLNwtiv9KdY3
-        C2D4Bwh2w+UM/elhWXf72TQobnpzZRWeTkB8Xpd3Edv3kg76nW7+Rde99CWWH/jODmPdpSB4ovpf
-        pi5YxA37tMbzwPToRjTWk18bs+vpMbnjC7eaTckM8xVcGAUjZL/NGo6icVGvlEwVsW/slJEiGxoa
-        yZZTHsrGUDXLuqVpjm5lqLbjsO+4P8i/PDRDboQHuqoCA2+vE9a3uEJM5Wv+iYik5fn0ZWAohl4x
-        DVSWNcVRQauhIqORimUF4bKuYNXWbDsDjB2HvQ6MkpmNBfS/BxT8DBDGeMw+aFPmn5N5qncWzyuV
-        LGkbtATCu1hcrTgVq6TK2NAM2cBYlZFpYFkdYWWkWRpWnFGWxXcb9jowKqVyNhiM8P42r5j8/NuN
-        njC9TlFD1bMVZYT3ULSs4xLCCMtWuQLZy9SGsmk6SDZsfWQM7WHFUY0M1Xcc9jow2MfMstHglLeB
-        44p9zY2mn28K8ATm5pds6Hl4fPw//zosBShOAAA=
+        H4sIAAAAAAAAA+VcbVfiSBb+Kznsnj0yQzBvBPDLLAKO7ohyROne7XY5RVJgrSFh8uJLi/99b1US
+        CHBDY7fazIwfYqXqqcq9z31JVSXhqcDckVc4eCp49y71CwcF4to+vf9nYN+WPX9cKBVcMqFQH9Ig
+        HAQWcQcj9hBGPuVN3iAk/piGhYMRcQJaKow8x6b+gNmFAzdynFLB8tzQ95zCQehH0B4F0Dql/oQF
+        AfPcoHCgarVSIbBuqB05dBBFvCtcbDJ1SEhlgwxNlQyHcsVSTVnV6kRWqWbLpKrULMWujHTVMEfV
+        WsVUq5W6qZjKqAqCUZuFA+I43j2157Jx4UHHQaLQVU9qOl5kS724HrpNPYdZj9B2SAJmSWc0vPf8
+        WwGA1uCG+HSumDf8H7VCoamm1kuFkIwTMoIUQiwHyp+eCksKK6WU6xhlswB0fUzEiuuy5QWX4eOU
+        C27TEYmcsPBcWhlZUJmMra4OnGvYtXqh0vxq3GKF5+tS4cYLQsuL3FCokBjKNKoWqdZrsk1VTTZq
+        VJOHI10Dc1V1XTN0VakonLqQhBFIWJiSKGAuv4pwpeQa06DACUzIS0paeRoNebEcUpcMHRpQK/JZ
+        +Fi2vAngiROmhA9AyIWdpxaTYXA5mjoeWTb/AATxQQG1UjX0ilKtVuG6bAKuTSbTeXXN1EFdEtwO
+        553hjETgVKFPmLPmUcmo3ErPgGVB6PmPwvJJWbiJqiqmXldTGw0Sni2fkhAMOLDB4ZdFcwjE3MSz
+        2YhZCEbI+TJDZAlHjRLHoS9snMNw6gzct6F4FzmgDRkyh4WMJpVgomkGw08dRlyLxucj5oTUj4Mj
+        cUOOLoMqpQLwYXN7p47bCAIaSietQiabPKWaUKh4FJ3G9AHOPyky5IjR9VPtWd6bnxjPcvFJf56f
+        q9rzXmlraPGnrFTplRRV042KWZXJ0LJlOlJUmVfIZrVW51W8BmK04EGMEnACrm2B/s4DTxwnJLRu
+        +FlcAFbGvhdNU62ztD6KWE8apk40Zm6ZgC+yYQRpuTxEaTuMxuCtv29L3H+5xtc/x7Rc/4zrfHbV
+        OWxfCOEfHOqOwxtwxtq7KEkfIJwhq498QPC0PIDguyMBonmzcdZv9KR23EM6SnugPNi+N7UhIKHR
+        gWDl8vNbFZwKZy9c52r3HcrEog+mxLolY5qvQncO2ErwuBdUtLREeT4AnH+4YSEddCHGICp9CPo3
+        0erBp6ODZvviUm42MZ2gRWrYdyyAjLi1WzYbcuyRcuqgqzXFn/6O+SrA/g1/8klL2mP0QIJzTVF0
+        WakV3ycs53TkcdHPjvXNcYorT/1Q6l9JIAL1KeTdmAMVCFCLuxK/no+6/vlFe6djd4pK3W1vZb4y
+        mlcv2x8v38cprTta9sk9pkF/Ow3+uwfIGaSaoryn1uv1maZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlbkeq1qlpIzWAEocMt9L6aCYDAkAYVVT46n9ns9CZYKFFYIMWL78P38uZwE8C+o/tVyZU1NmDMB
+        dCyOr+LJXEO+1PJ84mzW8jJBfZemqKJGWXtnRe9g3eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z87w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5IN7wGx4v3ndX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh91ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse568LegytvLh/0pUatu2DqN+R
+        0NW6VlbNWlktayW1ystlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiAfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yt9PwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnV6/L9Xod4IoiV2v1d2TgvNdvYXdHUf+nWXRN+QCDaTR0ll5OW1e7y4FSdwHkC9Cc
+        BAMNI0Yde42IJ+N5Py5oiwJKCX/pY7/T2W+11kzOh5cdnjWSEk2L43BRmlcKwkTpe7dLNu4idgVe
+        ai2BdmkrbkQmzBHvMOYKfyQgG/PrYBI5IVtk2flVLmD1c0xC6dSz+NOd5C1PSWyu8lumeHcyI9Vx
+        V776uBGtZdAtOmTE3QjXM/Ce5xAf1sCb8EYGf0Rtzycb4ZUMvPnriUSGUUDTRjPT+CuY2PM2jlXN
+        ihr12hvBtQy4cbKZsnoG+4G5YLBAOpDWk/bcIEq2Ax3CsP4df6Uzac4arNe57EpT3wO3mcwBWRsd
+        +ZQe9lqbPSBrpath5IbRZnzWSj2HWLd8WrO5S9ZSHf5eNLn9So+s+S7oxAupNGIOlYhlxStkgcpa
+        rQlGPu9tHjVruKPLblqN2Ch1eGVJcgsu8JUIUZdCxGWA9EbCiEw8ChCgrI06LLDKacNSxMR9JJuG
+        1EqylwAZS5cQG/TSlcsesvvzAogHCLjfx14vxSzFCYGM43teCFN/TrlIPAKVJfqi20yra6hzXwXU
+        lybEJWM6oeKxggDXlyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PT1ej3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+jpAW
+        j45SUH3VNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Uknfr54AsY/zDjHiNIpqWOXPHwPlSjjWWUsFZ
+        Jw0oI0vZ2UnKjGGupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn88IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqRf+3yF3+oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsrqks
+        BcR9j3+DIjV/7Z1u7qY+v96CdtOMcNtlzp4y+6TCdD6e0ysl87m49/lz8JPMD3urTcVf9kqi4YW9
+        cpZPH/lfSRxlcVxZSSmK8har/7gG+bInl81OBvrXWD7lbIskfOzologXhdMI25VKxD5P279V8JA+
+        hCUvvIFbHC++z6ZG4q7bLPVjNf/Ka/2ELKFkLkGXcetWm5EOz+ZiKD6bepXtSJhflfkBEzCu3nZ/
+        6kktVZ4XmXdRlybqr6FyEnNNKdUg+co1paa8ICenb2xya7+QDt8LPctzMEoWTdvtHltTOItsfmTW
+        ZPoaJsveKhARL6hFglD6B19a0SluQETSGC0e9McjQPHt3kvhExJYaCLiJy1/mq3RgNIBcQIPVZXC
+        VFY07drNa8Pzy42PLvM2+GC2O+J6nnr8NZYOtVnEv9s+ZmMuXRPGYzyzvYnDBZ4T5cRKb9G0S5us
+        WeEfXW8aMOxhYm/RtKPCR24QTXlKjd98uaOuLd6+XtXkaoHj7770U9wPeUAXwkrulrnj8oj5QTgY
+        eZGLLW2WP9g84lhYZlHclf4U85s5MeKnCLbj5ZT86WlZd/u7qV/O+4ZlmZ6uzzyxLr8gfAdM2ut3
+        L4ovuu+ln7P8wK93OHSbBcGK6n+ZdcE8bviPbHydmF6Yy8Z68juj/H56xB7ExK1hheyOihlcEPkj
+        Yr3OHC4k43Kv9ZsE1qJjz0cnBcvN3/Dkj49wR5yIanVoFaWV2uxu5ry6hoJrKFg1MbBqomBdxcC6
+        io9cQUeu4CMb6MgGriAK1nCwjrKh42zoKBs6zoZWRcWo4iOjYB0HayjPGs4zql+OegoqhIILgYI1
+        HIz6J+6eGBIForbATYE6BO4PKmoIFTeEoaMD6zhhGkqYhouBsqvi7OpoKOl4KBnoyAY+soHKbOAy
+        a6gYGi4GTgbOBcqymsMy6hZaToiiI2v4yAYadQYedejA+Lgq6p1qTrrCB84ZGQ07FY87HbWInmMS
+        lAsV5wJ1C9wr0ODDY09F5VVxeXWUCR1nQkVTJtSuP/oJaCjfiB9RSkquF75skmDXRrXR0KRyVR1Z
+        smEpdbluaZpsDY06taldMYwKMnnYsts3TCrEDxUKjQf1ajZXrDS8DRlqnShVRTbsqgZamZo8NEa6
+        bKuaVdMpMWyRytfJ2Krb95FRq2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEKJKVNFGcrGcETkGhma
+        smINK9WKYVojy0QU27Lb91nRNHOsyBveggx1VFMN066ALnUeqLoiE8PUZcuihqmpo7phYvG9Zbdv
+        JUP8wGesuP0IDcxaZQVBvAU9ll2jpAaK6RUT9FQ1U64T/qOAtFrVVKIpqlFH6Nmy23emv3pO9qu/
+        EhXX/Cdgw/Q3H306AdLF6h5qnp6f/w8uCax9XVYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -1238,12 +1518,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:54:17 GMT
+      - Thu, 21 Nov 2019 15:41:03 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1253,9 +1533,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 7fe591195ff49d93d61c1adfa098d868
+      - 9b1dc40fd7097f9410f8463162cb7da8
     status:
       code: 200
       message: OK
@@ -1271,76 +1551,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPfAJuXWQJkkt1AOJDQvdOd5QhbEG2MzdgySTrkv29J
-        tkEEQ0jn0sxMHoisKslVX12ski8POeKN/Fz1IeffejjIVXPIcwJ8+8/QuSn6wThXyHlogqGf4pAO
-        Qht5gxG5o1GAGckfUBSMMc1VR8gNcSE38l0HBwPi5Kpe5LqFnO17NPDdXJUGEdCjEKhTHExIGBLf
-        C3NVVTMLudC+xk7k4kEUsaFwssnURRTLeGgjG+m6rOmWLlcQLsumOipBSy05mmZaqm1aumLYCBkl
-        s6IgtWyAYNghdIBc17/FzkI2JjzoOEgUuuxJddePHKkX98Owqe8S+x5oRygkttTG9NYPbjgDUMNr
-        FOCFYv7wf9imXFNVVQo5isYJGGHKgmwX2l8ecisKA2+CdczlkBB0vU/EivvE9hJLej9lgjt4hCKX
-        5h4LT2bmUCZzq08n3mjYtX52Qm1xNmax3ONVIXfth9T2I49yFRJDmYZljTTFli0HGbJhmRXZBJvJ
-        JcVBFnYsyyjpDDqKaAQS5qYoConHzsJdKTnHNMwxABPwkpZWnEZD1ixS7KGhi0NsRwGh90XbnwA/
-        cmkK+ACEXNp5ahMZJpejqeujVfMPQJAAFFBLZV2vmKYCMFEyAddGk+myu1QGdVF4M1wMhiMUgVPR
-        ABF3zaOSWZmVHoGXhNQP7rnlk3bsJoqpWYqe2miQ4GwHGFEw4MABh18VzUUQcxPfISNiZ/EwOV9m
-        CBHwTKPEcRhwG29AOHUG5tvQnEUuaIOGxCWU4KQTTDQVeNihS5Bn4/h4RFyKgzg4Ejdk3EVQpZAD
-        PBxm79Rxa2GIqXTayAnZ5CHVBEPHPR80xndw/EWRLSSPrh7MR/lgcWA8yvkH/XFxrGqPB4WdWfM/
-        iVKlZ1JUTTdK5YqMhrYj45GiyqxDLldMi3WxHojRnA8xisAJmLY5/DsLPP47QdS+ZkdxA1AZB340
-        TbUWYb3nsZ4Qpm40Jl4RgS+SYQRpuTjMhO0oGoO3/r4rcP9lGl/9HMNy9XO2zu3L1lGzy4W/c7E3
-        ptfgjOaHKInvIJwhq48C4GBpeQDBN0Nhhub1Wrtf60nNeIR0nI7IxMEJ/KkDAQlEF4KVyc8uVXDI
-        nT13tVG7VygTiz6YIvsGjfFmFToLhp0Ej0dBR0NLlGcTwPGna0LxoAMxBlEZQNC/i1Z3AR5V683u
-        hVyvZ+kEFKnmzEgIGXFnt6zX5Ngj5dRBn/bkf/p7lq8C23/gTz5tSAcEVyU41hRFlxUz/zFhuYBj
-        ExZ9ca7vjtNs5XFApf6lBCLgAEPejTFQAQA1vy/x6weZrn/ebe517E4zpe40dzJfMTOvXjQ/X3yM
-        U9ozXAzQbZYG/d00+O8BcM4h1eTlA9WyrLmmfFHUK+6O+TgkH4wCXF9349vkwP0mhKtakmElUy4k
-        R2VZVeCS+1FIheFgiEIMVc8GT+33ehKUChgqhJhj9/D9+rWYBPAvmfpXiqU1NWHNBKxj/vsmnsw0
-        ZKWWHyB3u5YXCderNM1U1ChqH6zoDOo2P9gYBaK2fc6644UKRmp/a1YPLued8/r8eH4ybzfyh92z
-        6sH58fxi/ml+GXfUgaU+v+zO6+yYx8l3jcxvCJ1m9aQgNavHa7C+cWw8j+PL4av1qwdn89q8nT+s
-        gbYn89b8DJpR9aA9781b+cM6a3Xm9fzh6aJVS1sLLF83zSZgYdZ2QYLf2jtDq++Qd2Z6UfmjJx99
-        x+zDdf3jpyD9JTloVeeXRlIVRh/GGYXnk89JOkmyyec4mUAumXfhIImblw36welH3xXD74KOJZA2
-        JJCzeSdOIWfzk/xhp8t6efOS541u/rDH8KrzjHICpDbPKEmrlrZEgN946h+arOIS51MzywCfdl1O
-        JqH5XEXzqfm0moFy7l1KueVu1cDBoR2QKdt7y9LxGts3UpsdvPHa/w1EX4CVJfiCTeoKbHuhwrqX
-        JRveA2TH+8/r+jRijsN/e1ANSrWYL9yfmnG9+HW0AXZd4mdp0+SEfa6BF9LHY59V4T1C5F13KdAM
-        EZfJkKVbolRN4NkTu/B83GwcyXwzaZPgDUQRW2C+7ZbTXu0NJz3X0XAzDiecuCeWSwROeAcYzLNh
-        ZdNc4ZSawLmrGsnQUEIBlkQXb/tSIoBEQrjM/h4RdquTE254TsXZQ98TC+wMhveDCXJvUWZp0EzZ
-        pKN7qbVg2y+Dxkp4OAyjrFsVKzq0U64fogK/AZfczl8X9ASorHl42pFqjhOAqK9I6KqlFdWyWVSL
-        WkGtsHYRfuRlU1EKqsL+FUuwZNaMApcO3yFYt2B+A/jjtvBPa/1aBiKs+4UZVP5Sk39D8rcreTWj
-        Pu3fkGH5GdfWwKoq12RFLakfeVsDRDnKxuTowzE5ysTk6CMxCSkZD0I8w+z5hGxcWlJvSd8FHTI7
-        7V/9vEHn5Wyxyqf9D7Z+1k0t1v3h1r/48RFBvAG9BhTwbVaKP/Wki2sMyf12jwqSzVfVfb2QCou7
-        CaYo5J1Z8i+I+1xALVXYVEEJevxhqieeHFq946zk0CJ24If+iEpHketiSrzd8kSr9+T2/5OODZmh
-        1bMs2bIsYFcUuWJaH4jAea/fyLo68v4/TdE1ZRMMptHQXXk4bV3tDmOUOktGVoBuSDBAGBHsOmtA
-        PBiPh3FDWzYyIWEPfRy2WoeNxprJ2fSyy7JG0sJpc0yXrUUnB4y3XrtdsnUXscP5pcYK0z5txY3Q
-        hLj8GcaNwh9zlq35dTCJXEqWWXZxli5UPyeISme+ze7uJE95SnxzlV0y+bOTglQnHfny81ZuTeBu
-        4CFB3lZ2XWDv+S4KoAbexm8I/MfY8QO0lb0ksNd/PZXQMApxSiwLxF/BxL6/da6KKGrUa25lNgXm
-        2ul2yCyB9xPxwGChVJXWk/bCIIo4AA9h2mDGHulMyKLBeq2LjjQNfHCbyYJBtNFxgPFRr7HdA0Qr
-        XQ4jj0bb+UUr9Vxk37BlzfYhoqVa7LlodPPMCNF8XTzxKZZGxMUSsu24QuZcotXqYOTz3vZZRcMd
-        X3TS7gwbpQ6vrEhuwwmeiRB1JUQ8Apz+iBuR8FsBnEm0UYuEdjElrERMPEZyMMV2kr04k7FyCr5B
-        L1165E7cn+eM2QEC7ve510t5VuIEQcYJfJ/C0p9BzhMP5xKB7nbqabeZ6dyXIQ6kCfLQGE8wv63A
-        ma3ViITE6KZ5QkQ53URdJBER0Q7GgXzhy+y/dMwconcNacVLH6/XRWTrp736eUoQkT0mAb5Frrs4
-        hYjoEXi04/uLiNNFFHv1WqOWEkToGu0UUV3ECqBwwV+lMLblYk4RuA5/OUJa3jpKmaynpkFSeI1d
-        96l1DGXFayhkk/Eipa6g5wdUSp6tXzCIiLEXM+IahZNWMfPGgPlKjjVWUkG7lQaUIULWPk2RMcpP
-        0wCZbc/whohlv8UTTbO3PQINEdujIGKZww8gjmDdgAQ2Ed1/RZ6//dJUWsHYJuDX7OUB6Yx40d32
-        kaIFWv6QOW0Di95QEk1wHiAbOHaYV7RObYK+wfpvh1GiyTrI9aWaS7dfGkuiNU8idIvJdn7RzMel
-        9G2fZ/CtrGHQb20fIdr51LOJAzaRujic+l6YunBJtHKfBDTyv33brm5ZtPRvF9tXAmX18e3K2G3r
-        wF2LmwNl/kWFRXy8klcK5cf8wdev4U8y+zl4Ssr/clDghBeO2lA0fWZ/Bf4r898n9ZOiKO9R88c9
-        Ge/zbESzJbD+NYqmDZshCR57uhHiR3QaZe1FJWKfp/TvFZziO1rw6TVc2FjzY7YyEnfdpcCP1fwr
-        V/gJWFzJjQBdxNSdtiBdls35VGwN9SabkLCqKrKfLAHj7l13pR7UQulxmXmXfWmifo5rQ2I2lYIJ
-        yVc2FVN5QU5On9Nk1n4hHIFPfdt3syBZknbbM7ancBQ57JfYk+lbmEy8VGSI2MU2Cqn0D1ZQ4Wm2
-        ATMkjbn57f14Bmi+39MobEEC5WWG+AnlT7MhGmI8QG7oZ6qKYQHLSft28dpy13LrDctN23qwxh0x
-        Pc989vBKCzskYm9rn5Axk64O8xGW2d7F4ULfjTbESm9J2qetVVH4e8+fhiTrFmJvSdpT4SMvjKYs
-        pcbPu8yw5/Bnrp9qcrnkY0+89FO+H3JbjkL9dkO8cXFEgpAORn7kZZU2q69pHjNeKLNwtiv9KdY3
-        C2D4Bwh2w+UM/elhWXf72TQobnpzZRWeTkB8Xpd3Edv3kg76nW7+Rde99CWWH/jODmPdpSB4ovpf
-        pi5YxA37tMbzwPToRjTWk18bs+vpMbnjC7eaTckM8xVcGAUjZL/NGo6icVGvlEwVsW/slJEiGxoa
-        yZZTHsrGUDXLuqVpjm5lqLbjsO+4P8i/PDRDboQHuqoCA2+vE9a3uEJM5Wv+iYik5fn0ZWAohl4x
-        DVSWNcVRQauhIqORimUF4bKuYNXWbDsDjB2HvQ6MkpmNBfS/BxT8DBDGeMw+aFPmn5N5qncWzyuV
-        LGkbtATCu1hcrTgVq6TK2NAM2cBYlZFpYFkdYWWkWRpWnFGWxXcb9jowKqVyNhiM8P42r5j8/NuN
-        njC9TlFD1bMVZYT3ULSs4xLCCMtWuQLZy9SGsmk6SDZsfWQM7WHFUY0M1Xcc9jow2MfMstHglLeB
-        44p9zY2mn28K8ATm5pds6Hl4fPw//zosBShOAAA=
+        H4sIAAAAAAAAA+VcbVfiSBb+Kznsnj0yQzBvBPDLLAKO7ohyROne7XY5RVJgrSFh8uJLi/99b1US
+        CHBDY7fazIwfYqXqqcq9z31JVSXhqcDckVc4eCp49y71CwcF4to+vf9nYN+WPX9cKBVcMqFQH9Ig
+        HAQWcQcj9hBGPuVN3iAk/piGhYMRcQJaKow8x6b+gNmFAzdynFLB8tzQ95zCQehH0B4F0Dql/oQF
+        AfPcoHCgarVSIbBuqB05dBBFvCtcbDJ1SEhlgwxNlQyHcsVSTVnV6kRWqWbLpKrULMWujHTVMEfV
+        WsVUq5W6qZjKqAqCUZuFA+I43j2157Jx4UHHQaLQVU9qOl5kS724HrpNPYdZj9B2SAJmSWc0vPf8
+        WwGA1uCG+HSumDf8H7VCoamm1kuFkIwTMoIUQiwHyp+eCksKK6WU6xhlswB0fUzEiuuy5QWX4eOU
+        C27TEYmcsPBcWhlZUJmMra4OnGvYtXqh0vxq3GKF5+tS4cYLQsuL3FCokBjKNKoWqdZrsk1VTTZq
+        VJOHI10Dc1V1XTN0VakonLqQhBFIWJiSKGAuv4pwpeQa06DACUzIS0paeRoNebEcUpcMHRpQK/JZ
+        +Fi2vAngiROmhA9AyIWdpxaTYXA5mjoeWTb/AATxQQG1UjX0ilKtVuG6bAKuTSbTeXXN1EFdEtwO
+        553hjETgVKFPmLPmUcmo3ErPgGVB6PmPwvJJWbiJqiqmXldTGw0Sni2fkhAMOLDB4ZdFcwjE3MSz
+        2YhZCEbI+TJDZAlHjRLHoS9snMNw6gzct6F4FzmgDRkyh4WMJpVgomkGw08dRlyLxucj5oTUj4Mj
+        cUOOLoMqpQLwYXN7p47bCAIaSietQiabPKWaUKh4FJ3G9AHOPyky5IjR9VPtWd6bnxjPcvFJf56f
+        q9rzXmlraPGnrFTplRRV042KWZXJ0LJlOlJUmVfIZrVW51W8BmK04EGMEnACrm2B/s4DTxwnJLRu
+        +FlcAFbGvhdNU62ztD6KWE8apk40Zm6ZgC+yYQRpuTxEaTuMxuCtv29L3H+5xtc/x7Rc/4zrfHbV
+        OWxfCOEfHOqOwxtwxtq7KEkfIJwhq498QPC0PIDguyMBonmzcdZv9KR23EM6SnugPNi+N7UhIKHR
+        gWDl8vNbFZwKZy9c52r3HcrEog+mxLolY5qvQncO2ErwuBdUtLREeT4AnH+4YSEddCHGICp9CPo3
+        0erBp6ODZvviUm42MZ2gRWrYdyyAjLi1WzYbcuyRcuqgqzXFn/6O+SrA/g1/8klL2mP0QIJzTVF0
+        WakV3ycs53TkcdHPjvXNcYorT/1Q6l9JIAL1KeTdmAMVCFCLuxK/no+6/vlFe6djd4pK3W1vZb4y
+        mlcv2x8v38cprTta9sk9pkF/Ow3+uwfIGaSaoryn1uv1maZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlbkeq1qlpIzWAEocMt9L6aCYDAkAYVVT46n9ns9CZYKFFYIMWL78P38uZwE8C+o/tVyZU1NmDMB
+        dCyOr+LJXEO+1PJ84mzW8jJBfZemqKJGWXtnRe9g3eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z87w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5IN7wGx4v3ndX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh91ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse568LegytvLh/0pUatu2DqN+R
+        0NW6VlbNWlktayW1ystlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiAfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yt9PwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnV6/L9Xod4IoiV2v1d2TgvNdvYXdHUf+nWXRN+QCDaTR0ll5OW1e7y4FSdwHkC9Cc
+        BAMNI0Yde42IJ+N5Py5oiwJKCX/pY7/T2W+11kzOh5cdnjWSEk2L43BRmlcKwkTpe7dLNu4idgVe
+        ai2BdmkrbkQmzBHvMOYKfyQgG/PrYBI5IVtk2flVLmD1c0xC6dSz+NOd5C1PSWyu8lumeHcyI9Vx
+        V776uBGtZdAtOmTE3QjXM/Ce5xAf1sCb8EYGf0Rtzycb4ZUMvPnriUSGUUDTRjPT+CuY2PM2jlXN
+        ihr12hvBtQy4cbKZsnoG+4G5YLBAOpDWk/bcIEq2Ax3CsP4df6Uzac4arNe57EpT3wO3mcwBWRsd
+        +ZQe9lqbPSBrpath5IbRZnzWSj2HWLd8WrO5S9ZSHf5eNLn9So+s+S7oxAupNGIOlYhlxStkgcpa
+        rQlGPu9tHjVruKPLblqN2Ch1eGVJcgsu8JUIUZdCxGWA9EbCiEw8ChCgrI06LLDKacNSxMR9JJuG
+        1EqylwAZS5cQG/TSlcsesvvzAogHCLjfx14vxSzFCYGM43teCFN/TrlIPAKVJfqi20yra6hzXwXU
+        lybEJWM6oeKxggDXlyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PT1ej3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+jpAW
+        j45SUH3VNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Uknfr54AsY/zDjHiNIpqWOXPHwPlSjjWWUsFZ
+        Jw0oI0vZ2UnKjGGupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn88IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqRf+3yF3+oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsrqks
+        BcR9j3+DIjV/7Z1u7qY+v96CdtOMcNtlzp4y+6TCdD6e0ysl87m49/lz8JPMD3urTcVf9kqi4YW9
+        cpZPH/lfSRxlcVxZSSmK8har/7gG+bInl81OBvrXWD7lbIskfOzologXhdMI25VKxD5P279V8JA+
+        hCUvvIFbHC++z6ZG4q7bLPVjNf/Ka/2ELKFkLkGXcetWm5EOz+ZiKD6bepXtSJhflfkBEzCu3nZ/
+        6kktVZ4XmXdRlybqr6FyEnNNKdUg+co1paa8ICenb2xya7+QDt8LPctzMEoWTdvtHltTOItsfmTW
+        ZPoaJsveKhARL6hFglD6B19a0SluQETSGC0e9McjQPHt3kvhExJYaCLiJy1/mq3RgNIBcQIPVZXC
+        VFY07drNa8Pzy42PLvM2+GC2O+J6nnr8NZYOtVnEv9s+ZmMuXRPGYzyzvYnDBZ4T5cRKb9G0S5us
+        WeEfXW8aMOxhYm/RtKPCR24QTXlKjd98uaOuLd6+XtXkaoHj7770U9wPeUAXwkrulrnj8oj5QTgY
+        eZGLLW2WP9g84lhYZlHclf4U85s5MeKnCLbj5ZT86WlZd/u7qV/O+4ZlmZ6uzzyxLr8gfAdM2ut3
+        L4ovuu+ln7P8wK93OHSbBcGK6n+ZdcE8bviPbHydmF6Yy8Z68juj/H56xB7ExK1hheyOihlcEPkj
+        Yr3OHC4k43Kv9ZsE1qJjz0cnBcvN3/Dkj49wR5yIanVoFaWV2uxu5ry6hoJrKFg1MbBqomBdxcC6
+        io9cQUeu4CMb6MgGriAK1nCwjrKh42zoKBs6zoZWRcWo4iOjYB0HayjPGs4zql+OegoqhIILgYI1
+        HIz6J+6eGBIForbATYE6BO4PKmoIFTeEoaMD6zhhGkqYhouBsqvi7OpoKOl4KBnoyAY+soHKbOAy
+        a6gYGi4GTgbOBcqymsMy6hZaToiiI2v4yAYadQYedejA+Lgq6p1qTrrCB84ZGQ07FY87HbWInmMS
+        lAsV5wJ1C9wr0ODDY09F5VVxeXWUCR1nQkVTJtSuP/oJaCjfiB9RSkquF75skmDXRrXR0KRyVR1Z
+        smEpdbluaZpsDY06taldMYwKMnnYsts3TCrEDxUKjQf1ajZXrDS8DRlqnShVRTbsqgZamZo8NEa6
+        bKuaVdMpMWyRytfJ2Krb95FRq2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEKJKVNFGcrGcETkGhma
+        smINK9WKYVojy0QU27Lb91nRNHOsyBveggx1VFMN066ALnUeqLoiE8PUZcuihqmpo7phYvG9Zbdv
+        JUP8wGesuP0IDcxaZQVBvAU9ll2jpAaK6RUT9FQ1U64T/qOAtFrVVKIpqlFH6Nmy23emv3pO9qu/
+        EhXX/Cdgw/Q3H306AdLF6h5qnp6f/w8uCax9XVYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -1351,12 +1636,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:54:18 GMT
+      - Thu, 21 Nov 2019 15:41:04 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1366,9 +1651,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - bbbd69a55dd637ca67862e1898e63117
+      - e518269341d50e9a3994bae1049ee5e5
     status:
       code: 200
       message: OK
@@ -1384,76 +1669,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPfAJuXWQJkkt1AOJDQvdOd5QhbEG2MzdgySTrkv29J
-        tkEEQ0jn0sxMHoisKslVX12ski8POeKN/Fz1IeffejjIVXPIcwJ8+8/QuSn6wThXyHlogqGf4pAO
-        Qht5gxG5o1GAGckfUBSMMc1VR8gNcSE38l0HBwPi5Kpe5LqFnO17NPDdXJUGEdCjEKhTHExIGBLf
-        C3NVVTMLudC+xk7k4kEUsaFwssnURRTLeGgjG+m6rOmWLlcQLsumOipBSy05mmZaqm1aumLYCBkl
-        s6IgtWyAYNghdIBc17/FzkI2JjzoOEgUuuxJddePHKkX98Owqe8S+x5oRygkttTG9NYPbjgDUMNr
-        FOCFYv7wf9imXFNVVQo5isYJGGHKgmwX2l8ecisKA2+CdczlkBB0vU/EivvE9hJLej9lgjt4hCKX
-        5h4LT2bmUCZzq08n3mjYtX52Qm1xNmax3ONVIXfth9T2I49yFRJDmYZljTTFli0HGbJhmRXZBJvJ
-        JcVBFnYsyyjpDDqKaAQS5qYoConHzsJdKTnHNMwxABPwkpZWnEZD1ixS7KGhi0NsRwGh90XbnwA/
-        cmkK+ACEXNp5ahMZJpejqeujVfMPQJAAFFBLZV2vmKYCMFEyAddGk+myu1QGdVF4M1wMhiMUgVPR
-        ABF3zaOSWZmVHoGXhNQP7rnlk3bsJoqpWYqe2miQ4GwHGFEw4MABh18VzUUQcxPfISNiZ/EwOV9m
-        CBHwTKPEcRhwG29AOHUG5tvQnEUuaIOGxCWU4KQTTDQVeNihS5Bn4/h4RFyKgzg4Ejdk3EVQpZAD
-        PBxm79Rxa2GIqXTayAnZ5CHVBEPHPR80xndw/EWRLSSPrh7MR/lgcWA8yvkH/XFxrGqPB4WdWfM/
-        iVKlZ1JUTTdK5YqMhrYj45GiyqxDLldMi3WxHojRnA8xisAJmLY5/DsLPP47QdS+ZkdxA1AZB340
-        TbUWYb3nsZ4Qpm40Jl4RgS+SYQRpuTjMhO0oGoO3/r4rcP9lGl/9HMNy9XO2zu3L1lGzy4W/c7E3
-        ptfgjOaHKInvIJwhq48C4GBpeQDBN0Nhhub1Wrtf60nNeIR0nI7IxMEJ/KkDAQlEF4KVyc8uVXDI
-        nT13tVG7VygTiz6YIvsGjfFmFToLhp0Ej0dBR0NLlGcTwPGna0LxoAMxBlEZQNC/i1Z3AR5V683u
-        hVyvZ+kEFKnmzEgIGXFnt6zX5Ngj5dRBn/bkf/p7lq8C23/gTz5tSAcEVyU41hRFlxUz/zFhuYBj
-        ExZ9ca7vjtNs5XFApf6lBCLgAEPejTFQAQA1vy/x6weZrn/ebe517E4zpe40dzJfMTOvXjQ/X3yM
-        U9ozXAzQbZYG/d00+O8BcM4h1eTlA9WyrLmmfFHUK+6O+TgkH4wCXF9349vkwP0mhKtakmElUy4k
-        R2VZVeCS+1FIheFgiEIMVc8GT+33ehKUChgqhJhj9/D9+rWYBPAvmfpXiqU1NWHNBKxj/vsmnsw0
-        ZKWWHyB3u5YXCderNM1U1ChqH6zoDOo2P9gYBaK2fc6644UKRmp/a1YPLued8/r8eH4ybzfyh92z
-        6sH58fxi/ml+GXfUgaU+v+zO6+yYx8l3jcxvCJ1m9aQgNavHa7C+cWw8j+PL4av1qwdn89q8nT+s
-        gbYn89b8DJpR9aA9781b+cM6a3Xm9fzh6aJVS1sLLF83zSZgYdZ2QYLf2jtDq++Qd2Z6UfmjJx99
-        x+zDdf3jpyD9JTloVeeXRlIVRh/GGYXnk89JOkmyyec4mUAumXfhIImblw36welH3xXD74KOJZA2
-        JJCzeSdOIWfzk/xhp8t6efOS541u/rDH8KrzjHICpDbPKEmrlrZEgN946h+arOIS51MzywCfdl1O
-        JqH5XEXzqfm0moFy7l1KueVu1cDBoR2QKdt7y9LxGts3UpsdvPHa/w1EX4CVJfiCTeoKbHuhwrqX
-        JRveA2TH+8/r+jRijsN/e1ANSrWYL9yfmnG9+HW0AXZd4mdp0+SEfa6BF9LHY59V4T1C5F13KdAM
-        EZfJkKVbolRN4NkTu/B83GwcyXwzaZPgDUQRW2C+7ZbTXu0NJz3X0XAzDiecuCeWSwROeAcYzLNh
-        ZdNc4ZSawLmrGsnQUEIBlkQXb/tSIoBEQrjM/h4RdquTE254TsXZQ98TC+wMhveDCXJvUWZp0EzZ
-        pKN7qbVg2y+Dxkp4OAyjrFsVKzq0U64fogK/AZfczl8X9ASorHl42pFqjhOAqK9I6KqlFdWyWVSL
-        WkGtsHYRfuRlU1EKqsL+FUuwZNaMApcO3yFYt2B+A/jjtvBPa/1aBiKs+4UZVP5Sk39D8rcreTWj
-        Pu3fkGH5GdfWwKoq12RFLakfeVsDRDnKxuTowzE5ysTk6CMxCSkZD0I8w+z5hGxcWlJvSd8FHTI7
-        7V/9vEHn5Wyxyqf9D7Z+1k0t1v3h1r/48RFBvAG9BhTwbVaKP/Wki2sMyf12jwqSzVfVfb2QCou7
-        CaYo5J1Z8i+I+1xALVXYVEEJevxhqieeHFq946zk0CJ24If+iEpHketiSrzd8kSr9+T2/5OODZmh
-        1bMs2bIsYFcUuWJaH4jAea/fyLo68v4/TdE1ZRMMptHQXXk4bV3tDmOUOktGVoBuSDBAGBHsOmtA
-        PBiPh3FDWzYyIWEPfRy2WoeNxprJ2fSyy7JG0sJpc0yXrUUnB4y3XrtdsnUXscP5pcYK0z5txY3Q
-        hLj8GcaNwh9zlq35dTCJXEqWWXZxli5UPyeISme+ze7uJE95SnxzlV0y+bOTglQnHfny81ZuTeBu
-        4CFB3lZ2XWDv+S4KoAbexm8I/MfY8QO0lb0ksNd/PZXQMApxSiwLxF/BxL6/da6KKGrUa25lNgXm
-        2ul2yCyB9xPxwGChVJXWk/bCIIo4AA9h2mDGHulMyKLBeq2LjjQNfHCbyYJBtNFxgPFRr7HdA0Qr
-        XQ4jj0bb+UUr9Vxk37BlzfYhoqVa7LlodPPMCNF8XTzxKZZGxMUSsu24QuZcotXqYOTz3vZZRcMd
-        X3TS7gwbpQ6vrEhuwwmeiRB1JUQ8Apz+iBuR8FsBnEm0UYuEdjElrERMPEZyMMV2kr04k7FyCr5B
-        L1165E7cn+eM2QEC7ve510t5VuIEQcYJfJ/C0p9BzhMP5xKB7nbqabeZ6dyXIQ6kCfLQGE8wv63A
-        ma3ViITE6KZ5QkQ53URdJBER0Q7GgXzhy+y/dMwconcNacVLH6/XRWTrp736eUoQkT0mAb5Frrs4
-        hYjoEXi04/uLiNNFFHv1WqOWEkToGu0UUV3ECqBwwV+lMLblYk4RuA5/OUJa3jpKmaynpkFSeI1d
-        96l1DGXFayhkk/Eipa6g5wdUSp6tXzCIiLEXM+IahZNWMfPGgPlKjjVWUkG7lQaUIULWPk2RMcpP
-        0wCZbc/whohlv8UTTbO3PQINEdujIGKZww8gjmDdgAQ2Ed1/RZ6//dJUWsHYJuDX7OUB6Yx40d32
-        kaIFWv6QOW0Di95QEk1wHiAbOHaYV7RObYK+wfpvh1GiyTrI9aWaS7dfGkuiNU8idIvJdn7RzMel
-        9G2fZ/CtrGHQb20fIdr51LOJAzaRujic+l6YunBJtHKfBDTyv33brm5ZtPRvF9tXAmX18e3K2G3r
-        wF2LmwNl/kWFRXy8klcK5cf8wdev4U8y+zl4Ssr/clDghBeO2lA0fWZ/Bf4r898n9ZOiKO9R88c9
-        Ge/zbESzJbD+NYqmDZshCR57uhHiR3QaZe1FJWKfp/TvFZziO1rw6TVc2FjzY7YyEnfdpcCP1fwr
-        V/gJWFzJjQBdxNSdtiBdls35VGwN9SabkLCqKrKfLAHj7l13pR7UQulxmXmXfWmifo5rQ2I2lYIJ
-        yVc2FVN5QU5On9Nk1n4hHIFPfdt3syBZknbbM7ancBQ57JfYk+lbmEy8VGSI2MU2Cqn0D1ZQ4Wm2
-        ATMkjbn57f14Bmi+39MobEEC5WWG+AnlT7MhGmI8QG7oZ6qKYQHLSft28dpy13LrDctN23qwxh0x
-        Pc989vBKCzskYm9rn5Axk64O8xGW2d7F4ULfjTbESm9J2qetVVH4e8+fhiTrFmJvSdpT4SMvjKYs
-        pcbPu8yw5/Bnrp9qcrnkY0+89FO+H3JbjkL9dkO8cXFEgpAORn7kZZU2q69pHjNeKLNwtiv9KdY3
-        C2D4Bwh2w+UM/elhWXf72TQobnpzZRWeTkB8Xpd3Edv3kg76nW7+Rde99CWWH/jODmPdpSB4ovpf
-        pi5YxA37tMbzwPToRjTWk18bs+vpMbnjC7eaTckM8xVcGAUjZL/NGo6icVGvlEwVsW/slJEiGxoa
-        yZZTHsrGUDXLuqVpjm5lqLbjsO+4P8i/PDRDboQHuqoCA2+vE9a3uEJM5Wv+iYik5fn0ZWAohl4x
-        DVSWNcVRQauhIqORimUF4bKuYNXWbDsDjB2HvQ6MkpmNBfS/BxT8DBDGeMw+aFPmn5N5qncWzyuV
-        LGkbtATCu1hcrTgVq6TK2NAM2cBYlZFpYFkdYWWkWRpWnFGWxXcb9jowKqVyNhiM8P42r5j8/NuN
-        njC9TlFD1bMVZYT3ULSs4xLCCMtWuQLZy9SGsmk6SDZsfWQM7WHFUY0M1Xcc9jow2MfMstHglLeB
-        44p9zY2mn28K8ATm5pds6Hl4fPw//zosBShOAAA=
+        H4sIAAAAAAAAA+VcbVfiSBb+Kznsnj0yQzBvBPDLLAKO7ohyROne7XY5RVJgrSFh8uJLi/99b1US
+        CHBDY7fazIwfYqXqqcq9z31JVSXhqcDckVc4eCp49y71CwcF4to+vf9nYN+WPX9cKBVcMqFQH9Ig
+        HAQWcQcj9hBGPuVN3iAk/piGhYMRcQJaKow8x6b+gNmFAzdynFLB8tzQ95zCQehH0B4F0Dql/oQF
+        AfPcoHCgarVSIbBuqB05dBBFvCtcbDJ1SEhlgwxNlQyHcsVSTVnV6kRWqWbLpKrULMWujHTVMEfV
+        WsVUq5W6qZjKqAqCUZuFA+I43j2157Jx4UHHQaLQVU9qOl5kS724HrpNPYdZj9B2SAJmSWc0vPf8
+        WwGA1uCG+HSumDf8H7VCoamm1kuFkIwTMoIUQiwHyp+eCksKK6WU6xhlswB0fUzEiuuy5QWX4eOU
+        C27TEYmcsPBcWhlZUJmMra4OnGvYtXqh0vxq3GKF5+tS4cYLQsuL3FCokBjKNKoWqdZrsk1VTTZq
+        VJOHI10Dc1V1XTN0VakonLqQhBFIWJiSKGAuv4pwpeQa06DACUzIS0paeRoNebEcUpcMHRpQK/JZ
+        +Fi2vAngiROmhA9AyIWdpxaTYXA5mjoeWTb/AATxQQG1UjX0ilKtVuG6bAKuTSbTeXXN1EFdEtwO
+        553hjETgVKFPmLPmUcmo3ErPgGVB6PmPwvJJWbiJqiqmXldTGw0Sni2fkhAMOLDB4ZdFcwjE3MSz
+        2YhZCEbI+TJDZAlHjRLHoS9snMNw6gzct6F4FzmgDRkyh4WMJpVgomkGw08dRlyLxucj5oTUj4Mj
+        cUOOLoMqpQLwYXN7p47bCAIaSietQiabPKWaUKh4FJ3G9AHOPyky5IjR9VPtWd6bnxjPcvFJf56f
+        q9rzXmlraPGnrFTplRRV042KWZXJ0LJlOlJUmVfIZrVW51W8BmK04EGMEnACrm2B/s4DTxwnJLRu
+        +FlcAFbGvhdNU62ztD6KWE8apk40Zm6ZgC+yYQRpuTxEaTuMxuCtv29L3H+5xtc/x7Rc/4zrfHbV
+        OWxfCOEfHOqOwxtwxtq7KEkfIJwhq498QPC0PIDguyMBonmzcdZv9KR23EM6SnugPNi+N7UhIKHR
+        gWDl8vNbFZwKZy9c52r3HcrEog+mxLolY5qvQncO2ErwuBdUtLREeT4AnH+4YSEddCHGICp9CPo3
+        0erBp6ODZvviUm42MZ2gRWrYdyyAjLi1WzYbcuyRcuqgqzXFn/6O+SrA/g1/8klL2mP0QIJzTVF0
+        WakV3ycs53TkcdHPjvXNcYorT/1Q6l9JIAL1KeTdmAMVCFCLuxK/no+6/vlFe6djd4pK3W1vZb4y
+        mlcv2x8v38cprTta9sk9pkF/Ow3+uwfIGaSaoryn1uv1maZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlbkeq1qlpIzWAEocMt9L6aCYDAkAYVVT46n9ns9CZYKFFYIMWL78P38uZwE8C+o/tVyZU1NmDMB
+        dCyOr+LJXEO+1PJ84mzW8jJBfZemqKJGWXtnRe9g3eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z87w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5IN7wGx4v3ndX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh91ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse568LegytvLh/0pUatu2DqN+R
+        0NW6VlbNWlktayW1ystlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiAfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yt9PwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnV6/L9Xod4IoiV2v1d2TgvNdvYXdHUf+nWXRN+QCDaTR0ll5OW1e7y4FSdwHkC9Cc
+        BAMNI0Yde42IJ+N5Py5oiwJKCX/pY7/T2W+11kzOh5cdnjWSEk2L43BRmlcKwkTpe7dLNu4idgVe
+        ai2BdmkrbkQmzBHvMOYKfyQgG/PrYBI5IVtk2flVLmD1c0xC6dSz+NOd5C1PSWyu8lumeHcyI9Vx
+        V776uBGtZdAtOmTE3QjXM/Ce5xAf1sCb8EYGf0Rtzycb4ZUMvPnriUSGUUDTRjPT+CuY2PM2jlXN
+        ihr12hvBtQy4cbKZsnoG+4G5YLBAOpDWk/bcIEq2Ax3CsP4df6Uzac4arNe57EpT3wO3mcwBWRsd
+        +ZQe9lqbPSBrpath5IbRZnzWSj2HWLd8WrO5S9ZSHf5eNLn9So+s+S7oxAupNGIOlYhlxStkgcpa
+        rQlGPu9tHjVruKPLblqN2Ch1eGVJcgsu8JUIUZdCxGWA9EbCiEw8ChCgrI06LLDKacNSxMR9JJuG
+        1EqylwAZS5cQG/TSlcsesvvzAogHCLjfx14vxSzFCYGM43teCFN/TrlIPAKVJfqi20yra6hzXwXU
+        lybEJWM6oeKxggDXlyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PT1ej3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+jpAW
+        j45SUH3VNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Uknfr54AsY/zDjHiNIpqWOXPHwPlSjjWWUsFZ
+        Jw0oI0vZ2UnKjGGupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn88IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqRf+3yF3+oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsrqks
+        BcR9j3+DIjV/7Z1u7qY+v96CdtOMcNtlzp4y+6TCdD6e0ysl87m49/lz8JPMD3urTcVf9kqi4YW9
+        cpZPH/lfSRxlcVxZSSmK8har/7gG+bInl81OBvrXWD7lbIskfOzologXhdMI25VKxD5P279V8JA+
+        hCUvvIFbHC++z6ZG4q7bLPVjNf/Ka/2ELKFkLkGXcetWm5EOz+ZiKD6bepXtSJhflfkBEzCu3nZ/
+        6kktVZ4XmXdRlybqr6FyEnNNKdUg+co1paa8ICenb2xya7+QDt8LPctzMEoWTdvtHltTOItsfmTW
+        ZPoaJsveKhARL6hFglD6B19a0SluQETSGC0e9McjQPHt3kvhExJYaCLiJy1/mq3RgNIBcQIPVZXC
+        VFY07drNa8Pzy42PLvM2+GC2O+J6nnr8NZYOtVnEv9s+ZmMuXRPGYzyzvYnDBZ4T5cRKb9G0S5us
+        WeEfXW8aMOxhYm/RtKPCR24QTXlKjd98uaOuLd6+XtXkaoHj7770U9wPeUAXwkrulrnj8oj5QTgY
+        eZGLLW2WP9g84lhYZlHclf4U85s5MeKnCLbj5ZT86WlZd/u7qV/O+4ZlmZ6uzzyxLr8gfAdM2ut3
+        L4ovuu+ln7P8wK93OHSbBcGK6n+ZdcE8bviPbHydmF6Yy8Z68juj/H56xB7ExK1hheyOihlcEPkj
+        Yr3OHC4k43Kv9ZsE1qJjz0cnBcvN3/Dkj49wR5yIanVoFaWV2uxu5ry6hoJrKFg1MbBqomBdxcC6
+        io9cQUeu4CMb6MgGriAK1nCwjrKh42zoKBs6zoZWRcWo4iOjYB0HayjPGs4zql+OegoqhIILgYI1
+        HIz6J+6eGBIForbATYE6BO4PKmoIFTeEoaMD6zhhGkqYhouBsqvi7OpoKOl4KBnoyAY+soHKbOAy
+        a6gYGi4GTgbOBcqymsMy6hZaToiiI2v4yAYadQYedejA+Lgq6p1qTrrCB84ZGQ07FY87HbWInmMS
+        lAsV5wJ1C9wr0ODDY09F5VVxeXWUCR1nQkVTJtSuP/oJaCjfiB9RSkquF75skmDXRrXR0KRyVR1Z
+        smEpdbluaZpsDY06taldMYwKMnnYsts3TCrEDxUKjQf1ajZXrDS8DRlqnShVRTbsqgZamZo8NEa6
+        bKuaVdMpMWyRytfJ2Krb95FRq2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEKJKVNFGcrGcETkGhma
+        smINK9WKYVojy0QU27Lb91nRNHOsyBveggx1VFMN066ALnUeqLoiE8PUZcuihqmpo7phYvG9Zbdv
+        JUP8wGesuP0IDcxaZQVBvAU9ll2jpAaK6RUT9FQ1U64T/qOAtFrVVKIpqlFH6Nmy23emv3pO9qu/
+        EhXX/Cdgw/Q3H306AdLF6h5qnp6f/w8uCax9XVYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -1464,12 +1754,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:54:28 GMT
+      - Thu, 21 Nov 2019 15:41:14 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1479,9 +1769,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - ce01a173f24180805fc30806f240ef6c
+      - 6d65052854f447681aa679a2981cdcf0
     status:
       code: 200
       message: OK
@@ -1497,76 +1787,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPfAJuXWQJkkt1AOJDQvdOd5QhbEG2MzdgySTrkv29J
-        tkEEQ0jn0sxMHoisKslVX12ski8POeKN/Fz1IeffejjIVXPIcwJ8+8/QuSn6wThXyHlogqGf4pAO
-        Qht5gxG5o1GAGckfUBSMMc1VR8gNcSE38l0HBwPi5Kpe5LqFnO17NPDdXJUGEdCjEKhTHExIGBLf
-        C3NVVTMLudC+xk7k4kEUsaFwssnURRTLeGgjG+m6rOmWLlcQLsumOipBSy05mmZaqm1aumLYCBkl
-        s6IgtWyAYNghdIBc17/FzkI2JjzoOEgUuuxJddePHKkX98Owqe8S+x5oRygkttTG9NYPbjgDUMNr
-        FOCFYv7wf9imXFNVVQo5isYJGGHKgmwX2l8ecisKA2+CdczlkBB0vU/EivvE9hJLej9lgjt4hCKX
-        5h4LT2bmUCZzq08n3mjYtX52Qm1xNmax3ONVIXfth9T2I49yFRJDmYZljTTFli0HGbJhmRXZBJvJ
-        JcVBFnYsyyjpDDqKaAQS5qYoConHzsJdKTnHNMwxABPwkpZWnEZD1ixS7KGhi0NsRwGh90XbnwA/
-        cmkK+ACEXNp5ahMZJpejqeujVfMPQJAAFFBLZV2vmKYCMFEyAddGk+myu1QGdVF4M1wMhiMUgVPR
-        ABF3zaOSWZmVHoGXhNQP7rnlk3bsJoqpWYqe2miQ4GwHGFEw4MABh18VzUUQcxPfISNiZ/EwOV9m
-        CBHwTKPEcRhwG29AOHUG5tvQnEUuaIOGxCWU4KQTTDQVeNihS5Bn4/h4RFyKgzg4Ejdk3EVQpZAD
-        PBxm79Rxa2GIqXTayAnZ5CHVBEPHPR80xndw/EWRLSSPrh7MR/lgcWA8yvkH/XFxrGqPB4WdWfM/
-        iVKlZ1JUTTdK5YqMhrYj45GiyqxDLldMi3WxHojRnA8xisAJmLY5/DsLPP47QdS+ZkdxA1AZB340
-        TbUWYb3nsZ4Qpm40Jl4RgS+SYQRpuTjMhO0oGoO3/r4rcP9lGl/9HMNy9XO2zu3L1lGzy4W/c7E3
-        ptfgjOaHKInvIJwhq48C4GBpeQDBN0Nhhub1Wrtf60nNeIR0nI7IxMEJ/KkDAQlEF4KVyc8uVXDI
-        nT13tVG7VygTiz6YIvsGjfFmFToLhp0Ej0dBR0NLlGcTwPGna0LxoAMxBlEZQNC/i1Z3AR5V683u
-        hVyvZ+kEFKnmzEgIGXFnt6zX5Ngj5dRBn/bkf/p7lq8C23/gTz5tSAcEVyU41hRFlxUz/zFhuYBj
-        ExZ9ca7vjtNs5XFApf6lBCLgAEPejTFQAQA1vy/x6weZrn/ebe517E4zpe40dzJfMTOvXjQ/X3yM
-        U9ozXAzQbZYG/d00+O8BcM4h1eTlA9WyrLmmfFHUK+6O+TgkH4wCXF9349vkwP0mhKtakmElUy4k
-        R2VZVeCS+1FIheFgiEIMVc8GT+33ehKUChgqhJhj9/D9+rWYBPAvmfpXiqU1NWHNBKxj/vsmnsw0
-        ZKWWHyB3u5YXCderNM1U1ChqH6zoDOo2P9gYBaK2fc6644UKRmp/a1YPLued8/r8eH4ybzfyh92z
-        6sH58fxi/ml+GXfUgaU+v+zO6+yYx8l3jcxvCJ1m9aQgNavHa7C+cWw8j+PL4av1qwdn89q8nT+s
-        gbYn89b8DJpR9aA9781b+cM6a3Xm9fzh6aJVS1sLLF83zSZgYdZ2QYLf2jtDq++Qd2Z6UfmjJx99
-        x+zDdf3jpyD9JTloVeeXRlIVRh/GGYXnk89JOkmyyec4mUAumXfhIImblw36welH3xXD74KOJZA2
-        JJCzeSdOIWfzk/xhp8t6efOS541u/rDH8KrzjHICpDbPKEmrlrZEgN946h+arOIS51MzywCfdl1O
-        JqH5XEXzqfm0moFy7l1KueVu1cDBoR2QKdt7y9LxGts3UpsdvPHa/w1EX4CVJfiCTeoKbHuhwrqX
-        JRveA2TH+8/r+jRijsN/e1ANSrWYL9yfmnG9+HW0AXZd4mdp0+SEfa6BF9LHY59V4T1C5F13KdAM
-        EZfJkKVbolRN4NkTu/B83GwcyXwzaZPgDUQRW2C+7ZbTXu0NJz3X0XAzDiecuCeWSwROeAcYzLNh
-        ZdNc4ZSawLmrGsnQUEIBlkQXb/tSIoBEQrjM/h4RdquTE254TsXZQ98TC+wMhveDCXJvUWZp0EzZ
-        pKN7qbVg2y+Dxkp4OAyjrFsVKzq0U64fogK/AZfczl8X9ASorHl42pFqjhOAqK9I6KqlFdWyWVSL
-        WkGtsHYRfuRlU1EKqsL+FUuwZNaMApcO3yFYt2B+A/jjtvBPa/1aBiKs+4UZVP5Sk39D8rcreTWj
-        Pu3fkGH5GdfWwKoq12RFLakfeVsDRDnKxuTowzE5ysTk6CMxCSkZD0I8w+z5hGxcWlJvSd8FHTI7
-        7V/9vEHn5Wyxyqf9D7Z+1k0t1v3h1r/48RFBvAG9BhTwbVaKP/Wki2sMyf12jwqSzVfVfb2QCou7
-        CaYo5J1Z8i+I+1xALVXYVEEJevxhqieeHFq946zk0CJ24If+iEpHketiSrzd8kSr9+T2/5OODZmh
-        1bMs2bIsYFcUuWJaH4jAea/fyLo68v4/TdE1ZRMMptHQXXk4bV3tDmOUOktGVoBuSDBAGBHsOmtA
-        PBiPh3FDWzYyIWEPfRy2WoeNxprJ2fSyy7JG0sJpc0yXrUUnB4y3XrtdsnUXscP5pcYK0z5txY3Q
-        hLj8GcaNwh9zlq35dTCJXEqWWXZxli5UPyeISme+ze7uJE95SnxzlV0y+bOTglQnHfny81ZuTeBu
-        4CFB3lZ2XWDv+S4KoAbexm8I/MfY8QO0lb0ksNd/PZXQMApxSiwLxF/BxL6/da6KKGrUa25lNgXm
-        2ul2yCyB9xPxwGChVJXWk/bCIIo4AA9h2mDGHulMyKLBeq2LjjQNfHCbyYJBtNFxgPFRr7HdA0Qr
-        XQ4jj0bb+UUr9Vxk37BlzfYhoqVa7LlodPPMCNF8XTzxKZZGxMUSsu24QuZcotXqYOTz3vZZRcMd
-        X3TS7gwbpQ6vrEhuwwmeiRB1JUQ8Apz+iBuR8FsBnEm0UYuEdjElrERMPEZyMMV2kr04k7FyCr5B
-        L1165E7cn+eM2QEC7ve510t5VuIEQcYJfJ/C0p9BzhMP5xKB7nbqabeZ6dyXIQ6kCfLQGE8wv63A
-        ma3ViITE6KZ5QkQ53URdJBER0Q7GgXzhy+y/dMwconcNacVLH6/XRWTrp736eUoQkT0mAb5Frrs4
-        hYjoEXi04/uLiNNFFHv1WqOWEkToGu0UUV3ECqBwwV+lMLblYk4RuA5/OUJa3jpKmaynpkFSeI1d
-        96l1DGXFayhkk/Eipa6g5wdUSp6tXzCIiLEXM+IahZNWMfPGgPlKjjVWUkG7lQaUIULWPk2RMcpP
-        0wCZbc/whohlv8UTTbO3PQINEdujIGKZww8gjmDdgAQ2Ed1/RZ6//dJUWsHYJuDX7OUB6Yx40d32
-        kaIFWv6QOW0Di95QEk1wHiAbOHaYV7RObYK+wfpvh1GiyTrI9aWaS7dfGkuiNU8idIvJdn7RzMel
-        9G2fZ/CtrGHQb20fIdr51LOJAzaRujic+l6YunBJtHKfBDTyv33brm5ZtPRvF9tXAmX18e3K2G3r
-        wF2LmwNl/kWFRXy8klcK5cf8wdev4U8y+zl4Ssr/clDghBeO2lA0fWZ/Bf4r898n9ZOiKO9R88c9
-        Ge/zbESzJbD+NYqmDZshCR57uhHiR3QaZe1FJWKfp/TvFZziO1rw6TVc2FjzY7YyEnfdpcCP1fwr
-        V/gJWFzJjQBdxNSdtiBdls35VGwN9SabkLCqKrKfLAHj7l13pR7UQulxmXmXfWmifo5rQ2I2lYIJ
-        yVc2FVN5QU5On9Nk1n4hHIFPfdt3syBZknbbM7ancBQ57JfYk+lbmEy8VGSI2MU2Cqn0D1ZQ4Wm2
-        ATMkjbn57f14Bmi+39MobEEC5WWG+AnlT7MhGmI8QG7oZ6qKYQHLSft28dpy13LrDctN23qwxh0x
-        Pc989vBKCzskYm9rn5Axk64O8xGW2d7F4ULfjTbESm9J2qetVVH4e8+fhiTrFmJvSdpT4SMvjKYs
-        pcbPu8yw5/Bnrp9qcrnkY0+89FO+H3JbjkL9dkO8cXFEgpAORn7kZZU2q69pHjNeKLNwtiv9KdY3
-        C2D4Bwh2w+UM/elhWXf72TQobnpzZRWeTkB8Xpd3Edv3kg76nW7+Rde99CWWH/jODmPdpSB4ovpf
-        pi5YxA37tMbzwPToRjTWk18bs+vpMbnjC7eaTckM8xVcGAUjZL/NGo6icVGvlEwVsW/slJEiGxoa
-        yZZTHsrGUDXLuqVpjm5lqLbjsO+4P8i/PDRDboQHuqoCA2+vE9a3uEJM5Wv+iYik5fn0ZWAohl4x
-        DVSWNcVRQauhIqORimUF4bKuYNXWbDsDjB2HvQ6MkpmNBfS/BxT8DBDGeMw+aFPmn5N5qncWzyuV
-        LGkbtATCu1hcrTgVq6TK2NAM2cBYlZFpYFkdYWWkWRpWnFGWxXcb9jowKqVyNhiM8P42r5j8/NuN
-        njC9TlFD1bMVZYT3ULSs4xLCCMtWuQLZy9SGsmk6SDZsfWQM7WHFUY0M1Xcc9jow2MfMstHglLeB
-        44p9zY2mn28K8ATm5pds6Hl4fPw//zosBShOAAA=
+        H4sIAAAAAAAAA+VcbVfiSBb+Kznsnj0yQzBvBPDLLAKO7ohyROne7XY5RVJgrSFh8uJLi/99b1US
+        CHBDY7fazIwfYqXqqcq9z31JVSXhqcDckVc4eCp49y71CwcF4to+vf9nYN+WPX9cKBVcMqFQH9Ig
+        HAQWcQcj9hBGPuVN3iAk/piGhYMRcQJaKow8x6b+gNmFAzdynFLB8tzQ95zCQehH0B4F0Dql/oQF
+        AfPcoHCgarVSIbBuqB05dBBFvCtcbDJ1SEhlgwxNlQyHcsVSTVnV6kRWqWbLpKrULMWujHTVMEfV
+        WsVUq5W6qZjKqAqCUZuFA+I43j2157Jx4UHHQaLQVU9qOl5kS724HrpNPYdZj9B2SAJmSWc0vPf8
+        WwGA1uCG+HSumDf8H7VCoamm1kuFkIwTMoIUQiwHyp+eCksKK6WU6xhlswB0fUzEiuuy5QWX4eOU
+        C27TEYmcsPBcWhlZUJmMra4OnGvYtXqh0vxq3GKF5+tS4cYLQsuL3FCokBjKNKoWqdZrsk1VTTZq
+        VJOHI10Dc1V1XTN0VakonLqQhBFIWJiSKGAuv4pwpeQa06DACUzIS0paeRoNebEcUpcMHRpQK/JZ
+        +Fi2vAngiROmhA9AyIWdpxaTYXA5mjoeWTb/AATxQQG1UjX0ilKtVuG6bAKuTSbTeXXN1EFdEtwO
+        553hjETgVKFPmLPmUcmo3ErPgGVB6PmPwvJJWbiJqiqmXldTGw0Sni2fkhAMOLDB4ZdFcwjE3MSz
+        2YhZCEbI+TJDZAlHjRLHoS9snMNw6gzct6F4FzmgDRkyh4WMJpVgomkGw08dRlyLxucj5oTUj4Mj
+        cUOOLoMqpQLwYXN7p47bCAIaSietQiabPKWaUKh4FJ3G9AHOPyky5IjR9VPtWd6bnxjPcvFJf56f
+        q9rzXmlraPGnrFTplRRV042KWZXJ0LJlOlJUmVfIZrVW51W8BmK04EGMEnACrm2B/s4DTxwnJLRu
+        +FlcAFbGvhdNU62ztD6KWE8apk40Zm6ZgC+yYQRpuTxEaTuMxuCtv29L3H+5xtc/x7Rc/4zrfHbV
+        OWxfCOEfHOqOwxtwxtq7KEkfIJwhq498QPC0PIDguyMBonmzcdZv9KR23EM6SnugPNi+N7UhIKHR
+        gWDl8vNbFZwKZy9c52r3HcrEog+mxLolY5qvQncO2ErwuBdUtLREeT4AnH+4YSEddCHGICp9CPo3
+        0erBp6ODZvviUm42MZ2gRWrYdyyAjLi1WzYbcuyRcuqgqzXFn/6O+SrA/g1/8klL2mP0QIJzTVF0
+        WakV3ycs53TkcdHPjvXNcYorT/1Q6l9JIAL1KeTdmAMVCFCLuxK/no+6/vlFe6djd4pK3W1vZb4y
+        mlcv2x8v38cprTta9sk9pkF/Ow3+uwfIGaSaoryn1uv1maZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlbkeq1qlpIzWAEocMt9L6aCYDAkAYVVT46n9ns9CZYKFFYIMWL78P38uZwE8C+o/tVyZU1NmDMB
+        dCyOr+LJXEO+1PJ84mzW8jJBfZemqKJGWXtnRe9g3eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z87w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5IN7wGx4v3ndX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh91ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse568LegytvLh/0pUatu2DqN+R
+        0NW6VlbNWlktayW1ystlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiAfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yt9PwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnV6/L9Xod4IoiV2v1d2TgvNdvYXdHUf+nWXRN+QCDaTR0ll5OW1e7y4FSdwHkC9Cc
+        BAMNI0Yde42IJ+N5Py5oiwJKCX/pY7/T2W+11kzOh5cdnjWSEk2L43BRmlcKwkTpe7dLNu4idgVe
+        ai2BdmkrbkQmzBHvMOYKfyQgG/PrYBI5IVtk2flVLmD1c0xC6dSz+NOd5C1PSWyu8lumeHcyI9Vx
+        V776uBGtZdAtOmTE3QjXM/Ce5xAf1sCb8EYGf0Rtzycb4ZUMvPnriUSGUUDTRjPT+CuY2PM2jlXN
+        ihr12hvBtQy4cbKZsnoG+4G5YLBAOpDWk/bcIEq2Ax3CsP4df6Uzac4arNe57EpT3wO3mcwBWRsd
+        +ZQe9lqbPSBrpath5IbRZnzWSj2HWLd8WrO5S9ZSHf5eNLn9So+s+S7oxAupNGIOlYhlxStkgcpa
+        rQlGPu9tHjVruKPLblqN2Ch1eGVJcgsu8JUIUZdCxGWA9EbCiEw8ChCgrI06LLDKacNSxMR9JJuG
+        1EqylwAZS5cQG/TSlcsesvvzAogHCLjfx14vxSzFCYGM43teCFN/TrlIPAKVJfqi20yra6hzXwXU
+        lybEJWM6oeKxggDXlyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PT1ej3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+jpAW
+        j45SUH3VNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Uknfr54AsY/zDjHiNIpqWOXPHwPlSjjWWUsFZ
+        Jw0oI0vZ2UnKjGGupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn88IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqRf+3yF3+oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsrqks
+        BcR9j3+DIjV/7Z1u7qY+v96CdtOMcNtlzp4y+6TCdD6e0ysl87m49/lz8JPMD3urTcVf9kqi4YW9
+        cpZPH/lfSRxlcVxZSSmK8har/7gG+bInl81OBvrXWD7lbIskfOzologXhdMI25VKxD5P279V8JA+
+        hCUvvIFbHC++z6ZG4q7bLPVjNf/Ka/2ELKFkLkGXcetWm5EOz+ZiKD6bepXtSJhflfkBEzCu3nZ/
+        6kktVZ4XmXdRlybqr6FyEnNNKdUg+co1paa8ICenb2xya7+QDt8LPctzMEoWTdvtHltTOItsfmTW
+        ZPoaJsveKhARL6hFglD6B19a0SluQETSGC0e9McjQPHt3kvhExJYaCLiJy1/mq3RgNIBcQIPVZXC
+        VFY07drNa8Pzy42PLvM2+GC2O+J6nnr8NZYOtVnEv9s+ZmMuXRPGYzyzvYnDBZ4T5cRKb9G0S5us
+        WeEfXW8aMOxhYm/RtKPCR24QTXlKjd98uaOuLd6+XtXkaoHj7770U9wPeUAXwkrulrnj8oj5QTgY
+        eZGLLW2WP9g84lhYZlHclf4U85s5MeKnCLbj5ZT86WlZd/u7qV/O+4ZlmZ6uzzyxLr8gfAdM2ut3
+        L4ovuu+ln7P8wK93OHSbBcGK6n+ZdcE8bviPbHydmF6Yy8Z68juj/H56xB7ExK1hheyOihlcEPkj
+        Yr3OHC4k43Kv9ZsE1qJjz0cnBcvN3/Dkj49wR5yIanVoFaWV2uxu5ry6hoJrKFg1MbBqomBdxcC6
+        io9cQUeu4CMb6MgGriAK1nCwjrKh42zoKBs6zoZWRcWo4iOjYB0HayjPGs4zql+OegoqhIILgYI1
+        HIz6J+6eGBIForbATYE6BO4PKmoIFTeEoaMD6zhhGkqYhouBsqvi7OpoKOl4KBnoyAY+soHKbOAy
+        a6gYGi4GTgbOBcqymsMy6hZaToiiI2v4yAYadQYedejA+Lgq6p1qTrrCB84ZGQ07FY87HbWInmMS
+        lAsV5wJ1C9wr0ODDY09F5VVxeXWUCR1nQkVTJtSuP/oJaCjfiB9RSkquF75skmDXRrXR0KRyVR1Z
+        smEpdbluaZpsDY06taldMYwKMnnYsts3TCrEDxUKjQf1ajZXrDS8DRlqnShVRTbsqgZamZo8NEa6
+        bKuaVdMpMWyRytfJ2Krb95FRq2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEKJKVNFGcrGcETkGhma
+        smINK9WKYVojy0QU27Lb91nRNHOsyBveggx1VFMN066ALnUeqLoiE8PUZcuihqmpo7phYvG9Zbdv
+        JUP8wGesuP0IDcxaZQVBvAU9ll2jpAaK6RUT9FQ1U64T/qOAtFrVVKIpqlFH6Nmy23emv3pO9qu/
+        EhXX/Cdgw/Q3H306AdLF6h5qnp6f/w8uCax9XVYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -1577,12 +1872,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:54:39 GMT
+      - Thu, 21 Nov 2019 15:41:25 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1592,9 +1887,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 26ef1ec07bf359331c78a27ff6c129e8
+      - 5ed390aae8ea3060850f54b6054d7ff4
     status:
       code: 200
       message: OK
@@ -1610,76 +1905,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPfAJuXWQJkkt1AOJDQvdOd5QhbEG2MzdgySTrkv29J
-        tkEEQ0jn0sxMHoisKslVX12ski8POeKN/Fz1IeffejjIVXPIcwJ8+8/QuSn6wThXyHlogqGf4pAO
-        Qht5gxG5o1GAGckfUBSMMc1VR8gNcSE38l0HBwPi5Kpe5LqFnO17NPDdXJUGEdCjEKhTHExIGBLf
-        C3NVVTMLudC+xk7k4kEUsaFwssnURRTLeGgjG+m6rOmWLlcQLsumOipBSy05mmZaqm1aumLYCBkl
-        s6IgtWyAYNghdIBc17/FzkI2JjzoOEgUuuxJddePHKkX98Owqe8S+x5oRygkttTG9NYPbjgDUMNr
-        FOCFYv7wf9imXFNVVQo5isYJGGHKgmwX2l8ecisKA2+CdczlkBB0vU/EivvE9hJLej9lgjt4hCKX
-        5h4LT2bmUCZzq08n3mjYtX52Qm1xNmax3ONVIXfth9T2I49yFRJDmYZljTTFli0HGbJhmRXZBJvJ
-        JcVBFnYsyyjpDDqKaAQS5qYI5nNysTEGySmmYY7hl2CXtLTiNBqyZpFiDw1dHGI7Cgi9L9r+BPiR
-        S1O8B3zO1MxTm8gwuRxNXR+tWn8AcgQgv1oq63rFNBVAiZIJeDaaTJfdZgm0ReHNcDEYjlAEPkUD
-        RNw1h0pmZUZ6BF4SUj+454ZP2rGXKKZmKXpqokECsx1gRMF+Awf8fVU0F0HITXyHjIidxcPkfJkd
-        RMCzbBJHYcAtvAHg1BWYZ0NzFrmgDBoSl1CCk06w0FTgYYcuQZ6N4+MRcSkO4tBInJBxFwkTAuBw
-        mLlTt62FIabSaSMn5JKHVBEMHfd80BjfwfEXRbaQPLp6MB/lg8WB8SjnH/THxbGqPR4UdmbN/yRK
-        lZ5JUTXdKJUrMhrajoxHiiqzDrlcMS3WxXogQnM+RCgCH2Da5vDvLOz47wRR+5odxQ1AZRz40TTV
-        WoT1nkd6Qpi60Zh4RQSuSIYRJOXiMBO2o2gMzvr7rsD9l2l89XMMy9XP2Tq3L1tHzS4X/s7F3phe
-        gy+aH6IkvoNohpw+CoCDJeUBxN4MhRma12vtfq0nNeMR0nE6IhMHJ/CnDsQjEF2IVSY/u1DBIXf2
-        3NVG7V6hTCz6YIrsGzTGm1XoLBh2EjweBR0NLVGeTQDHn64JxYMOxBhEZQAx/y5a3QV4VK03uxdy
-        vZ6lE1CkmjMjISTEnd2yXpNjj5RTB33ak//p71m+Cmz/gT/5tCEdEFyV4FhTFF1WzPzHhOUCjk1Y
-        9MW5vjtOs5XHAZX6lxKIgAMMeTfGQAUA1Py+xK8fZLr+ebe517E7zZS609zJfMXMvHrR/HzxMU5p
-        z3AxQLdZGvR30+C/B8A5h1STlw9Uy7LmmvJFUa+4O+bjkHwwCnB93Y1vkwP3mxCuakmGhUy5kByV
-        ZVWBS+5HIRWGgyEKMdQ8Gzy13+tJUChgqA9ijt3D9+vXYhLAv2TqXymW1tSENROwjvnvm3gy05AV
-        Wn6A3O1aXiRcr9I0U1GjqH2wojOo2vxgYxSI2vY5644XKhip/a1ZPbicd87r8+P5ybzdyB92z6oH
-        58fzi/mn+WXcUQeW+vyyO6+zYx4n3zUyvyF0mtWTgtSsHq/B+sax8TyOL4ev1q8enM1r83b+sAba
-        nsxb8zNoRtWD9rw3b+UP66zVmdfzh6eLVi1tLbB83TSbgIVZ2wUJfmvvDK2+Q96Z6UXlj5589B2z
-        D9f1j5+C9JfkoFWdXxpJVRh9GGcUnk8+J+kkySaf42QCuWTehYMkbl426AenH31XDL8LOpZA2pBA
-        zuadOIWczU/yh50u6+XNS543uvnDHsOrzjPKCZDaPKMkrVraEgF+46l/aLKKS5xPzSwDfNp1OZmE
-        5nMVzafm02oGyrl3KeWWu1UDB4d2QKZs6y1Lx2ts30htdvDGa/83EH0BVpbgCzapK7DthQrrXpZs
-        dw+QHe8+r+vTiDkO/+1BNSjVYr5wf2rG9eLX0QbYdYmfpU2TE/a5Bl5IH499VoX3CJF33aVAM0Rc
-        JkOWbolSNYFnT+zC83GzcSTzzaRNgjcQRWyB+bZbTnu1N5z0XEfDzTiccOKeWC4ROOEdYDDPhpVN
-        c4VTagLnrmokQ0MJBVgSXbztS4kAEgnhMvt7RAJ+QwgINzyn4uyh74kFdgbD+8EEubcoszRopmzS
-        0b3UWrDtl0FjJTwchlHWrYoVHdop1w9Rgd+AS27mrwt6AlTWPDztSDXHCUDUVyR01dKKatksqkWt
-        oFZYuwg/8rKpKAVVYf+KJVgya0aBS4fvEKxbML//+3Fb+Ke1fi0DEdb9wgwqf6nJvyH525W8mlGf
-        9m/IsPyMa2tgVZVrsqKW1I+8rQGiHGVjcvThmBxlYnL0kZiElIwHIZ5h9nhCNi4tqbek74IOmZ32
-        r37eoPNytljl0/4HWz/rphbr/nDrX/z4iCDegF4DCvg2K8WfetLFNYbkfrtHBcnmq+q+XkiFxd0E
-        UxTyziz5F8R9LqCWKmyqoAQ9/jDVE08Ord5xVnJoETvwQ39EpaPIdTEl3m55otV7cvv/SceGzNDq
-        WZZsWRawK4pcMa0PROC8129kXR15/5+m6JqyCQbTaOiuPJu2rnaHMUqdJSMrQDckGCCMCHadNSAe
-        jMfDuKEtG5mQsIc+Dlutw0ZjzeRsetllWSNp4bQ5psvWopMDxluv3S7ZuovY4fxSY4Vpn7biRmhC
-        XP4I40bhjznL1vw6mEQuJcssuzhLF6qfE0SlM99md3eShzwlvrnKLpn80UlBqpOOfPl5K7cmcDfw
-        kCBvK7susPd8FwVQA2/jNwT+Y+z4AdrKXhLY67+eSmgYhTgllgXir2Bi3986V0UUNeo1tzKbAnPt
-        dDtklsD7iXhgsFCqSutJe2EQRRyAhzBtMGOPdCZk0WC91kVHmgY+uM1kwSDa6DjA+KjX2O4BopUu
-        h5FHo+38opV6LrJv2LJm+xDRUi32VDS6eWaEaL4unvgUSyPiYgnZdlwhcy7RanUw8nlv+6yi4Y4v
-        Oml3ho1Sh1dWJLfhBM9EiLoSIh4BTn/EjUj4rQDOJNqoRUK7mBJWIiYeIzmYYjvJXpzJWDkF36CX
-        Lj1yJ+7Pc8bsAAH3+9zrpTwrcYIg4wS+T2HpzyDniYdziUB3O/W028x07ssQB9IEeWiMJ5jfVuDM
-        1mpEQmJ00zwhopxuoi6SiIhoB+NAvvBl9l86Zg7Ru4a04qUP1+sisvXTXv08JYjIHpMA3yLXXZxC
-        RPQIPNrx/UXE6SKKvXqtUUsJInSNdoqoLmIFULjgr1IY23Ixpwhch78aIS1vHaVM1lPTICm8xq77
-        1DqGsuI1FLLJeJFSV9DzAyolj9YvGETE2GsZcY3CSauYeWPAfCXHGiupoN1KA8oQIWufpsgY5adp
-        gMy2Z3hDxLLf4omm2dsegYaI7VEQsczhBxBHsG5AApuI7r8iz99+aSqtYGwT8Gv27oB0RrzobvtI
-        0QItf8ictoFFbyiJJjgPkA0cO8wrWqc2Qd9g/bfDKNFkHeT6Us2l2y+NJdGaJxG6xWQ7v2jm41L6
-        rs8z+FbWMOi3to8Q7Xzq2cQBm0hdHE59L0xduCRauU8CGvnfvm1Xtyxa+reL7SuBsvr4dmXstnXg
-        rsXNgTL/osIiPl7JK4XyY/7g69fwJ5n9HDwl5X85KHDCC0dtKJo+s78C/5X575P6SVGU96j5456M
-        13k2otkSWP8aRdOGzZAEjz3dCPEjOo2y9qISsc9T+vcKTvEdLfj0Gi5srPkxWxmJu+5S4Mdq/pUr
-        /AQsruRGgC5i6k5bkC7L5nwqtoZ6k01IWFUV2U+WgHH3rrtSD2qh9LjMvMu+NFE/x7UhMZtKwYTk
-        K5uKqbwgJ6fPaTJrvxCOwKe+7btZkCxJu+0Z21M4ihz2S+zJ9C1MJl4qMkTsYhuFVPoHK6jwNNuA
-        GZLG3Pz2fjwDNN/vaRS2IIHyMkP8hPKn2RANMR4gN/QzVcWwgOWkfbt4bblrufWG5aZtPVjjjpie
-        Zz57eKWFHRKxl7VPyJhJV4f5CMts7+Jwoe9GG2KltyTt09aqKPy9509DknULsbck7anwkRdGU5ZS
-        4+ddZthz+DPXTzW5XPKxJ176Kd8PuS1HoX67Id64OCJBSAcjP/KySpvV1zSPGS+UWTjblf4U65sF
-        MPz7A7vhcob+9LCsu/1sGhQ3vbmyCk8nID6vy7uI7XtJB/1ON/+i6176EssPfGeHse5SEDxR/S9T
-        Fyzihn1Z43lgenQjGuvJr43Z9fSY3PGFW82mZIb5Ci6MghGy32YNR9G4qFdKporYF3bKSJENDY1k
-        yykPZWOommXd0jRHtzJU23HYd9wf5N8dmiE3wgNdVYGBt9cJ61tcIabyNf9ERNLyfPoyMBRDr5gG
-        Ksua4qig1VCR0UjFsoJwWVewamu2nQHGjsNeB0bJzMYC+t8DCn4GCGM8Zt+zKfOvyTzVO4vnlUqW
-        tA1aAuFdLK5WnIpVUmVsaIZsYKzKyDSwrI6wMtIsDSvOKMviuw17HRiVUjkbDEZ4f5tXTH7+7UZP
-        mF6nqKHq2YoywnsoWtZxCWGEZatcgexlakPZNB0kG7Y+Mob2sOKoRobqOw57HRjsU2bZaHDK28Bx
-        xb7lRtPPNwV4AnPzSzb0PDw+/h+9UbHyJk4AAA==
+        H4sIAAAAAAAAA+VcbVfiSBb+Kznsnj0yQzBvBPDLLAKO7ohyROne7XY5RVJgrSFh8uJLi/99b1US
+        CHBDY7fazIwfYqXqqcq9z31JVSXhqcDckVc4eCp49y71CwcF4to+vf9nYN+WPX9cKBVcMqFQH9Ig
+        HAQWcQcj9hBGPuVN3iAk/piGhYMRcQJaKow8x6b+gNmFAzdynFLB8tzQ95zCQehH0B4F0Dql/oQF
+        AfPcoHCgarVSIbBuqB05dBBFvCtcbDJ1SEhlgwxNlQyHcsVSTVnV6kRWqWbLpKrULMWujHTVMEfV
+        WsVUq5W6qZjKqAqCUZuFA+I43j2157Jx4UHHQaLQVU9qOl5kS724HrpNPYdZj9B2SAJmSWc0vPf8
+        WwGA1uCG+HSumDf8H7VCoamm1kuFkIwTMoIUQiwHyp+eCksKK6WU6xhlswB0fUzEiuuy5QWX4eOU
+        C27TEYmcsPBcWhlZUJmMra4OnGvYtXqh0vxq3GKF5+tS4cYLQsuL3FCokBjKNKoWqdZrsk1VTTZq
+        VJOHI10Dc1V1XTN0VakonLqQhBFIWJiSKGAuv4pwpeQa06DACUzIS0paeRoNebEcUpcMHRpQK/JZ
+        +Fi2vAngiROmhA9AyIWdpxaTYXA5mjoeWTb/AATxQQG1UjX0ilKtVuG6bAKuTSbTeXXN1EFdEtwO
+        553hjETgVKFPmLPmUcmo3ErPgGVB6PmPwvJJWbiJqiqmXldTGw0Sni2fkhAMOLDB4ZdFcwjE3MSz
+        2YhZCEbI+TJDZAlHjRLHoS9snMNw6gzct6F4FzmgDRkyh4WMJpVgomkGw08dRlyLxucj5oTUj4Mj
+        cUOOLoMqpQLwYXN7p47bCAIaSietQiabPKWaUKh4FJ3G9AHOPyky5IjR9VPtWd6bnxjPcvFJf56f
+        q9rzXmlraPGnrFTplRRV042KWZXJ0LJlOlJUmVfIZrVW51W8BmK04EGMEnACrm2B/s4DTxwnJLRu
+        +FlcAFbGvhdNU62ztD6KWE8apk40Zm6ZgC+yYQRpuTxEaTuMxuCtv29L3H+5xtc/x7Rc/4zrfHbV
+        OWxfCOEfHOqOwxtwxtq7KEkfIJwhq498QPC0PIDguyMBonmzcdZv9KR23EM6SnugPNi+N7UhIKHR
+        gWDl8vNbFZwKZy9c52r3HcrEog+mxLolY5qvQncO2ErwuBdUtLREeT4AnH+4YSEddCHGICp9CPo3
+        0erBp6ODZvviUm42MZ2gRWrYdyyAjLi1WzYbcuyRcuqgqzXFn/6O+SrA/g1/8klL2mP0QIJzTVF0
+        WakV3ycs53TkcdHPjvXNcYorT/1Q6l9JIAL1KeTdmAMVCFCLuxK/no+6/vlFe6djd4pK3W1vZb4y
+        mlcv2x8v38cprTta9sk9pkF/Ow3+uwfIGaSaoryn1uv1maZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlbkeq1qlpIzWAEocMt9L6aCYDAkAYVVT46n9ns9CZYKFFYIMWL78P38uZwE8C+o/tVyZU1NmDMB
+        dCyOr+LJXEO+1PJ84mzW8jJBfZemqKJGWXtnRe9g3eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z87w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5IN7wGx4v3ndX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh91ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse568LegytvLh/0pUatu2DqN+R
+        0NW6VlbNWlktayW1ystlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiAfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yt9PwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnV6/L9Xod4IoiV2v1d2TgvNdvYXdHUf+nWXRN+QCDaTR0ll5OW1e7y4FSdwHkC9Cc
+        BAMNI0Yde42IJ+N5Py5oiwJKCX/pY7/T2W+11kzOh5cdnjWSEk2L43BRmlcKwkTpe7dLNu4idgVe
+        ai2BdmkrbkQmzBHvMOYKfyQgG/PrYBI5IVtk2flVLmD1c0xC6dSz+NOd5C1PSWyu8lumeHcyI9Vx
+        V776uBGtZdAtOmTE3QjXM/Ce5xAf1sCb8EYGf0Rtzycb4ZUMvPnriUSGUUDTRjPT+CuY2PM2jlXN
+        ihr12hvBtQy4cbKZsnoG+4G5YLBAOpDWk/bcIEq2Ax3CsP4df6Uzac4arNe57EpT3wO3mcwBWRsd
+        +ZQe9lqbPSBrpath5IbRZnzWSj2HWLd8WrO5S9ZSHf5eNLn9So+s+S7oxAupNGIOlYhlxStkgcpa
+        rQlGPu9tHjVruKPLblqN2Ch1eGVJcgsu8JUIUZdCxGWA9EbCiEw8ChCgrI06LLDKacNSxMR9JJuG
+        1EqylwAZS5cQG/TSlcsesvvzAogHCLjfx14vxSzFCYGM43teCFN/TrlIPAKVJfqi20yra6hzXwXU
+        lybEJWM6oeKxggDXlyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PT1ej3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+jpAW
+        j45SUH3VNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Uknfr54AsY/zDjHiNIpqWOXPHwPlSjjWWUsFZ
+        Jw0oI0vZ2UnKjGGupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn88IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqRf+3yF3+oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsrqks
+        BcR9j3+DIjV/7Z1u7qY+v96CdtOMcNtlzp4y+6TCdD6e0ysl87m49/lz8JPMD3urTcVf9kqi4YW9
+        cpZPH/lfSRxlcVxZSSmK8har/7gG+bInl81OBvrXWD7lbIskfOzologXhdMI25VKxD5P279V8JA+
+        hCUvvIFbHC++z6ZG4q7bLPVjNf/Ka/2ELKFkLkGXcetWm5EOz+ZiKD6bepXtSJhflfkBEzCu3nZ/
+        6kktVZ4XmXdRlybqr6FyEnNNKdUg+co1paa8ICenb2xya7+QDt8LPctzMEoWTdvtHltTOItsfmTW
+        ZPoaJsveKhARL6hFglD6B19a0SluQETSGC0e9McjQPHt3kvhExJYaCLiJy1/mq3RgNIBcQIPVZXC
+        VFY07drNa8Pzy42PLvM2+GC2O+J6nnr8NZYOtVnEv9s+ZmMuXRPGYzyzvYnDBZ4T5cRKb9G0S5us
+        WeEfXW8aMOxhYm/RtKPCR24QTXlKjd98uaOuLd6+XtXkaoHj7770U9wPeUAXwkrulrnj8oj5QTgY
+        eZGLLW2WP9g84lhYZlHclf4U85s5MeKnCLbj5ZT86WlZd/u7qV/O+4ZlmZ6uzzyxLr8gfAdM2ut3
+        L4ovuu+ln7P8wK93OHSbBcGK6n+ZdcE8bviPbHydmF6Yy8Z68juj/H56xB7ExK1hheyOihlcEPkj
+        Yr3OHC4k43Kv9ZsE1qJjz0cnBcvN3/Dkj49wR5yIanVoFaWV2uxu5ry6hoJrKFg1MbBqomBdxcC6
+        io9cQUeu4CMb6MgGriAK1nCwjrKh42zoKBs6zoZWRcWo4iOjYB0HayjPGs4zql+OegoqhIILgYI1
+        HIz6J+6eGBIForbATYE6BO4PKmoIFTeEoaMD6zhhGkqYhouBsqvi7OpoKOl4KBnoyAY+soHKbOAy
+        a6gYGi4GTgbOBcqymsMy6hZaToiiI2v4yAYadQYedejA+Lgq6p1qTrrCB84ZGQ07FY87HbWInmMS
+        lAsV5wJ1C9wr0ODDY09F5VVxeXWUCR1nQkVTJtSuP/oJaCjfiB9RSkquF75skmDXRrXR0KRyVR1Z
+        smEpdbluaZpsDY06taldMYwKMnnYsts3TCrEDxUKjQf1ajZXrDS8DRlqnShVRTbsqgZamZo8NEa6
+        bKuaVdMpMWyRytfJ2Krb95FRq2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEKJKVNFGcrGcETkGhma
+        smINK9WKYVojy0QU27Lb91nRNHOsyBveggx1VFMN066ALnUeqLoiE8PUZcuihqmpo7phYvG9Zbdv
+        JUP8wGesuP0IDcxaZQVBvAU9ll2jpAaK6RUT9FQ1U64T/qOAtFrVVKIpqlFH6Nmy23emv3pO9qu/
+        EhXX/Cdgw/Q3H306AdLF6h5qnp6f/w8uCax9XVYAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -1690,12 +1990,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:54:50 GMT
+      - Thu, 21 Nov 2019 15:41:36 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1705,9 +2005,481 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 43e3a3dad2acdc266ebbdeae48d3b0b8
+      - 19fd292c6cc9b23e0cad92304310cd1e
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/219
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+VcbVfiSBb+Kznsnj0yQzBvBPDLLAKO7ohyROne7XY5RVJgrSFh8uJLi/99b1US
+        CHBDY7fazIwfYqXqqcq9z31JVSXhqcDckVc4eCp49y71CwcF4to+vf9nYN+WPX9cKBVcMqFQH9Ig
+        HAQWcQcj9hBGPuVN3iAk/piGhYMRcQJaKow8x6b+gNmFAzdynFLB8tzQ95zCQehH0B4F0Dql/oQF
+        AfPcoHCgarVSIbBuqB05dBBFvCtcbDJ1SEhlgwxNlQyHcsVSTVnV6kRWqWbLpKrULMWujHTVMEfV
+        WsVUq5W6qZjKqAqCUZuFA+I43j2157Jx4UHHQaLQVU9qOl5kS724HrpNPYdZj9B2SAJmSWc0vPf8
+        WwGA1uCG+HSumDf8H7VCoamm1kuFkIwTMoIUQiwHyp+eCksKK6WU6xhlswB0fUzEiuuy5QWX4eOU
+        C27TEYmcsPBcWhlZUJmMra4OnGvYtXqh0vxq3GKF5+tS4cYLQsuL3FCokBjKNKoWqdZrsk1VTTZq
+        VJOHI10Dc1V1XTN0VakonLqQhBFIWJiSKGAuv4pwpeQa06DACUzIS0paeRoNebEcUpcMHRpQK/JZ
+        +Fi2vAngiROmhA9AyIWdpxaTYXA5mjoeWTb/AATxQQG1UjX0ilKtVuG6bAKuTSbTeXXN1EFdEtwO
+        553hjETgVKFPmLPmUcmo3ErPgGVB6PmPwvJJWbiJqiqmXldTGw0Sni2fkhAMOLDB4ZdFcwjE3MSz
+        2YhZCEbI+TJDZAlHjRLHoS9snMNw6gzct6F4FzmgDRkyh4WMJpVgomkGw08dRlyLxucj5oTUj4Mj
+        cUOOLoMqpQLwYXN7p47bCAIaSietQiabPKWaUKh4FJ3G9AHOPyky5IjR9VPtWd6bnxjPcvFJf56f
+        q9rzXmlraPGnrFTplRRV042KWZXJ0LJlOlJUmVfIZrVW51W8BmK04EGMEnACrm2B/s4DTxwnJLRu
+        +FlcAFbGvhdNU62ztD6KWE8apk40Zm6ZgC+yYQRpuTxEaTuMxuCtv29L3H+5xtc/x7Rc/4zrfHbV
+        OWxfCOEfHOqOwxtwxtq7KEkfIJwhq498QPC0PIDguyMBonmzcdZv9KR23EM6SnugPNi+N7UhIKHR
+        gWDl8vNbFZwKZy9c52r3HcrEog+mxLolY5qvQncO2ErwuBdUtLREeT4AnH+4YSEddCHGICp9CPo3
+        0erBp6ODZvviUm42MZ2gRWrYdyyAjLi1WzYbcuyRcuqgqzXFn/6O+SrA/g1/8klL2mP0QIJzTVF0
+        WakV3ycs53TkcdHPjvXNcYorT/1Q6l9JIAL1KeTdmAMVCFCLuxK/no+6/vlFe6djd4pK3W1vZb4y
+        mlcv2x8v38cprTta9sk9pkF/Ow3+uwfIGaSaoryn1uv1maZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlbkeq1qlpIzWAEocMt9L6aCYDAkAYVVT46n9ns9CZYKFFYIMWL78P38uZwE8C+o/tVyZU1NmDMB
+        dCyOr+LJXEO+1PJ84mzW8jJBfZemqKJGWXtnRe9g3eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z87w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5IN7wGx4v3ndX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh91ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse568LegytvLh/0pUatu2DqN+R
+        0NW6VlbNWlktayW1ystlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiAfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yt9PwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnV6/L9Xod4IoiV2v1d2TgvNdvYXdHUf+nWXRN+QCDaTR0ll5OW1e7y4FSdwHkC9Cc
+        BAMNI0Yde42IJ+N5Py5oiwJKCX/pY7/T2W+11kzOh5cdnjWSEk2L43BRmlcKwkTpe7dLNu4idgVe
+        ai2BdmkrbkQmzBHvMOYKfyQgG/PrYBI5IVtk2flVLmD1c0xC6dSz+NOd5C1PSWyu8lumeHcyI9Vx
+        V776uBGtZdAtOmTE3QjXM/Ce5xAf1sCb8EYGf0Rtzycb4ZUMvPnriUSGUUDTRjPT+CuY2PM2jlXN
+        ihr12hvBtQy4cbKZsnoG+4G5YLBAOpDWk/bcIEq2Ax3CsP4df6Uzac4arNe57EpT3wO3mcwBWRsd
+        +ZQe9lqbPSBrpath5IbRZnzWSj2HWLd8WrO5S9ZSHf5eNLn9So+s+S7oxAupNGIOlYhlxStkgcpa
+        rQlGPu9tHjVruKPLblqN2Ch1eGVJcgsu8JUIUZdCxGWA9EbCiEw8ChCgrI06LLDKacNSxMR9JJuG
+        1EqylwAZS5cQG/TSlcsesvvzAogHCLjfx14vxSzFCYGM43teCFN/TrlIPAKVJfqi20yra6hzXwXU
+        lybEJWM6oeKxggDXlyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PT1ej3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+jpAW
+        j45SUH3VNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Uknfr54AsY/zDjHiNIpqWOXPHwPlSjjWWUsFZ
+        Jw0oI0vZ2UnKjGGupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn88IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqRf+3yF3+oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsrqks
+        BcR9j3+DIjV/7Z1u7qY+v96CdtOMcNtlzp4y+6TCdD6e0ysl87m49/lz8JPMD3urTcVf9kqi4YW9
+        cpZPH/lfSRxlcVxZSSmK8har/7gG+bInl81OBvrXWD7lbIskfOzologXhdMI25VKxD5P279V8JA+
+        hCUvvIFbHC++z6ZG4q7bLPVjNf/Ka/2ELKFkLkGXcetWm5EOz+ZiKD6bepXtSJhflfkBEzCu3nZ/
+        6kktVZ4XmXdRlybqr6FyEnNNKdUg+co1paa8ICenb2xya7+QDt8LPctzMEoWTdvtHltTOItsfmTW
+        ZPoaJsveKhARL6hFglD6B19a0SluQETSGC0e9McjQPHt3kvhExJYaCLiJy1/mq3RgNIBcQIPVZXC
+        VFY07drNa8Pzy42PLvM2+GC2O+J6nnr8NZYOtVnEv9s+ZmMuXRPGYzyzvYnDBZ4T5cRKb9G0S5us
+        WeEfXW8aMOxhYm/RtKPCR24QTXlKjd98uaOuLd6+XtXkaoHj7770U9wPeUAXwkrulrnj8oj5QTgY
+        eZGLLW2WP9g84lhYZlHclf4U85s5MeKnCLbj5ZT86WlZd/u7qV/O+4ZlmZ6uzzyxLr8gfAdM2ut3
+        L4ovuu+ln7P8wK93OHSbBcGK6n+ZdcE8bviPbHydmF6Yy8Z68juj/H56xB7ExK1hheyOihlcEPkj
+        Yr3OHC4k43Kv9ZsE1qJjz0cnBcvN3/Dkj49wR5yIanVoFaWV2uxu5ry6hoJrKFg1MbBqomBdxcC6
+        io9cQUeu4CMb6MgGriAK1nCwjrKh42zoKBs6zoZWRcWo4iOjYB0HayjPGs4zql+OegoqhIILgYI1
+        HIz6J+6eGBIForbATYE6BO4PKmoIFTeEoaMD6zhhGkqYhouBsqvi7OpoKOl4KBnoyAY+soHKbOAy
+        a6gYGi4GTgbOBcqymsMy6hZaToiiI2v4yAYadQYedejA+Lgq6p1qTrrCB84ZGQ07FY87HbWInmMS
+        lAsV5wJ1C9wr0ODDY09F5VVxeXWUCR1nQkVTJtSuP/oJaCjfiB9RSkquF75skmDXRrXR0KRyVR1Z
+        smEpdbluaZpsDY06taldMYwKMnnYsts3TCrEDxUKjQf1ajZXrDS8DRlqnShVRTbsqgZamZo8NEa6
+        bKuaVdMpMWyRytfJ2Krb95FRq2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEKJKVNFGcrGcETkGhma
+        smINK9WKYVojy0QU27Lb91nRNHOsyBveggx1VFMN066ALnUeqLoiE8PUZcuihqmpo7phYvG9Zbdv
+        JUP8wGesuP0IDcxaZQVBvAU9ll2jpAaK6RUT9FQ1U64T/qOAtFrVVKIpqlFH6Nmy23emv3pO9qu/
+        EhXX/Cdgw/Q3H306AdLF6h5qnp6f/w8uCax9XVYAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:41:46 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-c-ca-central-1-prod
+      X-Request-Uuid:
+      - e077b86620947dc69d40b207368d50c5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/219
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+VcbVfiSBb+Kznsnj0yQzBvBPDLLAKO7ohyROne7XY5RVJgrSFh8uJLi/99b1US
+        CHBDY7fazIwfYqXqqcq9z31JVSXhqcDckVc4eCp49y71CwcF4to+vf9nYN+WPX9cKBVcMqFQH9Ig
+        HAQWcQcj9hBGPuVN3iAk/piGhYMRcQJaKow8x6b+gNmFAzdynFLB8tzQ95zCQehH0B4F0Dql/oQF
+        AfPcoHCgarVSIbBuqB05dBBFvCtcbDJ1SEhlgwxNlQyHcsVSTVnV6kRWqWbLpKrULMWujHTVMEfV
+        WsVUq5W6qZjKqAqCUZuFA+I43j2157Jx4UHHQaLQVU9qOl5kS724HrpNPYdZj9B2SAJmSWc0vPf8
+        WwGA1uCG+HSumDf8H7VCoamm1kuFkIwTMoIUQiwHyp+eCksKK6WU6xhlswB0fUzEiuuy5QWX4eOU
+        C27TEYmcsPBcWhlZUJmMra4OnGvYtXqh0vxq3GKF5+tS4cYLQsuL3FCokBjKNKoWqdZrsk1VTTZq
+        VJOHI10Dc1V1XTN0VakonLqQhBFIWJiSKGAuv4pwpeQa06DACUzIS0paeRoNebEcUpcMHRpQK/JZ
+        +Fi2vAngiROmhA9AyIWdpxaTYXA5mjoeWTb/AATxQQG1UjX0ilKtVuG6bAKuTSbTeXXN1EFdEtwO
+        553hjETgVKFPmLPmUcmo3ErPgGVB6PmPwvJJWbiJqiqmXldTGw0Sni2fkhAMOLDB4ZdFcwjE3MSz
+        2YhZCEbI+TJDZAlHjRLHoS9snMNw6gzct6F4FzmgDRkyh4WMJpVgomkGw08dRlyLxucj5oTUj4Mj
+        cUOOLoMqpQLwYXN7p47bCAIaSietQiabPKWaUKh4FJ3G9AHOPyky5IjR9VPtWd6bnxjPcvFJf56f
+        q9rzXmlraPGnrFTplRRV042KWZXJ0LJlOlJUmVfIZrVW51W8BmK04EGMEnACrm2B/s4DTxwnJLRu
+        +FlcAFbGvhdNU62ztD6KWE8apk40Zm6ZgC+yYQRpuTxEaTuMxuCtv29L3H+5xtc/x7Rc/4zrfHbV
+        OWxfCOEfHOqOwxtwxtq7KEkfIJwhq498QPC0PIDguyMBonmzcdZv9KR23EM6SnugPNi+N7UhIKHR
+        gWDl8vNbFZwKZy9c52r3HcrEog+mxLolY5qvQncO2ErwuBdUtLREeT4AnH+4YSEddCHGICp9CPo3
+        0erBp6ODZvviUm42MZ2gRWrYdyyAjLi1WzYbcuyRcuqgqzXFn/6O+SrA/g1/8klL2mP0QIJzTVF0
+        WakV3ycs53TkcdHPjvXNcYorT/1Q6l9JIAL1KeTdmAMVCFCLuxK/no+6/vlFe6djd4pK3W1vZb4y
+        mlcv2x8v38cprTta9sk9pkF/Ow3+uwfIGaSaoryn1uv1maZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlbkeq1qlpIzWAEocMt9L6aCYDAkAYVVT46n9ns9CZYKFFYIMWL78P38uZwE8C+o/tVyZU1NmDMB
+        dCyOr+LJXEO+1PJ84mzW8jJBfZemqKJGWXtnRe9g3eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z87w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5IN7wGx4v3ndX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh91ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse568LegytvLh/0pUatu2DqN+R
+        0NW6VlbNWlktayW1ystlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiAfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yt9PwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnV6/L9Xod4IoiV2v1d2TgvNdvYXdHUf+nWXRN+QCDaTR0ll5OW1e7y4FSdwHkC9Cc
+        BAMNI0Yde42IJ+N5Py5oiwJKCX/pY7/T2W+11kzOh5cdnjWSEk2L43BRmlcKwkTpe7dLNu4idgVe
+        ai2BdmkrbkQmzBHvMOYKfyQgG/PrYBI5IVtk2flVLmD1c0xC6dSz+NOd5C1PSWyu8lumeHcyI9Vx
+        V776uBGtZdAtOmTE3QjXM/Ce5xAf1sCb8EYGf0Rtzycb4ZUMvPnriUSGUUDTRjPT+CuY2PM2jlXN
+        ihr12hvBtQy4cbKZsnoG+4G5YLBAOpDWk/bcIEq2Ax3CsP4df6Uzac4arNe57EpT3wO3mcwBWRsd
+        +ZQe9lqbPSBrpath5IbRZnzWSj2HWLd8WrO5S9ZSHf5eNLn9So+s+S7oxAupNGIOlYhlxStkgcpa
+        rQlGPu9tHjVruKPLblqN2Ch1eGVJcgsu8JUIUZdCxGWA9EbCiEw8ChCgrI06LLDKacNSxMR9JJuG
+        1EqylwAZS5cQG/TSlcsesvvzAogHCLjfx14vxSzFCYGM43teCFN/TrlIPAKVJfqi20yra6hzXwXU
+        lybEJWM6oeKxggDXlyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PT1ej3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+jpAW
+        j45SUH3VNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Uknfr54AsY/zDjHiNIpqWOXPHwPlSjjWWUsFZ
+        Jw0oI0vZ2UnKjGGupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn88IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqRf+3yF3+oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsrqks
+        BcR9j3+DIjV/7Z1u7qY+v96CdtOMcNtlzp4y+6TCdD6e0ysl87m49/lz8JPMD3urTcVf9kqi4YW9
+        cpZPH/lfSRxlcVxZSSmK8har/7gG+bInl81OBvrXWD7lbIskfOzologXhdMI25VKxD5P279V8JA+
+        hCUvvIFbHC++z6ZG4q7bLPVjNf/Ka/2ELKFkLkGXcetWm5EOz+ZiKD6bepXtSJhflfkBEzCu3nZ/
+        6kktVZ4XmXdRlybqr6FyEnNNKdUg+co1paa8ICenb2xya7+QDt8LPctzMEoWTdvtHltTOItsfmTW
+        ZPoaJsveKhARL6hFglD6B19a0SluQETSGC0e9McjQPHt3kvhExJYaCLiJy1/mq3RgNIBcQIPVZXC
+        VFY07drNa8Pzy42PLvM2+GC2O+J6nnr8NZYOtVnEv9s+ZmMuXRPGYzyzvYnDBZ4T5cRKb9G0S5us
+        WeEfXW8aMOxhYm/RtKPCR24QTXlKjd98uaOuLd6+XtXkaoHj7770U9wPeUAXwkrulrnj8oj5QTgY
+        eZGLLW2WP9g84lhYZlHclf4U85s5MeKnCLbj5ZT86WlZd/u7qV/O+4ZlmZ6uzzyxLr8gfAdM2ut3
+        L4ovuu+ln7P8wK93OHSbBcGK6n+ZdcE8bviPbHydmF6Yy8Z68juj/H56xB7ExK1hheyOihlcEPkj
+        Yr3OHC4k43Kv9ZsE1qJjz0cnBcvN3/Dkj49wR5yIanVoFaWV2uxu5ry6hoJrKFg1MbBqomBdxcC6
+        io9cQUeu4CMb6MgGriAK1nCwjrKh42zoKBs6zoZWRcWo4iOjYB0HayjPGs4zql+OegoqhIILgYI1
+        HIz6J+6eGBIForbATYE6BO4PKmoIFTeEoaMD6zhhGkqYhouBsqvi7OpoKOl4KBnoyAY+soHKbOAy
+        a6gYGi4GTgbOBcqymsMy6hZaToiiI2v4yAYadQYedejA+Lgq6p1qTrrCB84ZGQ07FY87HbWInmMS
+        lAsV5wJ1C9wr0ODDY09F5VVxeXWUCR1nQkVTJtSuP/oJaCjfiB9RSkquF75skmDXRrXR0KRyVR1Z
+        smEpdbluaZpsDY06taldMYwKMnnYsts3TCrEDxUKjQf1ajZXrDS8DRlqnShVRTbsqgZamZo8NEa6
+        bKuaVdMpMWyRytfJ2Krb95FRq2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEKJKVNFGcrGcETkGhma
+        smINK9WKYVojy0QU27Lb91nRNHOsyBveggx1VFMN066ALnUeqLoiE8PUZcuihqmpo7phYvG9Zbdv
+        JUP8wGesuP0IDcxaZQVBvAU9ll2jpAaK6RUT9FQ1U64T/qOAtFrVVKIpqlFH6Nmy23emv3pO9qu/
+        EhXX/Cdgw/Q3H306AdLF6h5qnp6f/w8uCax9XVYAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:41:57 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-c-ca-central-1-prod
+      X-Request-Uuid:
+      - a7259308bbb8bee95cdeab9556906b53
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/219
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+VcbVfiSBb+Kznsnj0yQzBvBPDLLAKO7ohyROne7XY5RVJgrSFh8uJLi/99b1US
+        CHBDY7fazIwfYqXqqcq9z31JVSXhqcDckVc4eCp49y71CwcF4to+vf9nYN+WPX9cKBVcMqFQH9Ig
+        HAQWcQcj9hBGPuVN3iAk/piGhYMRcQJaKow8x6b+gNmFAzdynFLB8tzQ95zCQehH0B4F0Dql/oQF
+        AfPcoHCgarVSIbBuqB05dBBFvCtcbDJ1SEhlgwxNlQyHcsVSTVnV6kRWqWbLpKrULMWujHTVMEfV
+        WsVUq5W6qZjKqAqCUZuFA+I43j2157Jx4UHHQaLQVU9qOl5kS724HrpNPYdZj9B2SAJmSWc0vPf8
+        WwGA1uCG+HSumDf8H7VCoamm1kuFkIwTMoIUQiwHyp+eCksKK6WU6xhlswB0fUzEiuuy5QWX4eOU
+        C27TEYmcsPBcWhlZUJmMra4OnGvYtXqh0vxq3GKF5+tS4cYLQsuL3FCokBjKNKoWqdZrsk1VTTZq
+        VJOHI10Dc1V1XTN0VakonLqQhBFIWJiSKGAuv4pwpeQa06DACUzIS0paeRoNebEcUpcMHRpQK/JZ
+        +Fi2vAngiROmhA9AyIWdpxaTYXA5mjoeWTb/AATxQQG1UjX0ilKtVuG6bAKuTSbTeXXN1EFdEtwO
+        553hjETgVKFPmLPmUcmo3ErPgGVB6PmPwvJJWbiJqiqmXldTGw0Sni2fkhAMOLDB4ZdFcwjE3MSz
+        2YhZCEbI+TJDZAlHjRLHoS9snMNw6gzct6F4FzmgDRkyh4WMJpVgomkGw08dRlyLxucj5oTUj4Mj
+        cUOOLoMqpQLwYXN7p47bCAIaSietQiabPKWaUKh4FJ3G9AHOPyky5IjR9VPtWd6bnxjPcvFJf56f
+        q9rzXmlraPGnrFTplRRV042KWZXJ0LJlOlJUmVfIZrVW51W8BmK04EGMEnACrm2B/s4DTxwnJLRu
+        +FlcAFbGvhdNU62ztD6KWE8apk40Zm6ZgC+yYQRpuTxEaTuMxuCtv29L3H+5xtc/x7Rc/4zrfHbV
+        OWxfCOEfHOqOwxtwxtq7KEkfIJwhq498QPC0PIDguyMBonmzcdZv9KR23EM6SnugPNi+N7UhIKHR
+        gWDl8vNbFZwKZy9c52r3HcrEog+mxLolY5qvQncO2ErwuBdUtLREeT4AnH+4YSEddCHGICp9CPo3
+        0erBp6ODZvviUm42MZ2gRWrYdyyAjLi1WzYbcuyRcuqgqzXFn/6O+SrA/g1/8klL2mP0QIJzTVF0
+        WakV3ycs53TkcdHPjvXNcYorT/1Q6l9JIAL1KeTdmAMVCFCLuxK/no+6/vlFe6djd4pK3W1vZb4y
+        mlcv2x8v38cprTta9sk9pkF/Ow3+uwfIGaSaoryn1uv1maZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlbkeq1qlpIzWAEocMt9L6aCYDAkAYVVT46n9ns9CZYKFFYIMWL78P38uZwE8C+o/tVyZU1NmDMB
+        dCyOr+LJXEO+1PJ84mzW8jJBfZemqKJGWXtnRe9g3eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z87w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5IN7wGx4v3ndX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh91ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse568LegytvLh/0pUatu2DqN+R
+        0NW6VlbNWlktayW1ystlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiAfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yt9PwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnV6/L9Xod4IoiV2v1d2TgvNdvYXdHUf+nWXRN+QCDaTR0ll5OW1e7y4FSdwHkC9Cc
+        BAMNI0Yde42IJ+N5Py5oiwJKCX/pY7/T2W+11kzOh5cdnjWSEk2L43BRmlcKwkTpe7dLNu4idgVe
+        ai2BdmkrbkQmzBHvMOYKfyQgG/PrYBI5IVtk2flVLmD1c0xC6dSz+NOd5C1PSWyu8lumeHcyI9Vx
+        V776uBGtZdAtOmTE3QjXM/Ce5xAf1sCb8EYGf0Rtzycb4ZUMvPnriUSGUUDTRjPT+CuY2PM2jlXN
+        ihr12hvBtQy4cbKZsnoG+4G5YLBAOpDWk/bcIEq2Ax3CsP4df6Uzac4arNe57EpT3wO3mcwBWRsd
+        +ZQe9lqbPSBrpath5IbRZnzWSj2HWLd8WrO5S9ZSHf5eNLn9So+s+S7oxAupNGIOlYhlxStkgcpa
+        rQlGPu9tHjVruKPLblqN2Ch1eGVJcgsu8JUIUZdCxGWA9EbCiEw8ChCgrI06LLDKacNSxMR9JJuG
+        1EqylwAZS5cQG/TSlcsesvvzAogHCLjfx14vxSzFCYGM43teCFN/TrlIPAKVJfqi20yra6hzXwXU
+        lybEJWM6oeKxggDXlyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PT1ej3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+jpAW
+        j45SUH3VNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Uknfr54AsY/zDjHiNIpqWOXPHwPlSjjWWUsFZ
+        Jw0oI0vZ2UnKjGGupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn88IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqRf+3yF3+oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsrqks
+        BcR9j3+DIjV/7Z1u7qY+v96CdtOMcNtlzp4y+6TCdD6e0ysl87m49/lz8JPMD3urTcVf9kqi4YW9
+        cpZPH/lfSRxlcVxZSSmK8har/7gG+bInl81OBvrXWD7lbIskfOzologXhdMI25VKxD5P279V8JA+
+        hCUvvIFbHC++z6ZG4q7bLPVjNf/Ka/2ELKFkLkGXcetWm5EOz+ZiKD6bepXtSJhflfkBEzCu3nZ/
+        6kktVZ4XmXdRlybqr6FyEnNNKdUg+co1paa8ICenb2xya7+QDt8LPctzMEoWTdvtHltTOItsfmTW
+        ZPoaJsveKhARL6hFglD6B19a0SluQETSGC0e9McjQPHt3kvhExJYaCLiJy1/mq3RgNIBcQIPVZXC
+        VFY07drNa8Pzy42PLvM2+GC2O+J6nnr8NZYOtVnEv9s+ZmMuXRPGYzyzvYnDBZ4T5cRKb9G0S5us
+        WeEfXW8aMOxhYm/RtKPCR24QTXlKjd98uaOuLd6+XtXkaoHj7770U9wPeUAXwkrulrnj8oj5QTgY
+        eZGLLW2WP9g84lhYZlHclf4U85s5MeKnCLbj5ZT86WlZd/u7qV/O+4ZlmZ6uzzyxLr8gfAdM2ut3
+        L4ovuu+ln7P8wK93OHSbBcGK6n+ZdcE8bviPbHydmF6Yy8Z68juj/H56xB7ExK1hheyOihlcEPkj
+        Yr3OHC4k43Kv9ZsE1qJjz0cnBcvN3/Dkj49wR5yIanVoFaWV2uxu5ry6hoJrKFg1MbBqomBdxcC6
+        io9cQUeu4CMb6MgGriAK1nCwjrKh42zoKBs6zoZWRcWo4iOjYB0HayjPGs4zql+OegoqhIILgYI1
+        HIz6J+6eGBIForbATYE6BO4PKmoIFTeEoaMD6zhhGkqYhouBsqvi7OpoKOl4KBnoyAY+soHKbOAy
+        a6gYGi4GTgbOBcqymsMy6hZaToiiI2v4yAYadQYedejA+Lgq6p1qTrrCB84ZGQ07FY87HbWInmMS
+        lAsV5wJ1C9wr0ODDY09F5VVxeXWUCR1nQkVTJtSuP/oJaCjfiB9RSkquF75skmDXRrXR0KRyVR1Z
+        smEpdbluaZpsDY06taldMYwKMnnYsts3TCrEDxUKjQf1ajZXrDS8DRlqnShVRTbsqgZamZo8NEa6
+        bKuaVdMpMWyRytfJ2Krb95FRq2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEKJKVNFGcrGcETkGhma
+        smINK9WKYVojy0QU27Lb91nRNHOsyBveggx1VFMN066ALnUeqLoiE8PUZcuihqmpo7phYvG9Zbdv
+        JUP8wGesuP0IDcxaZQVBvAU9ll2jpAaK6RUT9FQ1U64T/qOAtFrVVKIpqlFH6Nmy23emv3pO9qu/
+        EhXX/Cdgw/Q3H306AdLF6h5qnp6f/w8uCax9XVYAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:42:07 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-c-ca-central-1-prod
+      X-Request-Uuid:
+      - 8cd117abc2dc9673c955fe49acc58cea
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/219
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKBhlWVTIcyhVLrcqqZhJZpZotk5pStxS7MtJVozqq
+        1StVtVYxq0pVGdVAMGqzcEAcx7un9lw2LjzoOEgUuupJTceLbKkX10O3qecw6xHaDknALOmMhvee
+        fysA0BrcEJ/OFfOG/6NWKDTVVLNUCMk4ISNIIcRyoPzpqbCksFJKuY5RNgtA18dErLguW15wGT5O
+        ueA2HZHICQvPpZWRBZXJ2OrqwLmGXasXKs2vxi1WeL4uFW68ILS8yA2FComhqkbNIjWzLttU1WSj
+        TjV5ONI1MFdN1zVDV5WKwqkLSRiBhIUpgfHsQmyMQXKJaVDg/CXcJSWtPI2GvFgOqUuGDg2oFfks
+        fCxb3gTwxAlTvgdizNTMU4vJMLgcTR2PLFt/AHL4IL9aqRl6RanVanBdNgHPJpPpvNrkNN6Q4HY4
+        7wxnJAKfCn3CnDWHSkblRnoGLAtCz38Uhk/KwktUVanqppqaaJDQbPmUhGC/gQ3+viyaQyDkJp7N
+        RsxCMELOl9khSzhmkzgKfWHhHIJTV+CeDcW7yAFlyJA5LGQ0qQQLTTMYfuow4lo0Ph8xJ6R+HBqJ
+        E3J0mXEhgA6bmzt120YQ0FA6aRUyueQpVYRCxaPoNKYPcP5JkSFDjK6f6s/y3vzEeJaLT/rz/FzV
+        nvdKW0OLP2WlSq+kqJpuVKo1mQwtW6YjRZV5hVyt1U1exWsgQgseRCgBH+DaFujvPOzEcUJC64af
+        xQVgZex70TTVOkvro4j0pGHqRGPmlgm4IhtGkJTLQ5S2w2gMzvr7tsT9l2t8/XNMy/XPuM5nV53D
+        9oUQ/sGh7ji8AV+sv4uS9AGiGXL6yAcET8oDiL07EiCaNxtn/UZPasc9pKO0B8qD7XtTG+IRGh2I
+        VS4/v1HBqXD2wnWudt+hTCz6YEqsWzKm+Sp054CtBI97QUVLS5TnA8D5hxsW0kEXYgyi0oeYfxOt
+        Hnw6Omi2Ly7lZhPTCVqkhn3HAkiIW7tlsyHHHimnDrpaU/zp75ivAuzf8CeftKQ9Rg8kONcURZeV
+        evF9wnJORx4X/exY3xynuPLUD6X+lQQiUJ9C3o05UIEAtbgr8ev5qOufX7R3OnanqNTd9lbmK6N5
+        9bL98fJ9nNK6o2Wf3GMa9LfT4L97gJxBqinKe6ppmjNN+aSo18Idi3FIPhkluL9uh8tz4H4bwlWt
+        yGa9Vi0lZzD/V+CW+15MBcFgSAIKa54cT+33ehIsFCisD2LE9uH7+XM5CeBfUP1r5cqamjBnAuhY
+        HF/Fk7mGfKHl+cTZrOVlgvouTVFFjbL2zorewarN83OjIKttX0C3vFFBT+1v7YO9q1n3vDk7mh3P
+        zlrF/YvTg73zo9nl7MPsKq5oAqQ5u7qYNfm5iJNv6lnMCZ32wXFJah8crdH6yrHxdR5fTl+jf7B3
+        OmvMzor7DdD2eNaZnUIxOtg7m/VmneJ+k5e6s2Zx/2ReaqSlOZffN0wesTDqWUmCY+ONqdW3yDt3
+        eln5oycffcvsI3T946cg/SU5aFnnl0bSAfTejzOKyCcfk3SSZJOPcTKBXDK7gJMkbl7W6QenH31b
+        Dr+JOp5AziCBnM66cQo5nR0X97sXvFYUr0TeuCju9zhfTZFRjqHpTGSUpNRIS1mCX3noH5qs4iXO
+        hzZmgA/bTieT0PzaiuZDe3U1A8u5N1nKLXarBjYNLJ9N+dYbpuMNtW6lM37yynP/VxB9ThYm+Bwm
+        XWRgO6HCupcl290DYsW7z+v6tGLE/m8urAalRowLdmfNuL74tbUBdRzmYdq0RcMur4Hn0sd9v6rC
+        W4TIm+5SkDvCHC4DpluiVCOD2RG7iHzcbh3KYjMpT/AWCQmfYL7ultNO7Q0nNTfRMJ+HY9G4I5ZL
+        BE6wAwrmyZnZtJeQUhuQ26qRdA0k4lMp6+JnnpQIILEAbrO/R8wXD4Sg4VbkVIp3fUsuqD0YPg4m
+        xLkn6NKgncKkw0epM4ftlkFjJVwaBBH2qGJJh7MU9UNUEA/gkof564IeQysv7p90pYZt+yDqdyR0
+        1dTKarVeVstaSa3xchkO8qKoKCVV4f/KFZgya0ZJSEcfCMxbqHj++35b+CeNfgNhhFe/MIPKnxry
+        f4j85Vpezqir9TkZVlxxbQ6sqnJDVtSK+p6PNUCUQ5yTw3fn5BDl5PA9OQlCNh4E9I7y1xNwXjpS
+        b9G+DTvs7qR//XOOzovRYpVP+u9sfeyhFq9+d+tf/viIYO4gvAEW6D2W4k9c6fKGQnK/36EFSf5d
+        dVdvpJnJ3YSGJBCVmPzzxl1eQC1UyFtBZfT4w6yeRHLo9I6w5NBhlu8F3iiUDiPHoSFzt8sTnd7K
+        4/+VipzM0OmZpmyaJsAVRa7VzXdk4LzXb2F3R1H/p1l0TfkAg2k0dJbeTVtXu8uBUncB5AvQnAQD
+        DSNGHXuNiCfjeT8uaIsCSgl/6WO/09lvtdZMzoeXHZ41khJNi+NwUZpXCsJE6Xu3SzbuInYFXmot
+        gXZpK25EJswRrzDmCn8kIBvz62ASOSFbZNn5VS5g9XNMQunUs/jTneQlT0lsrvJbpnh1MiPVcVe+
+        +rgRrWXQLTpkxN0I1zPwnucQH9bAm/BGBn9Ebc8nG+GVDLz564lEhlFA08ZqpvFXMLHnbRyrlhU1
+        6rU3gusZcONkM2VmBvuBuWCwQDqQ1pP23CBKtgMdwrD+HX+lM2nOGqzXuexKU98Dt5nMAVkbHfmU
+        HvZamz0ga6WrYeSG0WZ81ko9h1i3fFqzuUvWUh3+VjS5/UqPrPku6MQLqTRiDpWIZcUrZIHKWq0J
+        Rj7vbR41a7ijy25ajdgodXhlSXILLvCVCFGXQsRlgPRGwohMPAoQoKyNOiywymnDUsTEfSSbhtRK
+        spcAGUuXEBv00pXLHrL78wKIBwi438deL8UsxQmBjON7XghTf065SDwClSX6ottMq+uoc18F1Jcm
+        xCVjOqHisYIAm8sRCYnRSfNEluV0E3WeRLKMdin15UtP5v+lI+4QvRtIK276cr2eZbZ50muepw1Z
+        Zo+YT++J48wvkWX0EDza9rx5xOlZFnvNRquRNmSpa52ljOpZroAKB/xVCmJbzsfMEtcVn0ZIi0dH
+        KchcNQ2RghvqOKvWMZQlrwkhm4znKXWJPc8PpeTV+jkgyxj/LCNeo4imZc7cMXC+lGONpVRw1kkD
+        yshSdnaSMmNUV9MAu9uc4Y0sl/2OSDTt3uYINLLcHvoRzxyeD3EE8waSgWXZ/VfkeptvTZUlji0G
+        fs2/HZBOmRs9bO6ZtUDHG3KnbdGsN1SyJjj3iQWILcbNWqcxIV9g/rdFr6zJusTxpIYTbr41VrLW
+        PI7IPWWb8VkzH1XSb32+wm9tjYN+Z3OPrJ1PXIvZYBPpggZTzw1SF65krdxnfhh5X75sVreqLAXE
+        fY9/giI1f+2dbu6mPr/egnbTjHDbZc6eMvukwnQ+ntMrpepzce/z5+AnmR/2VpuKv+yVRMMLe+Us
+        nz7yv5I4yuK4spJSFOUtVv9xDfJhTy6bnQz0r7F8ytkWSfjY0S0RLwqnEbYrlYh9nrZ/q+AhfQhL
+        XngDtzhefJ9NjcRdt1nqx2r+ldf6CVlCyVyCLuPWrTYjHZ7NxVB8NvUq25EwvyrzAyZgXL3t/tST
+        Wqo8LzLvoi5N1F9D5STmulKqQ/KV60pdeUFOTt/Y5NZ+IR2+F3qW52CULJq22z22pnAW2fzIrMn0
+        NUyWvVUgIl5QiwSh9A++tKJT3ICIpDFaPOiPR4Di272XwicksNBExE9a/jRbowGlA+IEHqoqhams
+        aNq1m9eG55cbH13mbfDBbHfE9Tz1+GssHWqziH+2fczGXLomjMd4ZnsThws8J8qJld6iaZc2WbPC
+        P7reNGDYw8TeomlHhY/cIJrylBq/+XJHXVu8fb2qydUCx9996ae4H/KALoSV3C1zx+UR84NwMPIi
+        F1vaLH+wecSxsMyiuCv9KeY3c2LELxFsx8sp+dPTsu72d1O/nPcNyzI9XZ95Yl1+QfgOmLTX714U
+        X3TfSz9n+YFf73DoNguCFdX/MuuCedzw39j4OjG9MJeN9eR3Rvn99Ig9iIlbwwrZHRUzuCDyR8R6
+        nTlcSMblXus3CaxFx56PTgqWm7/hyR8f4Y44EdVMaBWlldrsbua8uo6C6yhYrWJgtYqCdRUD6yo+
+        cgUduYKPbKAjG7iCKFjDwTrKho6zoaNs6DgbWg0Vo4aPjIJ1HKyhPGs4z6h+OeopqBAKLgQK1nAw
+        6p+4e2JIFIjaAjcF6hC4P6ioIVTcEIaODqzjhGkoYRouBsquirOro6Gk46FkoCMb+MgGKrOBy6yh
+        Ymi4GDgZOBcoy2oOy6hbaDkhio6s4SMbaNQZeNShA+Pjqqh3qjnpCh84Z2Q07FQ87nTUInqOSVAu
+        VJwL1C1wr0CDD489FZVXxeXVUSZ0nAkVTZlQu/7oJ6ChfCN+RCkpuV74skmCXR/VR8MqlWvqyJIN
+        SzFl09I02RoaJrWpXTGMCjJ52LLbN0wqxM8UCo0HZi2bK1Ya3oYM1SRKTZENu6aBVlVNHhojXbZV
+        zarrlBi2SOXrZGzV7fvIqFc0nAze8BZk8EsgyibV36jMigpvIrhiaRahpCpTRRnKxnBE5DoZVmXF
+        GlZqFaNqjawqotiW3b7PitVqjhV5w1uQoY7qqlG1K6CLyQNVV2RiVHXZsqhR1dSRaVSx+N6y27eS
+        IX7eM1bcfoQGZq2ygiDegh7LrlNSB8X0ShX0VLWqbBL+o4C0VtNUoimqYSL0bNntO9OfmZP9zFei
+        4pr/AGyY/uajTydAuljdQ83T8/P/Af2+UAlbVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:42:18 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-c-ca-central-1-prod
+      X-Request-Uuid:
+      - 42e4e8a21538f96f31a1a879316dfbd9
     status:
       code: 200
       message: OK
@@ -1727,11 +2499,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/110/resume
+    uri: https://cloud.tenable.com/scans/219/resume
   response:
     body:
       string: ''
@@ -1743,7 +2515,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Wed, 17 Jul 2019 15:54:50 GMT
+      - Thu, 21 Nov 2019 15:42:18 GMT
       Expires:
       - '0'
       Pragma:
@@ -1751,8 +2523,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -1760,9 +2532,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 443692ca6f454a802f7b8500ae89331f
+      - 3ba952de0ce8c1aa88d6e8650e85505c
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1780,76 +2552,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPbGLB5mSVAJtkNhAMJ3TvdWY6wBWhjbMaWSdIh/31L
-        sg0CDCGdSzMzeSCyqiRXfXWxSr48Zog79DKVx4x352I/U8kg1/bx3T8D+zbv+aNMLuOiCYZ+igPa
-        Dyzk9ofknoY+ZiSvT5E/wjRTGSInwLnM0HNs7PeJnam4oePkMpbnUt9zMhXqh0APA6BOsT8hQUA8
-        N8hUVM3IZQJrjO3Qwf0wZEPhZJOpgyiW8cBCFioUZK1gFuQywiXZUIdFaKlFW9MMU7UMs6DoFkJ6
-        0SgrSC3pIBi2Ce0jx/HusL2QjQkPOvZjha67Us3xQlvqRv0wbOo5xHoA2gkKiCW1ML3z/FvOANRg
-        jHy8UMwb/A9blGuqqkouQ9EoBiNIWJDlQPvLY2ZFYeCNsY64bBKArg+xWFGf2F5iSR+mTHAbD1Ho
-        0MxTbm1mDmU8t7o+8VbDbvSzE2qLszGLZZ5ucpmxF1DLC13KVYgNZeimOdQUSzZtpMu6aZRlA2wm
-        FxUbmdg2Tb1YYNBRREOQMOPjIJwQl52G+1J8kmmQYQjG6MUtLT8NB6yZp9hFAwcH2Ap9Qh/yljcB
-        fuTQBPE+SLk09NQiMkwuh1PHQ6v274MkPmigFkuFQtkwFMCJkgn4NppMl90maDhGwe1gMRiOUAhe
-        RX1EnA2XimdlZnoCXhJQz3/gpo/bkZ8ohmYqhcRI/Rhoy8eIggX7Nnj8qmgOgqCbeDYZEiuNx3yx
-        JUTA060SRaLPrbwF4sQdmHdDcxY6oA4aEIdQguNOsNFU4GGHDkGuhaPjIXEo9qPwiB2RcedBlxzI
-        g2xm8MR1q0GAqXRezwj55DFRBUPHAx80wvdw/EWRTSQPbx6NJ/locaA/ydnHwtPiWNWejnJ7s2Z/
-        EqVKzqSoWkEvlsoyGli2jIeKKrMOuVQ2TNbFeiBKMx5EKQIvYNpm8O8s9PjvBFFrzI6iBqAy8r1w
-        mmgtwvrAoz0mTJ1wRNw8AmckgxASc36QCttJOAJ3/X1f4P7LNL75OYLl5ud0nVvXzZNGhwt/72B3
-        RMfgjcaHKInvIZ4hrw994GCJuQ/RN0NBiua1aqtX7UqNaIR0moxIxcH2vakNEQlEB6KVyc8uVnDI
-        nT1zs1W7VygTid6fIusWjfB2FdoLhr0Ej0ZBR12LlWcTwPGnMaG434YYg6j0IerfRat7Hw8rtUbn
-        Sq7V0nQCilS1ZySAlLi3W9aqcuSRcuKg6z3Zn/6e5qvA9h/4k8/r0hHBFQmONUUpyIqR/ZiwXMCx
-        DYueONd3x2m68tinUu9aAhGwjyHvRhioAICaPZT49fxU17/sNA46dqepUrcbe5kvn5pXrxqfrz7G
-        Ka0ZzvvoLk2D3n4a/PcIOOeQarLykWqa5lxTvijqDXfHbBSSj3oOrq/78W1z4F4DwlUtyrCUKeXi
-        o5KsKnDJ/SikgqA/QAGGumeLp/a6XQmKBQw1QsSxf/h+/ZqPA/iXVP3L+eKGmrBmAtYR/30TT2Ya
-        smLL85GzW8urmOtVmqYqque1D1Z0BpWb52+NAlHbHmfd80IFI7W/NSpH1/P2ZW1+Oj+bt+rZ485F
-        5ejydH41/zS/jjpqwFKbX3fmNXbM4+S7Rma3hE6jcpaTGpXTDVjfODaex/Hl8FV7laOLeXXeyh5X
-        QduzeXN+Ac2wctSad+fN7HGNtdrzWvb4fNGqJq0Flq+bZhuwMGsrJ8Fv9Z2hLeyRd2aFvPJHTz6F
-        PbMP1/WPn4IKL8lBqzq/NJIqMPo4yig8n3yO00mcTT5HyQRyybwDB3HcvGzQD04/hX0x/C7oWAJp
-        QQK5mLejFHIxP8setzuslzeved7oZI+7DK8azyhnQGrxjBK3qklLBPiNp/6hySoqcT410gzwad/l
-        ZByaz1U0nxrr1QyUc+9Syi13q/o2DiyfTNnmW5qOY2zdSi128MZr/zcQfQFWmuALNqkjsB2ECpte
-        Fm9595EV7UBv6lOPOI7/7UI1KFUjvuBwasbN4tfW+thxiJemTYMTDrkGXkgfjX1WhfcIkXfdpUAz
-        RBwmQ5pusVJVgedA7MLzcaN+IvPNpG2C1xFFbIH5tltOB7U3HPeMw8F2HM448UAsFwsc8/YxmGfL
-        yqaxwik1gHNfNeKhgYR8LIku3vKkWACJBHCZ/T0k7GYnJ9zynIrTh74nFtjuDx76E+TcodTSoJGw
-        SScPUnPBdlgGjZRwcRCEabcqVnRoJVw/RAV+Ay6+ob8p6BlQWfP4vC1VbdsHUV+R0FVTy6slI6/m
-        tZxaZu08/MjLpqLkVIX9yxdhyazpOS4dvkewbsH8DvDHbeGfV3vVFERY9wszqPylKv+G5G838mpG
-        Xe/fkmH5GTfWwKoqV2VFLaofeVsDRDlJx+TkwzE5ScXk5CMxCSgZ9QM8w+wBhXRcmlJ3Sd8HHTI7
-        7938vEXn5WyRyue9D7Z+2k0t1v3h1r/68RFB3D4dAwr4Li3Fn7vS1RhDcr87oIJk+1X1UC+kwuJu
-        gikKeGea/AviIRdQSxW2VVCCHn+Y6oknh2b3NC05NInle4E3pNJJ6DiYEne/PNHsrt3+X+vYkhma
-        XdOUTdMEdkWRy4b5gQhcdnv1tKsj7//TFF1TNkF/Gg6clafTNtVuM0apvWRkBeiWBAOEIcGOvQHE
-        o/50HDW0ZSMVEvbQx3GzeVyvb5icTS87LGvELZw0R3TZWnRywHjrtdslO3cR25xfqq8wHdJW3BBN
-        iMMfYtwq/Cln2Zlf+5PQoWSZZRdn6UD1c4aodOFZ7O5O/JinxDdX2SWTPzwpSHXWlq8/7+TWBO46
-        HhDk7mQvCOxdz0E+1MC7+HWB/xTbno92shcF9tqv5xIahAFOiCWB+CuY2PN2zlUWRQ27jZ3MhsBc
-        Pd8NmSnwfiIuGCyQKtJm0l4YRBEH4AFM68/YI50xWTRYt3nVlqa+B24zWTCINjr1MT7p1nd7gGil
-        60Ho0nA3v2ilroOsW7as2T1EtFSTPRmNbp8ZIZqvgycexdKQOFhClhVVyJxLtFoNjHzZ3T2raLjT
-        q3bSnWKjxOGVFcktOMEzEaKuhIhLgNMbciMSfiuAM4k2apLAyieElYiJxkg2ptiKsxdn0ldOwTfo
-        pWuX3Iv785wxPUDA/T53uwnPSpwgyDi+51FY+jPIeeLhXCLQnXYt6TZSnfs6wL40QS4a4QnmtxU4
-        s7kakZAYnSRPiCgnm6iLJCIi2sbYl688mf2XTplDdMeQVtzkAfuCiGztvFu7TAgisqfEx3fIcRan
-        EBE9AY+2PW8RcQURxW6tWq8mBBG6eitBtCBiBVA44K9SENlyMacIXJu/HiEtbx0lTOa6aZAUjLHj
-        rFtHV1a8hkI2GS1S6gp6nk+l+OH6BYOIGHs1I6pROGkVM3cEmK/kWH0lFbSaSUDpImSt8wQZvbSe
-        Bshsd4bXRSx7TZ5oGt3dEaiL2J74Icscng9xBOsGJLCJ6P4rdL3dl6biCsYWAb9mbw9IF8QN73eP
-        FC3Q9AbMaetY9IaiaIJLH1nAsce8onWqE/QN1n97jBJN1kaOJ1UduvvSWBSteRaiO0x284tmPi0m
-        7/s8g295A4Nec/cI0c7nrkVssInUwcHUc4PEhYuilXvEp6H37dtudUuipX+72r0SKKlPb1fG7loH
-        7lvcHCnzLyos4qOVvJIrPWWPvn4NfpLZz9E6KfvLUY4TXjhqS9H0mf3l+K/Mf9fqJ0VR3qPmj3pS
-        XujZimZTYP1rFE1bNkNiPA50I8QL6TRM24uKxb5M6N8rOMX3NOfRMVzYWPNjtjJid92nwI/U/CtX
-        +DFYXMmtAF1F1L22IB2WzflUbA31JpuQsKrKs580AaPufXelHtVc8WmZeZd9SaJ+jmtLYjaUnAHJ
-        VzYUQ3lBTk6e02TWfiEcvkc9y3PSIFmS9tsztqZwFNrsl1iT6VuYTLxUpIjYwRYKqPQPVlDhaboB
-        UySNuPnt/WgGaL7f0yhsQQLlZYr4MeVPsyEaYNxHTuClqophActJh3bx2nHXcucNy23berDGHTI9
-        Lzz28EoT2yRkr2ufkRGTrgbzEZbZ3sXhAs8Jt8RKd0k6pK1VUfgH15sGJO0WYndJOlDhQzcIpyyl
-        Rs+7zLBr82eu1zW5XvKxJ156Cd8PuS1HoX67Je4oPyR+QPtDL3TTSpvV1zRPGS+UWTjdlf4U65sF
-        MPwLBPvhcoH+9LBsuv1s6ue3vbmyCk/bJx6vyzuI7XtJR712J/ui617yEssPfGeHse5TEKyp/pep
-        CxZxw76t8TwwXboVjc3k18LsenpK7vnCrWpRMsN8BReE/hBZb7OGo2iUL5SLhorYV3ZKSJF1DQ1l
-        0y4NZH2gGqWCqWl2wUxRbc9h33F/kH97aIacEPcLqgoMvL1J2NziCjCVx/wTEXHL9ejLwFD0QtnQ
-        UUnWFFsFrQaKjIYqlhWESwUFq5ZmWSlg7DnsdWAUjXQsoP89oOBngDDGI/ZFmxL/nsy63mk8r1Sy
-        qG3REgjvYnG1bJfNoipjXdNlHWNVRoaOZXWIlaFmalixh2kW32/Y68AoF0vpYDDC+9u8bPDz7zZ6
-        zPQ6RXW1kK4oI7yHoqUCLiKMsGyWypC9DG0gG4aNZN0qDPWBNSjbqp6i+p7DXgcG+5xZOhqc8jZw
-        3LDvudHk800+nsDc/JINPY9PT/8HpjaqSSpOAAA=
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKBhlWVTIcyhVLrcqqZhJZpZotk5pStxS7MtJVozqq
+        1StVtVYxq0pVGdVAMGqzcEAcx7un9lw2LjzoOEgUuupJTceLbKkX10O3qecw6xHaDknALOmMhvee
+        fysA0BrcEJ/OFfOG/6NWKDTVVLNUCMk4ISNIIcRyoPzpqbCksFJKuY5RNgtA18dErLguW15wGT5O
+        ueA2HZHICQvPpZWRBZXJ2OrqwLmGXasXKs2vxi1WeL4uFW68ILS8yA2FComhqkbNIjWzLttU1WSj
+        TjV5ONI1MFdN1zVDV5WKwqkLSRiBhAWfBtGEufwywpeSi0yDAmcwYS8paeVpNOTFckhdMnRoQK3I
+        Z+Fj2fImgCdOmDI+ACkXhp5aTIbB5WjqeGTZ/gOQxAcN1ErN0CtKrVaD67IJ+DaZTOfVpg5E3pDg
+        djjvDGckAq8KfcKcNZdKRuVmegYsC0LPfxSmT8rCT1RVqeqmmhppkBBt+ZSEYMGBDR6/LJpDIOgm
+        ns1GzEIwQs6XWSJLOG6VOBJ9YeUcilN34N4NxbvIAXXIkDksZDSpBBtNMxh+6jDiWjQ+HzEnpH4c
+        HokjcnQZdCmBPMTmBk9dtxEENJROWoVMPnlKVaFQ8Sg6jekDnH9SZMgSo+un+rO8Nz8xnuXik/48
+        P1e1573S1tDiT1mp0ispqqYblWpNJkPLlulIUWVeIVdrdZNX8RqI0oIHUUrAC7i2Bfo7Dz1xnJDQ
+        uuFncQFYGfteNE21ztL6KKI9aZg60Zi5ZQLOyIYRJObyEKXtMBqDu/6+LXH/5Rpf/xzTcv0zrvPZ
+        VeewfSGEf3CoOw5vwBvr76IkfYB4hrw+8gHBE/MAou+OBIjmzcZZv9GT2nEP6SjtgfJg+97UhoiE
+        RgeilcvPb1ZwKpy9cJ2r3XcoE4s+mBLrloxpvgrdOWArweNeUNHSEuX5AHD+4YaFdNCFGIOo9CHq
+        30SrB5+ODprti0u52cR0ghapYd+xAFLi1m7ZbMixR8qpg67WFH/6O+arAPs3/MknLWmP0QMJzjVF
+        0WWlXnyfsJzTkcdFPzvWN8cprjz1Q6l/JYEI1KeQd2MOVCBALe5K/Ho+6vrnF+2djt0pKnW3vZX5
+        ymhevWx/vHwfp7TuaNkn95gG/e00+O8eIGeQaorynmqa5kxTPinqtXDHYhyST0YJ7q/b4fIcuN+G
+        cFUrslmvVUvJGawBFLjlvhdTQTAYkoDCuifHU/u9ngSLBQprhBixffh+/lxOAvgXVP9aubKmJsyZ
+        ADoWx1fxZK4hX2x5PnE2a3mZoL5LU1RRo6y9s6J3sHLz/NwoyGrbF9Atb1TQU/tb+2DvatY9b86O
+        Zsezs1Zx/+L0YO/8aHY5+zC7iiuaAGnOri5mTX4u4uSbehZzQqd9cFyS2gdHa7S+cmx8nceX09fo
+        H+ydzhqzs+J+A7Q9nnVmp1CMDvbOZr1Zp7jf5KXurFncP5mXGmlpzuX3DZNHLIx6VpLg2HhjavUt
+        8s6dXlb+6MlH3zL7CF3/+ClIf0kOWtb5pZF0AL3344wi8snHJJ0k2eRjnEwgl8wu4CSJm5d1+sHp
+        R9+Ww2+ijieQM0ggp7NunEJOZ8fF/e4FrxXFK5E3Lor7Pc5XU2SUY2g6ExklKTXSUpbgVx76hyar
+        eInzoY0Z4MO208kkNL+2ovnQXl3NwHLuTZZyi92qgU0Dy2dTvvmG6XhDrVvpjJ+88tz/FUSfk4UJ
+        PodJFxnYTqiw7mXJlveAWPEO9Lo+rRix/5sLq0GpEeOC3Vkzri9+bW1AHYd5mDZt0bDLa+C59HHf
+        r6rwFiHyprsU5I4wh8uA6ZYo1chgdsQuIh+3W4ey2EzKE7xFQsInmK+75bRTe8NJzU00zOfhWDTu
+        iOUSgRPsgIJ5cmY27SWk1AbktmokXQOJ+FTKuviZJyUCSCyA2+zvEeMPO0XDrcipFO/6llxQezB8
+        HEyIc0/QpUE7hUmHj1JnDtstg8ZKuDQIIuxRxZIOZynqh6ggHsAlD/TXBT2GVl7cP+lKDdv2QdTv
+        SOiqqZXVar2slrWSWuPlMhzkRVFRSqrC/5UrMGXWjJKQjj4QmLdQ8QT4/bbwTxr9BsIIr35hBpU/
+        NeT/EPnLtbycUVfrczKsuOLaHFhV5YasqBX1PR9rgCiHOCeH787JIcrJ4XtyEoRsPAjoHeUvKOC8
+        dKTeon0bdtjdSf/65xydF6PFKp/039n62EMtXv3u1r/88RHB3EF4AyzQeyzFn7jS5Q2F5H6/QwuS
+        /Lvqrt5IM5O7CQ1JICox+eeNu7yAWqiQt4LK6PGHWT2J5NDpHWHJocMs3wu8USgdRo5DQ+Zulyc6
+        vZXH/ysVOZmh0zNN2TRNgCuKXKub78jAea/fwu6Oov5Ps+ia8gEG02joLL2dtq52lwOl7gLIF6A5
+        CQYaRow69hoRT8bzflzQFgWUEv7Sx36ns99qrZmcDy87PGskJZoWx+GiNK8UhInS926XbNxF7Aq8
+        1FoC7dJW3IhMmCNeYswV/khANubXwSRyQrbIsvOrXMDq55iE0qln8ac7yWuekthc5bdM8fJkRqrj
+        rnz1cSNay6BbdMiIuxGuZ+A9zyE+rIE34Y0M/ojank82wisZePPXE4kMo4CmjdVM469gYs/bOFYt
+        K2rUa28E1zPgxslmyswM9gNzwWCBdCCtJ+25QZRsBzqEYf07/kpn0pw1WK9z2ZWmvgduM5kDsjY6
+        8ik97LU2e0DWSlfDyA2jzfislXoOsW75tGZzl6ylOvzNaHL7lR5Z813QiRdSacQcKhHLilfIApW1
+        WhOMfN7bPGrWcEeX3bQasVHq8MqS5BZc4CsRoi6FiMsA6Y2EEZl4FCBAWRt1WGCV04aliIn7SDYN
+        qZVkLwEyli4hNuilK5c9ZPfnBRAPEHC/j71eilmKEwIZx/e8EKb+nHKReAQqS/RFt5lW11Hnvgqo
+        L02IS8Z0QsVjBQE2lyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PQFez3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+j5AW
+        j45SkLlqGiIFN9RxVq1jKEteE0I2Gc9T6hJ7nh9Kycv1c0CWMf5pRrxGEU3LnLlj4HwpxxpLqeCs
+        kwaUkaXs7CRlxqiupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn89IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqTf+3yF39oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsblVZ
+        Coj7Hv8IRWr+2jvd3E19fr0F7aYZ4bbLnD1l9kmF6Xw8p1dK1efi3ufPwU8yP+ytNhV/2SuJhhf2
+        ylk+feR/JXGUxXFlJaUoylus/uMa5NOeXDY7GehfY/mUsy2S8LGjWyJeFE4jbFcqEfs8bf9WwUP6
+        EJa88AZucbz4Ppsaibtus9SP1fwrr/UTsoSSuQRdxq1bbUY6PJuLofhs6lW2I2F+VeYHTMC4etv9
+        qSe1VHleZN5FXZqov4bKScx1pVSH5CvXlbrygpycvrHJrf1COnwv9CzPwShZNG23e2xN4Syy+ZFZ
+        k+lrmCx7q0BEvKAWCULpH3xpRae4ARFJY7R40B+PAMW3ey+FT0hgoYmIn7T8abZGA0oHxAk8VFUK
+        U1nRtGs3rw3PLzc+uszb4IPZ7ojreerx11g61GYR/3D7mI25dE0Yj/HM9iYOF3hOlBMrvUXTLm2y
+        ZoV/dL1pwLCHib1F044KH7lBNOUpNX7z5Y66tnj7elWTqwWOv/vST3E/5AFdCCu5W+aOyyPmB+Fg
+        5EUutrRZ/mDziGNhmUVxV/pTzG/mxIjfItiOl1Pyp6dl3e3vpn457xuWZXq6PvPEuvyC8B0waa/f
+        vSi+6L6Xfs7yA7/e4dBtFgQrqv9l1gXzuOG/svF1YnphLhvrye+M8vvpEXsQE7eGFbI7KmZwQeSP
+        iPU6c7iQjMu91m8SWIuOPR+dFCw3f8OTPz7CHXEiqpnQKkortdndzHl1HQXXUbBaxcBqFQXrKgbW
+        VXzkCjpyBR/ZQEc2cAVRsIaDdZQNHWdDR9nQcTa0GipGDR8ZBes4WEN51nCeUf1y1FNQIRRcCBSs
+        4WDUP3H3xJAoELUFbgrUIXB/UFFDqLghDB0dWMcJ01DCNFwMlF0VZ1dHQ0nHQ8lARzbwkQ1UZgOX
+        WUPF0HAxcDJwLlCW1RyWUbfQckIUHVnDRzbQqDPwqEMHxsdVUe9Uc9IVPnDOyGjYqXjc6ahF9ByT
+        oFyoOBeoW+BegQYfHnsqKq+Ky6ujTOg4EyqaMqF2/dFPQEP5RvyIUlJyvfBlkwS7PqqPhlUq19SR
+        JRuWYsqmpWmyNTRMalO7YhgVZPKwZbdvmFSInyoUGg/MWjZXrDS8DRmqSZSaIht2TQOtqpo8NEa6
+        bKuaVdcpMWyRytfJ2Krb95FRr2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEJJVaaKMpSN4YjIdTKs
+        yoo1rNQqRtUaWVVEsS27fZ8Vq9UcK/KGtyBDHdVVo2pXQBeTB6quyMSo6rJlUaOqqSPTqGLxvWW3
+        byVD/MRnrLj9CA3MWmUFQbwFPZZdp6QOiumVKuipalXZJPxHAWmtpqlEU1TDROjZstt3pj8zJ/uZ
+        r0TFNf8R2DD9zUefToB0sbqHmqfn5/8DdS/C3F9WAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -1860,12 +2637,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:54:51 GMT
+      - Thu, 21 Nov 2019 15:42:19 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1875,9 +2652,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - f8b34babd27c8377df03d44bba27c6e3
+      - 24379a2b74cc5c96baae25245f6bfffa
     status:
       code: 200
       message: OK
@@ -1893,76 +2670,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPbGLB5mSVAJtkNhAMJ3TvdWY6wBWhjbMaWSdIh/31L
-        sg0CDCGdSzMzeSCyqiRXfXWxSr48Zog79DKVx4x352I/U8kg1/bx3T8D+zbv+aNMLuOiCYZ+igPa
-        Dyzk9ofknoY+ZiSvT5E/wjRTGSInwLnM0HNs7PeJnam4oePkMpbnUt9zMhXqh0APA6BOsT8hQUA8
-        N8hUVM3IZQJrjO3Qwf0wZEPhZJOpgyiW8cBCFioUZK1gFuQywiXZUIdFaKlFW9MMU7UMs6DoFkJ6
-        0SgrSC3pIBi2Ce0jx/HusL2QjQkPOvZjha67Us3xQlvqRv0wbOo5xHoA2gkKiCW1ML3z/FvOANRg
-        jHy8UMwb/A9blGuqqkouQ9EoBiNIWJDlQPvLY2ZFYeCNsY64bBKArg+xWFGf2F5iSR+mTHAbD1Ho
-        0MxTbm1mDmU8t7o+8VbDbvSzE2qLszGLZZ5ucpmxF1DLC13KVYgNZeimOdQUSzZtpMu6aZRlA2wm
-        FxUbmdg2Tb1YYNBRREOQMOPjIJwQl52G+1J8kmmQYQjG6MUtLT8NB6yZp9hFAwcH2Ap9Qh/yljcB
-        fuTQBPE+SLk09NQiMkwuh1PHQ6v274MkPmigFkuFQtkwFMCJkgn4NppMl90maDhGwe1gMRiOUAhe
-        RX1EnA2XimdlZnoCXhJQz3/gpo/bkZ8ohmYqhcRI/Rhoy8eIggX7Nnj8qmgOgqCbeDYZEiuNx3yx
-        JUTA060SRaLPrbwF4sQdmHdDcxY6oA4aEIdQguNOsNFU4GGHDkGuhaPjIXEo9qPwiB2RcedBlxzI
-        g2xm8MR1q0GAqXRezwj55DFRBUPHAx80wvdw/EWRTSQPbx6NJ/locaA/ydnHwtPiWNWejnJ7s2Z/
-        EqVKzqSoWkEvlsoyGli2jIeKKrMOuVQ2TNbFeiBKMx5EKQIvYNpm8O8s9PjvBFFrzI6iBqAy8r1w
-        mmgtwvrAoz0mTJ1wRNw8AmckgxASc36QCttJOAJ3/X1f4P7LNL75OYLl5ud0nVvXzZNGhwt/72B3
-        RMfgjcaHKInvIZ4hrw994GCJuQ/RN0NBiua1aqtX7UqNaIR0moxIxcH2vakNEQlEB6KVyc8uVnDI
-        nT1zs1W7VygTid6fIusWjfB2FdoLhr0Ej0ZBR12LlWcTwPGnMaG434YYg6j0IerfRat7Hw8rtUbn
-        Sq7V0nQCilS1ZySAlLi3W9aqcuSRcuKg6z3Zn/6e5qvA9h/4k8/r0hHBFQmONUUpyIqR/ZiwXMCx
-        DYueONd3x2m68tinUu9aAhGwjyHvRhioAICaPZT49fxU17/sNA46dqepUrcbe5kvn5pXrxqfrz7G
-        Ka0ZzvvoLk2D3n4a/PcIOOeQarLykWqa5lxTvijqDXfHbBSSj3oOrq/78W1z4F4DwlUtyrCUKeXi
-        o5KsKnDJ/SikgqA/QAGGumeLp/a6XQmKBQw1QsSxf/h+/ZqPA/iXVP3L+eKGmrBmAtYR/30TT2Ya
-        smLL85GzW8urmOtVmqYqque1D1Z0BpWb52+NAlHbHmfd80IFI7W/NSpH1/P2ZW1+Oj+bt+rZ485F
-        5ejydH41/zS/jjpqwFKbX3fmNXbM4+S7Rma3hE6jcpaTGpXTDVjfODaex/Hl8FV7laOLeXXeyh5X
-        QduzeXN+Ac2wctSad+fN7HGNtdrzWvb4fNGqJq0Flq+bZhuwMGsrJ8Fv9Z2hLeyRd2aFvPJHTz6F
-        PbMP1/WPn4IKL8lBqzq/NJIqMPo4yig8n3yO00mcTT5HyQRyybwDB3HcvGzQD04/hX0x/C7oWAJp
-        QQK5mLejFHIxP8setzuslzeved7oZI+7DK8azyhnQGrxjBK3qklLBPiNp/6hySoqcT410gzwad/l
-        ZByaz1U0nxrr1QyUc+9Syi13q/o2DiyfTNnmW5qOY2zdSi128MZr/zcQfQFWmuALNqkjsB2ECpte
-        Fm9595EV7UBv6lOPOI7/7UI1KFUjvuBwasbN4tfW+thxiJemTYMTDrkGXkgfjX1WhfcIkXfdpUAz
-        RBwmQ5pusVJVgedA7MLzcaN+IvPNpG2C1xFFbIH5tltOB7U3HPeMw8F2HM448UAsFwsc8/YxmGfL
-        yqaxwik1gHNfNeKhgYR8LIku3vKkWACJBHCZ/T0k7GYnJ9zynIrTh74nFtjuDx76E+TcodTSoJGw
-        SScPUnPBdlgGjZRwcRCEabcqVnRoJVw/RAV+Ay6+ob8p6BlQWfP4vC1VbdsHUV+R0FVTy6slI6/m
-        tZxaZu08/MjLpqLkVIX9yxdhyazpOS4dvkewbsH8DvDHbeGfV3vVFERY9wszqPylKv+G5G838mpG
-        Xe/fkmH5GTfWwKoqV2VFLaofeVsDRDlJx+TkwzE5ScXk5CMxCSgZ9QM8w+wBhXRcmlJ3Sd8HHTI7
-        7938vEXn5WyRyue9D7Z+2k0t1v3h1r/68RFB3D4dAwr4Li3Fn7vS1RhDcr87oIJk+1X1UC+kwuJu
-        gikKeGea/AviIRdQSxW2VVCCHn+Y6oknh2b3NC05NInle4E3pNJJ6DiYEne/PNHsrt3+X+vYkhma
-        XdOUTdMEdkWRy4b5gQhcdnv1tKsj7//TFF1TNkF/Gg6clafTNtVuM0apvWRkBeiWBAOEIcGOvQHE
-        o/50HDW0ZSMVEvbQx3GzeVyvb5icTS87LGvELZw0R3TZWnRywHjrtdslO3cR25xfqq8wHdJW3BBN
-        iMMfYtwq/Cln2Zlf+5PQoWSZZRdn6UD1c4aodOFZ7O5O/JinxDdX2SWTPzwpSHXWlq8/7+TWBO46
-        HhDk7mQvCOxdz0E+1MC7+HWB/xTbno92shcF9tqv5xIahAFOiCWB+CuY2PN2zlUWRQ27jZ3MhsBc
-        Pd8NmSnwfiIuGCyQKtJm0l4YRBEH4AFM68/YI50xWTRYt3nVlqa+B24zWTCINjr1MT7p1nd7gGil
-        60Ho0nA3v2ilroOsW7as2T1EtFSTPRmNbp8ZIZqvgycexdKQOFhClhVVyJxLtFoNjHzZ3T2raLjT
-        q3bSnWKjxOGVFcktOMEzEaKuhIhLgNMbciMSfiuAM4k2apLAyieElYiJxkg2ptiKsxdn0ldOwTfo
-        pWuX3Iv785wxPUDA/T53uwnPSpwgyDi+51FY+jPIeeLhXCLQnXYt6TZSnfs6wL40QS4a4QnmtxU4
-        s7kakZAYnSRPiCgnm6iLJCIi2sbYl688mf2XTplDdMeQVtzkAfuCiGztvFu7TAgisqfEx3fIcRan
-        EBE9AY+2PW8RcQURxW6tWq8mBBG6eitBtCBiBVA44K9SENlyMacIXJu/HiEtbx0lTOa6aZAUjLHj
-        rFtHV1a8hkI2GS1S6gp6nk+l+OH6BYOIGHs1I6pROGkVM3cEmK/kWH0lFbSaSUDpImSt8wQZvbSe
-        Bshsd4bXRSx7TZ5oGt3dEaiL2J74Icscng9xBOsGJLCJ6P4rdL3dl6biCsYWAb9mbw9IF8QN73eP
-        FC3Q9AbMaetY9IaiaIJLH1nAsce8onWqE/QN1n97jBJN1kaOJ1UduvvSWBSteRaiO0x284tmPi0m
-        7/s8g295A4Nec/cI0c7nrkVssInUwcHUc4PEhYuilXvEp6H37dtudUuipX+72r0SKKlPb1fG7loH
-        7lvcHCnzLyos4qOVvJIrPWWPvn4NfpLZz9E6KfvLUY4TXjhqS9H0mf3l+K/Mf9fqJ0VR3qPmj3pS
-        XujZimZTYP1rFE1bNkNiPA50I8QL6TRM24uKxb5M6N8rOMX3NOfRMVzYWPNjtjJid92nwI/U/CtX
-        +DFYXMmtAF1F1L22IB2WzflUbA31JpuQsKrKs580AaPufXelHtVc8WmZeZd9SaJ+jmtLYjaUnAHJ
-        VzYUQ3lBTk6e02TWfiEcvkc9y3PSIFmS9tsztqZwFNrsl1iT6VuYTLxUpIjYwRYKqPQPVlDhaboB
-        UySNuPnt/WgGaL7f0yhsQQLlZYr4MeVPsyEaYNxHTuClqophActJh3bx2nHXcucNy23berDGHTI9
-        Lzz28EoT2yRkr2ufkRGTrgbzEZbZ3sXhAs8Jt8RKd0k6pK1VUfgH15sGJO0WYndJOlDhQzcIpyyl
-        Rs+7zLBr82eu1zW5XvKxJ156Cd8PuS1HoX67Je4oPyR+QPtDL3TTSpvV1zRPGS+UWTjdlf4U65sF
-        MPwLBPvhcoH+9LBsuv1s6ue3vbmyCk/bJx6vyzuI7XtJR712J/ui617yEssPfGeHse5TEKyp/pep
-        CxZxw76t8TwwXboVjc3k18LsenpK7vnCrWpRMsN8BReE/hBZb7OGo2iUL5SLhorYV3ZKSJF1DQ1l
-        0y4NZH2gGqWCqWl2wUxRbc9h33F/kH97aIacEPcLqgoMvL1J2NziCjCVx/wTEXHL9ejLwFD0QtnQ
-        UUnWFFsFrQaKjIYqlhWESwUFq5ZmWSlg7DnsdWAUjXQsoP89oOBngDDGI/ZFmxL/nsy63mk8r1Sy
-        qG3REgjvYnG1bJfNoipjXdNlHWNVRoaOZXWIlaFmalixh2kW32/Y68AoF0vpYDDC+9u8bPDz7zZ6
-        zPQ6RXW1kK4oI7yHoqUCLiKMsGyWypC9DG0gG4aNZN0qDPWBNSjbqp6i+p7DXgcG+5xZOhqc8jZw
-        3LDvudHk800+nsDc/JINPY9PT/8HpjaqSSpOAAA=
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKBhlWVTIcyhVLrcqqZhJZpZotk5pStxS7MtJVozqq
+        1StVtVYxq0pVGdVAMGqzcEAcx7un9lw2LjzoOEgUuupJTceLbKkX10O3qecw6xHaDknALOmMhvee
+        fysA0BrcEJ/OFfOG/6NWKDTVVLNUCMk4ISNIIcRyoPzpqbCksFJKuY5RNgtA18dErLguW15wGT5O
+        ueA2HZHICQvPpZWRBZXJ2OrqwLmGXasXKs2vxi1WeL4uFW68ILS8yA2FComhqkbNIjWzLttU1WSj
+        TjV5ONI1MFdN1zVDV5WKwqkLSRiBhAWfBtGEufwywpeSi0yDAmcwYS8paeVpNOTFckhdMnRoQK3I
+        Z+Fj2fImgCdOmDI+ACkXhp5aTIbB5WjqeGTZ/gOQxAcN1ErN0CtKrVaD67IJ+DaZTOfVpg5E3pDg
+        djjvDGckAq8KfcKcNZdKRuVmegYsC0LPfxSmT8rCT1RVqeqmmhppkBBt+ZSEYMGBDR6/LJpDIOgm
+        ns1GzEIwQs6XWSJLOG6VOBJ9YeUcilN34N4NxbvIAXXIkDksZDSpBBtNMxh+6jDiWjQ+HzEnpH4c
+        HokjcnQZdCmBPMTmBk9dtxEENJROWoVMPnlKVaFQ8Sg6jekDnH9SZMgSo+un+rO8Nz8xnuXik/48
+        P1e1573S1tDiT1mp0ispqqYblWpNJkPLlulIUWVeIVdrdZNX8RqI0oIHUUrAC7i2Bfo7Dz1xnJDQ
+        uuFncQFYGfteNE21ztL6KKI9aZg60Zi5ZQLOyIYRJObyEKXtMBqDu/6+LXH/5Rpf/xzTcv0zrvPZ
+        VeewfSGEf3CoOw5vwBvr76IkfYB4hrw+8gHBE/MAou+OBIjmzcZZv9GT2nEP6SjtgfJg+97UhoiE
+        RgeilcvPb1ZwKpy9cJ2r3XcoE4s+mBLrloxpvgrdOWArweNeUNHSEuX5AHD+4YaFdNCFGIOo9CHq
+        30SrB5+ODprti0u52cR0ghapYd+xAFLi1m7ZbMixR8qpg67WFH/6O+arAPs3/MknLWmP0QMJzjVF
+        0WWlXnyfsJzTkcdFPzvWN8cprjz1Q6l/JYEI1KeQd2MOVCBALe5K/Ho+6vrnF+2djt0pKnW3vZX5
+        ymhevWx/vHwfp7TuaNkn95gG/e00+O8eIGeQaorynmqa5kxTPinqtXDHYhyST0YJ7q/b4fIcuN+G
+        cFUrslmvVUvJGawBFLjlvhdTQTAYkoDCuifHU/u9ngSLBQprhBixffh+/lxOAvgXVP9aubKmJsyZ
+        ADoWx1fxZK4hX2x5PnE2a3mZoL5LU1RRo6y9s6J3sHLz/NwoyGrbF9Atb1TQU/tb+2DvatY9b86O
+        Zsezs1Zx/+L0YO/8aHY5+zC7iiuaAGnOri5mTX4u4uSbehZzQqd9cFyS2gdHa7S+cmx8nceX09fo
+        H+ydzhqzs+J+A7Q9nnVmp1CMDvbOZr1Zp7jf5KXurFncP5mXGmlpzuX3DZNHLIx6VpLg2HhjavUt
+        8s6dXlb+6MlH3zL7CF3/+ClIf0kOWtb5pZF0AL3344wi8snHJJ0k2eRjnEwgl8wu4CSJm5d1+sHp
+        R9+Ww2+ijieQM0ggp7NunEJOZ8fF/e4FrxXFK5E3Lor7Pc5XU2SUY2g6ExklKTXSUpbgVx76hyar
+        eInzoY0Z4MO208kkNL+2ovnQXl3NwHLuTZZyi92qgU0Dy2dTvvmG6XhDrVvpjJ+88tz/FUSfk4UJ
+        PodJFxnYTqiw7mXJlveAWPEO9Lo+rRix/5sLq0GpEeOC3Vkzri9+bW1AHYd5mDZt0bDLa+C59HHf
+        r6rwFiHyprsU5I4wh8uA6ZYo1chgdsQuIh+3W4ey2EzKE7xFQsInmK+75bRTe8NJzU00zOfhWDTu
+        iOUSgRPsgIJ5cmY27SWk1AbktmokXQOJ+FTKuviZJyUCSCyA2+zvEeMPO0XDrcipFO/6llxQezB8
+        HEyIc0/QpUE7hUmHj1JnDtstg8ZKuDQIIuxRxZIOZynqh6ggHsAlD/TXBT2GVl7cP+lKDdv2QdTv
+        SOiqqZXVar2slrWSWuPlMhzkRVFRSqrC/5UrMGXWjJKQjj4QmLdQ8QT4/bbwTxr9BsIIr35hBpU/
+        NeT/EPnLtbycUVfrczKsuOLaHFhV5YasqBX1PR9rgCiHOCeH787JIcrJ4XtyEoRsPAjoHeUvKOC8
+        dKTeon0bdtjdSf/65xydF6PFKp/039n62EMtXv3u1r/88RHB3EF4AyzQeyzFn7jS5Q2F5H6/QwuS
+        /Lvqrt5IM5O7CQ1JICox+eeNu7yAWqiQt4LK6PGHWT2J5NDpHWHJocMs3wu8USgdRo5DQ+Zulyc6
+        vZXH/ysVOZmh0zNN2TRNgCuKXKub78jAea/fwu6Oov5Ps+ia8gEG02joLL2dtq52lwOl7gLIF6A5
+        CQYaRow69hoRT8bzflzQFgWUEv7Sx36ns99qrZmcDy87PGskJZoWx+GiNK8UhInS926XbNxF7Aq8
+        1FoC7dJW3IhMmCNeYswV/khANubXwSRyQrbIsvOrXMDq55iE0qln8ac7yWuekthc5bdM8fJkRqrj
+        rnz1cSNay6BbdMiIuxGuZ+A9zyE+rIE34Y0M/ojank82wisZePPXE4kMo4CmjdVM469gYs/bOFYt
+        K2rUa28E1zPgxslmyswM9gNzwWCBdCCtJ+25QZRsBzqEYf07/kpn0pw1WK9z2ZWmvgduM5kDsjY6
+        8ik97LU2e0DWSlfDyA2jzfislXoOsW75tGZzl6ylOvzNaHL7lR5Z813QiRdSacQcKhHLilfIApW1
+        WhOMfN7bPGrWcEeX3bQasVHq8MqS5BZc4CsRoi6FiMsA6Y2EEZl4FCBAWRt1WGCV04aliIn7SDYN
+        qZVkLwEyli4hNuilK5c9ZPfnBRAPEHC/j71eilmKEwIZx/e8EKb+nHKReAQqS/RFt5lW11Hnvgqo
+        L02IS8Z0QsVjBQE2lyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PQFez3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+j5AW
+        j45SkLlqGiIFN9RxVq1jKEteE0I2Gc9T6hJ7nh9Kycv1c0CWMf5pRrxGEU3LnLlj4HwpxxpLqeCs
+        kwaUkaXs7CRlxqiupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn89IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqTf+3yF39oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsblVZ
+        Coj7Hv8IRWr+2jvd3E19fr0F7aYZ4bbLnD1l9kmF6Xw8p1dK1efi3ufPwU8yP+ytNhV/2SuJhhf2
+        ylk+feR/JXGUxXFlJaUoylus/uMa5NOeXDY7GehfY/mUsy2S8LGjWyJeFE4jbFcqEfs8bf9WwUP6
+        EJa88AZucbz4Ppsaibtus9SP1fwrr/UTsoSSuQRdxq1bbUY6PJuLofhs6lW2I2F+VeYHTMC4etv9
+        qSe1VHleZN5FXZqov4bKScx1pVSH5CvXlbrygpycvrHJrf1COnwv9CzPwShZNG23e2xN4Syy+ZFZ
+        k+lrmCx7q0BEvKAWCULpH3xpRae4ARFJY7R40B+PAMW3ey+FT0hgoYmIn7T8abZGA0oHxAk8VFUK
+        U1nRtGs3rw3PLzc+uszb4IPZ7ojreerx11g61GYR/3D7mI25dE0Yj/HM9iYOF3hOlBMrvUXTLm2y
+        ZoV/dL1pwLCHib1F044KH7lBNOUpNX7z5Y66tnj7elWTqwWOv/vST3E/5AFdCCu5W+aOyyPmB+Fg
+        5EUutrRZ/mDziGNhmUVxV/pTzG/mxIjfItiOl1Pyp6dl3e3vpn457xuWZXq6PvPEuvyC8B0waa/f
+        vSi+6L6Xfs7yA7/e4dBtFgQrqv9l1gXzuOG/svF1YnphLhvrye+M8vvpEXsQE7eGFbI7KmZwQeSP
+        iPU6c7iQjMu91m8SWIuOPR+dFCw3f8OTPz7CHXEiqpnQKkortdndzHl1HQXXUbBaxcBqFQXrKgbW
+        VXzkCjpyBR/ZQEc2cAVRsIaDdZQNHWdDR9nQcTa0GipGDR8ZBes4WEN51nCeUf1y1FNQIRRcCBSs
+        4WDUP3H3xJAoELUFbgrUIXB/UFFDqLghDB0dWMcJ01DCNFwMlF0VZ1dHQ0nHQ8lARzbwkQ1UZgOX
+        WUPF0HAxcDJwLlCW1RyWUbfQckIUHVnDRzbQqDPwqEMHxsdVUe9Uc9IVPnDOyGjYqXjc6ahF9ByT
+        oFyoOBeoW+BegQYfHnsqKq+Ky6ujTOg4EyqaMqF2/dFPQEP5RvyIUlJyvfBlkwS7PqqPhlUq19SR
+        JRuWYsqmpWmyNTRMalO7YhgVZPKwZbdvmFSInyoUGg/MWjZXrDS8DRmqSZSaIht2TQOtqpo8NEa6
+        bKuaVdcpMWyRytfJ2Krb95FRr2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEJJVaaKMpSN4YjIdTKs
+        yoo1rNQqRtUaWVVEsS27fZ8Vq9UcK/KGtyBDHdVVo2pXQBeTB6quyMSo6rJlUaOqqSPTqGLxvWW3
+        byVD/MRnrLj9CA3MWmUFQbwFPZZdp6QOiumVKuipalXZJPxHAWmtpqlEU1TDROjZstt3pj8zJ/uZ
+        r0TFNf8R2DD9zUefToB0sbqHmqfn5/8DdS/C3F9WAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -1973,12 +2755,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:54:52 GMT
+      - Thu, 21 Nov 2019 15:42:19 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1988,9 +2770,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 1e66867a1a960dd80951e539555b494d
+      - d7e653eaff9a5e6a40e2a620730ded6b
     status:
       code: 200
       message: OK
@@ -2006,76 +2788,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPbGLB5mSVAJtkNhAMJ3TvdWY6wBWhjbMaWSdIh/31L
-        sg0CDCGdSzMzeSCyqiRXfXWxSr48Zog79DKVx4x352I/U8kg1/bx3T8D+zbv+aNMLuOiCYZ+igPa
-        Dyzk9ofknoY+ZiSvT5E/wjRTGSInwLnM0HNs7PeJnam4oePkMpbnUt9zMhXqh0APA6BOsT8hQUA8
-        N8hUVM3IZQJrjO3Qwf0wZEPhZJOpgyiW8cBCFioUZK1gFuQywiXZUIdFaKlFW9MMU7UMs6DoFkJ6
-        0SgrSC3pIBi2Ce0jx/HusL2QjQkPOvZjha67Us3xQlvqRv0wbOo5xHoA2gkKiCW1ML3z/FvOANRg
-        jHy8UMwb/A9blGuqqkouQ9EoBiNIWJDlQPvLY2ZFYeCNsY64bBKArg+xWFGf2F5iSR+mTHAbD1Ho
-        0MxTbm1mDmU8t7o+8VbDbvSzE2qLszGLZZ5ucpmxF1DLC13KVYgNZeimOdQUSzZtpMu6aZRlA2wm
-        FxUbmdg2Tb1YYNBRREOQMOPjIJwQl52G+1J8kmmQYQjG6MUtLT8NB6yZp9hFAwcH2Ap9Qh/yljcB
-        fuTQBPE+SLk09NQiMkwuh1PHQ6v274MkPmigFkuFQtkwFMCJkgn4NppMl90maDhGwe1gMRiOUAhe
-        RX1EnA2XimdlZnoCXhJQz3/gpo/bkZ8ohmYqhcRI/Rhoy8eIggX7Nnj8qmgOgqCbeDYZEiuNx3yx
-        JUTA060SRaLPrbwF4sQdmHdDcxY6oA4aEIdQguNOsNFU4GGHDkGuhaPjIXEo9qPwiB2RcedBlxzI
-        g2xm8MR1q0GAqXRezwj55DFRBUPHAx80wvdw/EWRTSQPbx6NJ/locaA/ydnHwtPiWNWejnJ7s2Z/
-        EqVKzqSoWkEvlsoyGli2jIeKKrMOuVQ2TNbFeiBKMx5EKQIvYNpm8O8s9PjvBFFrzI6iBqAy8r1w
-        mmgtwvrAoz0mTJ1wRNw8AmckgxASc36QCttJOAJ3/X1f4P7LNL75OYLl5ud0nVvXzZNGhwt/72B3
-        RMfgjcaHKInvIZ4hrw994GCJuQ/RN0NBiua1aqtX7UqNaIR0moxIxcH2vakNEQlEB6KVyc8uVnDI
-        nT1zs1W7VygTid6fIusWjfB2FdoLhr0Ej0ZBR12LlWcTwPGnMaG434YYg6j0IerfRat7Hw8rtUbn
-        Sq7V0nQCilS1ZySAlLi3W9aqcuSRcuKg6z3Zn/6e5qvA9h/4k8/r0hHBFQmONUUpyIqR/ZiwXMCx
-        DYueONd3x2m68tinUu9aAhGwjyHvRhioAICaPZT49fxU17/sNA46dqepUrcbe5kvn5pXrxqfrz7G
-        Ka0ZzvvoLk2D3n4a/PcIOOeQarLykWqa5lxTvijqDXfHbBSSj3oOrq/78W1z4F4DwlUtyrCUKeXi
-        o5KsKnDJ/SikgqA/QAGGumeLp/a6XQmKBQw1QsSxf/h+/ZqPA/iXVP3L+eKGmrBmAtYR/30TT2Ya
-        smLL85GzW8urmOtVmqYqque1D1Z0BpWb52+NAlHbHmfd80IFI7W/NSpH1/P2ZW1+Oj+bt+rZ485F
-        5ejydH41/zS/jjpqwFKbX3fmNXbM4+S7Rma3hE6jcpaTGpXTDVjfODaex/Hl8FV7laOLeXXeyh5X
-        QduzeXN+Ac2wctSad+fN7HGNtdrzWvb4fNGqJq0Flq+bZhuwMGsrJ8Fv9Z2hLeyRd2aFvPJHTz6F
-        PbMP1/WPn4IKL8lBqzq/NJIqMPo4yig8n3yO00mcTT5HyQRyybwDB3HcvGzQD04/hX0x/C7oWAJp
-        QQK5mLejFHIxP8setzuslzeved7oZI+7DK8azyhnQGrxjBK3qklLBPiNp/6hySoqcT410gzwad/l
-        ZByaz1U0nxrr1QyUc+9Syi13q/o2DiyfTNnmW5qOY2zdSi128MZr/zcQfQFWmuALNqkjsB2ECpte
-        Fm9595EV7UBv6lOPOI7/7UI1KFUjvuBwasbN4tfW+thxiJemTYMTDrkGXkgfjX1WhfcIkXfdpUAz
-        RBwmQ5pusVJVgedA7MLzcaN+IvPNpG2C1xFFbIH5tltOB7U3HPeMw8F2HM448UAsFwsc8/YxmGfL
-        yqaxwik1gHNfNeKhgYR8LIku3vKkWACJBHCZ/T0k7GYnJ9zynIrTh74nFtjuDx76E+TcodTSoJGw
-        SScPUnPBdlgGjZRwcRCEabcqVnRoJVw/RAV+Ay6+ob8p6BlQWfP4vC1VbdsHUV+R0FVTy6slI6/m
-        tZxaZu08/MjLpqLkVIX9yxdhyazpOS4dvkewbsH8DvDHbeGfV3vVFERY9wszqPylKv+G5G838mpG
-        Xe/fkmH5GTfWwKoqV2VFLaofeVsDRDlJx+TkwzE5ScXk5CMxCSgZ9QM8w+wBhXRcmlJ3Sd8HHTI7
-        7938vEXn5WyRyue9D7Z+2k0t1v3h1r/68RFB3D4dAwr4Li3Fn7vS1RhDcr87oIJk+1X1UC+kwuJu
-        gikKeGea/AviIRdQSxW2VVCCHn+Y6oknh2b3NC05NInle4E3pNJJ6DiYEne/PNHsrt3+X+vYkhma
-        XdOUTdMEdkWRy4b5gQhcdnv1tKsj7//TFF1TNkF/Gg6clafTNtVuM0apvWRkBeiWBAOEIcGOvQHE
-        o/50HDW0ZSMVEvbQx3GzeVyvb5icTS87LGvELZw0R3TZWnRywHjrtdslO3cR25xfqq8wHdJW3BBN
-        iMMfYtwq/Cln2Zlf+5PQoWSZZRdn6UD1c4aodOFZ7O5O/JinxDdX2SWTPzwpSHXWlq8/7+TWBO46
-        HhDk7mQvCOxdz0E+1MC7+HWB/xTbno92shcF9tqv5xIahAFOiCWB+CuY2PN2zlUWRQ27jZ3MhsBc
-        Pd8NmSnwfiIuGCyQKtJm0l4YRBEH4AFM68/YI50xWTRYt3nVlqa+B24zWTCINjr1MT7p1nd7gGil
-        60Ho0nA3v2ilroOsW7as2T1EtFSTPRmNbp8ZIZqvgycexdKQOFhClhVVyJxLtFoNjHzZ3T2raLjT
-        q3bSnWKjxOGVFcktOMEzEaKuhIhLgNMbciMSfiuAM4k2apLAyieElYiJxkg2ptiKsxdn0ldOwTfo
-        pWuX3Iv785wxPUDA/T53uwnPSpwgyDi+51FY+jPIeeLhXCLQnXYt6TZSnfs6wL40QS4a4QnmtxU4
-        s7kakZAYnSRPiCgnm6iLJCIi2sbYl688mf2XTplDdMeQVtzkAfuCiGztvFu7TAgisqfEx3fIcRan
-        EBE9AY+2PW8RcQURxW6tWq8mBBG6eitBtCBiBVA44K9SENlyMacIXJu/HiEtbx0lTOa6aZAUjLHj
-        rFtHV1a8hkI2GS1S6gp6nk+l+OH6BYOIGHs1I6pROGkVM3cEmK/kWH0lFbSaSUDpImSt8wQZvbSe
-        Bshsd4bXRSx7TZ5oGt3dEaiL2J74Icscng9xBOsGJLCJ6P4rdL3dl6biCsYWAb9mbw9IF8QN73eP
-        FC3Q9AbMaetY9IaiaIJLH1nAsce8onWqE/QN1n97jBJN1kaOJ1UduvvSWBSteRaiO0x284tmPi0m
-        7/s8g295A4Nec/cI0c7nrkVssInUwcHUc4PEhYuilXvEp6H37dtudUuipX+72r0SKKlPb1fG7loH
-        7lvcHCnzLyos4qOVvJIrPWWPvn4NfpLZz9E6KfvLUY4TXjhqS9H0mf3l+K/Mf9fqJ0VR3qPmj3pS
-        XujZimZTYP1rFE1bNkNiPA50I8QL6TRM24uKxb5M6N8rOMX3NOfRMVzYWPNjtjJid92nwI/U/CtX
-        +DFYXMmtAF1F1L22IB2WzflUbA31JpuQsKrKs580AaPufXelHtVc8WmZeZd9SaJ+jmtLYjaUnAHJ
-        VzYUQ3lBTk6e02TWfiEcvkc9y3PSIFmS9tsztqZwFNrsl1iT6VuYTLxUpIjYwRYKqPQPVlDhaboB
-        UySNuPnt/WgGaL7f0yhsQQLlZYr4MeVPsyEaYNxHTuClqophActJh3bx2nHXcucNy23berDGHTI9
-        Lzz28EoT2yRkr2ufkRGTrgbzEZbZ3sXhAs8Jt8RKd0k6pK1VUfgH15sGJO0WYndJOlDhQzcIpyyl
-        Rs+7zLBr82eu1zW5XvKxJ156Cd8PuS1HoX67Je4oPyR+QPtDL3TTSpvV1zRPGS+UWTjdlf4U65sF
-        MPwLBPvhcoH+9LBsuv1s6ue3vbmyCk/bJx6vyzuI7XtJR712J/ui617yEssPfGeHse5TEKyp/pep
-        CxZxw76t8TwwXboVjc3k18LsenpK7vnCrWpRMsN8BReE/hBZb7OGo2iUL5SLhorYV3ZKSJF1DQ1l
-        0y4NZH2gGqWCqWl2wUxRbc9h33F/kH97aIacEPcLqgoMvL1J2NziCjCVx/wTEXHL9ejLwFD0QtnQ
-        UUnWFFsFrQaKjIYqlhWESwUFq5ZmWSlg7DnsdWAUjXQsoP89oOBngDDGI/ZFmxL/nsy63mk8r1Sy
-        qG3REgjvYnG1bJfNoipjXdNlHWNVRoaOZXWIlaFmalixh2kW32/Y68AoF0vpYDDC+9u8bPDz7zZ6
-        zPQ6RXW1kK4oI7yHoqUCLiKMsGyWypC9DG0gG4aNZN0qDPWBNSjbqp6i+p7DXgcG+5xZOhqc8jZw
-        3LDvudHk800+nsDc/JINPY9PT/8HpjaqSSpOAAA=
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKBhlWVTIcyhVLrcqqZhJZpZotk5pStxS7MtJVozqq
+        1StVtVYxq0pVGdVAMGqzcEAcx7un9lw2LjzoOEgUuupJTceLbKkX10O3qecw6xHaDknALOmMhvee
+        fysA0BrcEJ/OFfOG/6NWKDTVVLNUCMk4ISNIIcRyoPzpqbCksFJKuY5RNgtA18dErLguW15wGT5O
+        ueA2HZHICQvPpZWRBZXJ2OrqwLmGXasXKs2vxi1WeL4uFW68ILS8yA2FComhqkbNIjWzLttU1WSj
+        TjV5ONI1MFdN1zVDV5WKwqkLSRiBhAWfBtGEufwywpeSi0yDAmcwYS8paeVpNOTFckhdMnRoQK3I
+        Z+Fj2fImgCdOmDI+ACkXhp5aTIbB5WjqeGTZ/gOQxAcN1ErN0CtKrVaD67IJ+DaZTOfVpg5E3pDg
+        djjvDGckAq8KfcKcNZdKRuVmegYsC0LPfxSmT8rCT1RVqeqmmhppkBBt+ZSEYMGBDR6/LJpDIOgm
+        ns1GzEIwQs6XWSJLOG6VOBJ9YeUcilN34N4NxbvIAXXIkDksZDSpBBtNMxh+6jDiWjQ+HzEnpH4c
+        HokjcnQZdCmBPMTmBk9dtxEENJROWoVMPnlKVaFQ8Sg6jekDnH9SZMgSo+un+rO8Nz8xnuXik/48
+        P1e1573S1tDiT1mp0ispqqYblWpNJkPLlulIUWVeIVdrdZNX8RqI0oIHUUrAC7i2Bfo7Dz1xnJDQ
+        uuFncQFYGfteNE21ztL6KKI9aZg60Zi5ZQLOyIYRJObyEKXtMBqDu/6+LXH/5Rpf/xzTcv0zrvPZ
+        VeewfSGEf3CoOw5vwBvr76IkfYB4hrw+8gHBE/MAou+OBIjmzcZZv9GT2nEP6SjtgfJg+97UhoiE
+        RgeilcvPb1ZwKpy9cJ2r3XcoE4s+mBLrloxpvgrdOWArweNeUNHSEuX5AHD+4YaFdNCFGIOo9CHq
+        30SrB5+ODprti0u52cR0ghapYd+xAFLi1m7ZbMixR8qpg67WFH/6O+arAPs3/MknLWmP0QMJzjVF
+        0WWlXnyfsJzTkcdFPzvWN8cprjz1Q6l/JYEI1KeQd2MOVCBALe5K/Ho+6vrnF+2djt0pKnW3vZX5
+        ymhevWx/vHwfp7TuaNkn95gG/e00+O8eIGeQaorynmqa5kxTPinqtXDHYhyST0YJ7q/b4fIcuN+G
+        cFUrslmvVUvJGawBFLjlvhdTQTAYkoDCuifHU/u9ngSLBQprhBixffh+/lxOAvgXVP9aubKmJsyZ
+        ADoWx1fxZK4hX2x5PnE2a3mZoL5LU1RRo6y9s6J3sHLz/NwoyGrbF9Atb1TQU/tb+2DvatY9b86O
+        Zsezs1Zx/+L0YO/8aHY5+zC7iiuaAGnOri5mTX4u4uSbehZzQqd9cFyS2gdHa7S+cmx8nceX09fo
+        H+ydzhqzs+J+A7Q9nnVmp1CMDvbOZr1Zp7jf5KXurFncP5mXGmlpzuX3DZNHLIx6VpLg2HhjavUt
+        8s6dXlb+6MlH3zL7CF3/+ClIf0kOWtb5pZF0AL3344wi8snHJJ0k2eRjnEwgl8wu4CSJm5d1+sHp
+        R9+Ww2+ijieQM0ggp7NunEJOZ8fF/e4FrxXFK5E3Lor7Pc5XU2SUY2g6ExklKTXSUpbgVx76hyar
+        eInzoY0Z4MO208kkNL+2ovnQXl3NwHLuTZZyi92qgU0Dy2dTvvmG6XhDrVvpjJ+88tz/FUSfk4UJ
+        PodJFxnYTqiw7mXJlveAWPEO9Lo+rRix/5sLq0GpEeOC3Vkzri9+bW1AHYd5mDZt0bDLa+C59HHf
+        r6rwFiHyprsU5I4wh8uA6ZYo1chgdsQuIh+3W4ey2EzKE7xFQsInmK+75bRTe8NJzU00zOfhWDTu
+        iOUSgRPsgIJ5cmY27SWk1AbktmokXQOJ+FTKuviZJyUCSCyA2+zvEeMPO0XDrcipFO/6llxQezB8
+        HEyIc0/QpUE7hUmHj1JnDtstg8ZKuDQIIuxRxZIOZynqh6ggHsAlD/TXBT2GVl7cP+lKDdv2QdTv
+        SOiqqZXVar2slrWSWuPlMhzkRVFRSqrC/5UrMGXWjJKQjj4QmLdQ8QT4/bbwTxr9BsIIr35hBpU/
+        NeT/EPnLtbycUVfrczKsuOLaHFhV5YasqBX1PR9rgCiHOCeH787JIcrJ4XtyEoRsPAjoHeUvKOC8
+        dKTeon0bdtjdSf/65xydF6PFKp/039n62EMtXv3u1r/88RHB3EF4AyzQeyzFn7jS5Q2F5H6/QwuS
+        /Lvqrt5IM5O7CQ1JICox+eeNu7yAWqiQt4LK6PGHWT2J5NDpHWHJocMs3wu8USgdRo5DQ+Zulyc6
+        vZXH/ysVOZmh0zNN2TRNgCuKXKub78jAea/fwu6Oov5Ps+ia8gEG02joLL2dtq52lwOl7gLIF6A5
+        CQYaRow69hoRT8bzflzQFgWUEv7Sx36ns99qrZmcDy87PGskJZoWx+GiNK8UhInS926XbNxF7Aq8
+        1FoC7dJW3IhMmCNeYswV/khANubXwSRyQrbIsvOrXMDq55iE0qln8ac7yWuekthc5bdM8fJkRqrj
+        rnz1cSNay6BbdMiIuxGuZ+A9zyE+rIE34Y0M/ojank82wisZePPXE4kMo4CmjdVM469gYs/bOFYt
+        K2rUa28E1zPgxslmyswM9gNzwWCBdCCtJ+25QZRsBzqEYf07/kpn0pw1WK9z2ZWmvgduM5kDsjY6
+        8ik97LU2e0DWSlfDyA2jzfislXoOsW75tGZzl6ylOvzNaHL7lR5Z813QiRdSacQcKhHLilfIApW1
+        WhOMfN7bPGrWcEeX3bQasVHq8MqS5BZc4CsRoi6FiMsA6Y2EEZl4FCBAWRt1WGCV04aliIn7SDYN
+        qZVkLwEyli4hNuilK5c9ZPfnBRAPEHC/j71eilmKEwIZx/e8EKb+nHKReAQqS/RFt5lW11Hnvgqo
+        L02IS8Z0QsVjBQE2lyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PQFez3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+j5AW
+        j45SkLlqGiIFN9RxVq1jKEteE0I2Gc9T6hJ7nh9Kycv1c0CWMf5pRrxGEU3LnLlj4HwpxxpLqeCs
+        kwaUkaXs7CRlxqiupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn89IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqTf+3yF39oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsblVZ
+        Coj7Hv8IRWr+2jvd3E19fr0F7aYZ4bbLnD1l9kmF6Xw8p1dK1efi3ufPwU8yP+ytNhV/2SuJhhf2
+        ylk+feR/JXGUxXFlJaUoylus/uMa5NOeXDY7GehfY/mUsy2S8LGjWyJeFE4jbFcqEfs8bf9WwUP6
+        EJa88AZucbz4Ppsaibtus9SP1fwrr/UTsoSSuQRdxq1bbUY6PJuLofhs6lW2I2F+VeYHTMC4etv9
+        qSe1VHleZN5FXZqov4bKScx1pVSH5CvXlbrygpycvrHJrf1COnwv9CzPwShZNG23e2xN4Syy+ZFZ
+        k+lrmCx7q0BEvKAWCULpH3xpRae4ARFJY7R40B+PAMW3ey+FT0hgoYmIn7T8abZGA0oHxAk8VFUK
+        U1nRtGs3rw3PLzc+uszb4IPZ7ojreerx11g61GYR/3D7mI25dE0Yj/HM9iYOF3hOlBMrvUXTLm2y
+        ZoV/dL1pwLCHib1F044KH7lBNOUpNX7z5Y66tnj7elWTqwWOv/vST3E/5AFdCCu5W+aOyyPmB+Fg
+        5EUutrRZ/mDziGNhmUVxV/pTzG/mxIjfItiOl1Pyp6dl3e3vpn457xuWZXq6PvPEuvyC8B0waa/f
+        vSi+6L6Xfs7yA7/e4dBtFgQrqv9l1gXzuOG/svF1YnphLhvrye+M8vvpEXsQE7eGFbI7KmZwQeSP
+        iPU6c7iQjMu91m8SWIuOPR+dFCw3f8OTPz7CHXEiqpnQKkortdndzHl1HQXXUbBaxcBqFQXrKgbW
+        VXzkCjpyBR/ZQEc2cAVRsIaDdZQNHWdDR9nQcTa0GipGDR8ZBes4WEN51nCeUf1y1FNQIRRcCBSs
+        4WDUP3H3xJAoELUFbgrUIXB/UFFDqLghDB0dWMcJ01DCNFwMlF0VZ1dHQ0nHQ8lARzbwkQ1UZgOX
+        WUPF0HAxcDJwLlCW1RyWUbfQckIUHVnDRzbQqDPwqEMHxsdVUe9Uc9IVPnDOyGjYqXjc6ahF9ByT
+        oFyoOBeoW+BegQYfHnsqKq+Ky6ujTOg4EyqaMqF2/dFPQEP5RvyIUlJyvfBlkwS7PqqPhlUq19SR
+        JRuWYsqmpWmyNTRMalO7YhgVZPKwZbdvmFSInyoUGg/MWjZXrDS8DRmqSZSaIht2TQOtqpo8NEa6
+        bKuaVdcpMWyRytfJ2Krb95FRr2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEJJVaaKMpSN4YjIdTKs
+        yoo1rNQqRtUaWVVEsS27fZ8Vq9UcK/KGtyBDHdVVo2pXQBeTB6quyMSo6rJlUaOqqSPTqGLxvWW3
+        byVD/MRnrLj9CA3MWmUFQbwFPZZdp6QOiumVKuipalXZJPxHAWmtpqlEU1TDROjZstt3pj8zJ/uZ
+        r0TFNf8R2DD9zUefToB0sbqHmqfn5/8DdS/C3F9WAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -2086,12 +2873,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:55:02 GMT
+      - Thu, 21 Nov 2019 15:42:30 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -2101,9 +2888,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 777cbcb780a795d0486014349cfc5dfc
+      - 9598f4e2d5834f0574ac96a7293f4f15
     status:
       code: 200
       message: OK
@@ -2119,76 +2906,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPbGLB5mSVAJtkNhAMJ3TvdWY6wBWhjbMaWSdIh/31L
-        sg0CDCGdSzMzeSCyqiRXfXWxSr48Zog79DKVx4x352I/U8kg1/bx3T8D+zbv+aNMLuOiCYZ+igPa
-        Dyzk9ofknoY+ZiSvT5E/wjRTGSInwLnM0HNs7PeJnam4oePkMpbnUt9zMhXqh0APA6BOsT8hQUA8
-        N8hUVM3IZQJrjO3Qwf0wZEPhZJOpgyiW8cBCFioUZK1gFuQywiXZUIdFaKlFW9MMU7UMs6DoFkJ6
-        0SgrSC3pIBi2Ce0jx/HusL2QjQkPOvZjha67Us3xQlvqRv0wbOo5xHoA2gkKiCW1ML3z/FvOANRg
-        jHy8UMwb/A9blGuqqkouQ9EoBiNIWJDlQPvLY2ZFYeCNsY64bBKArg+xWFGf2F5iSR+mTHAbD1Ho
-        0MxTbm1mDmU8t7o+8VbDbvSzE2qLszGLZZ5ucpmxF1DLC13KVYgNZeimOdQUSzZtpMu6aZRlA2wm
-        FxUbmdg2Tb1YYNBRREOQMOPjIJwQl52G+1J8kmmQYQjG6MUtLT8NB6yZp9hFAwcH2Ap9Qh/yljcB
-        fuTQBPE+SLk09NQiMkwuh1PHQ6v274MkPmigFkuFQtkwFMCJkgn4NppMl90maDhGwe1gMRiOUAhe
-        RX1EnA2XimdlZnoCXhJQz3/gpo/bkZ8ohmYqhcRI/Rhoy8eIggX7Nnj8qmgOgqCbeDYZEiuNx3yx
-        JUTA060SRaLPrbwF4sQdmHdDcxY6oA4aEIdQguNOsNFU4GGHDkGuhaPjIXEo9qPwiB2RcedBlxzI
-        g2xm8MR1q0GAqXRezwj55DFRBUPHAx80wvdw/EWRTSQPbx6NJ/locaA/ydnHwtPiWNWejnJ7s2Z/
-        EqVKzqSoWkEvlsoyGli2jIeKKrMOuVQ2TNbFeiBKMx5EKQIvYNpm8O8s9PjvBFFrzI6iBqAy8r1w
-        mmgtwvrAoz0mTJ1wRNw8AmckgxASc36QCttJOAJ3/X1f4P7LNL75OYLl5ud0nVvXzZNGhwt/72B3
-        RMfgjcaHKInvIZ4hrw994GCJuQ/RN0NBiua1aqtX7UqNaIR0moxIxcH2vakNEQlEB6KVyc8uVnDI
-        nT1zs1W7VygTid6fIusWjfB2FdoLhr0Ej0ZBR12LlWcTwPGnMaG434YYg6j0IerfRat7Hw8rtUbn
-        Sq7V0nQCilS1ZySAlLi3W9aqcuSRcuKg6z3Zn/6e5qvA9h/4k8/r0hHBFQmONUUpyIqR/ZiwXMCx
-        DYueONd3x2m68tinUu9aAhGwjyHvRhioAICaPZT49fxU17/sNA46dqepUrcbe5kvn5pXrxqfrz7G
-        Ka0ZzvvoLk2D3n4a/PcIOOeQarLykWqa5lxTvijqDXfHbBSSj3oOrq/78W1z4F4DwlUtyrCUKeXi
-        o5KsKnDJ/SikgqA/QAGGumeLp/a6XQmKBQw1QsSxf/h+/ZqPA/iXVP3L+eKGmrBmAtYR/30TT2Ya
-        smLL85GzW8urmOtVmqYqque1D1Z0BpWb52+NAlHbHmfd80IFI7W/NSpH1/P2ZW1+Oj+bt+rZ485F
-        5ejydH41/zS/jjpqwFKbX3fmNXbM4+S7Rma3hE6jcpaTGpXTDVjfODaex/Hl8FV7laOLeXXeyh5X
-        QduzeXN+Ac2wctSad+fN7HGNtdrzWvb4fNGqJq0Flq+bZhuwMGsrJ8Fv9Z2hLeyRd2aFvPJHTz6F
-        PbMP1/WPn4IKL8lBqzq/NJIqMPo4yig8n3yO00mcTT5HyQRyybwDB3HcvGzQD04/hX0x/C7oWAJp
-        QQK5mLejFHIxP8setzuslzeved7oZI+7DK8azyhnQGrxjBK3qklLBPiNp/6hySoqcT410gzwad/l
-        ZByaz1U0nxrr1QyUc+9Syi13q/o2DiyfTNnmW5qOY2zdSi128MZr/zcQfQFWmuALNqkjsB2ECpte
-        Fm9595EV7UBv6lOPOI7/7UI1KFUjvuBwasbN4tfW+thxiJemTYMTDrkGXkgfjX1WhfcIkXfdpUAz
-        RBwmQ5pusVJVgedA7MLzcaN+IvPNpG2C1xFFbIH5tltOB7U3HPeMw8F2HM448UAsFwsc8/YxmGfL
-        yqaxwik1gHNfNeKhgYR8LIku3vKkWACJBHCZ/T0k7GYnJ9zynIrTh74nFtjuDx76E+TcodTSoJGw
-        SScPUnPBdlgGjZRwcRCEabcqVnRoJVw/RAV+Ay6+ob8p6BlQWfP4vC1VbdsHUV+R0FVTy6slI6/m
-        tZxaZu08/MjLpqLkVIX9yxdhyazpOS4dvkewbsH8DvDHbeGfV3vVFERY9wszqPylKv+G5G838mpG
-        Xe/fkmH5GTfWwKoqV2VFLaofeVsDRDlJx+TkwzE5ScXk5CMxCSgZ9QM8w+wBhXRcmlJ3Sd8HHTI7
-        7938vEXn5WyRyue9D7Z+2k0t1v3h1r/68RFB3D4dAwr4Li3Fn7vS1RhDcr87oIJk+1X1UC+kwuJu
-        gikKeGea/AviIRdQSxW2VVCCHn+Y6oknh2b3NC05NInle4E3pNJJ6DiYEne/PNHsrt3+X+vYkhma
-        XdOUTdMEdkWRy4b5gQhcdnv1tKsj7//TFF1TNkF/Gg6clafTNtVuM0apvWRkBeiWBAOEIcGOvQHE
-        o/50HDW0ZSMVEvbQx3GzeVyvb5icTS87LGvELZw0R3TZWnRywHjrtdslO3cR25xfqq8wHdJW3BBN
-        iMMfYtwq/Cln2Zlf+5PQoWSZZRdn6UD1c4aodOFZ7O5O/JinxDdX2SWTPzwpSHXWlq8/7+TWBO46
-        HhDk7mQvCOxdz0E+1MC7+HWB/xTbno92shcF9tqv5xIahAFOiCWB+CuY2PN2zlUWRQ27jZ3MhsBc
-        Pd8NmSnwfiIuGCyQKtJm0l4YRBEH4AFM68/YI50xWTRYt3nVlqa+B24zWTCINjr1MT7p1nd7gGil
-        60Ho0nA3v2ilroOsW7as2T1EtFSTPRmNbp8ZIZqvgycexdKQOFhClhVVyJxLtFoNjHzZ3T2raLjT
-        q3bSnWKjxOGVFcktOMEzEaKuhIhLgNMbciMSfiuAM4k2apLAyieElYiJxkg2ptiKsxdn0ldOwTfo
-        pWuX3Iv785wxPUDA/T53uwnPSpwgyDi+51FY+jPIeeLhXCLQnXYt6TZSnfs6wL40QS4a4QnmtxU4
-        s7kakZAYnSRPiCgnm6iLJCIi2sbYl688mf2XTplDdMeQVtzkAfuCiGztvFu7TAgisqfEx3fIcRan
-        EBE9AY+2PW8RcQURxW6tWq8mBBG6eitBtCBiBVA44K9SENlyMacIXJu/HiEtbx0lTOa6aZAUjLHj
-        rFtHV1a8hkI2GS1S6gp6nk+l+OH6BYOIGHs1I6pROGkVM3cEmK/kWH0lFbSaSUDpImSt8wQZvbSe
-        Bshsd4bXRSx7TZ5oGt3dEaiL2J74Icscng9xBOsGJLCJ6P4rdL3dl6biCsYWAb9mbw9IF8QN73eP
-        FC3Q9AbMaetY9IaiaIJLH1nAsce8onWqE/QN1n97jBJN1kaOJ1UduvvSWBSteRaiO0x284tmPi0m
-        7/s8g295A4Nec/cI0c7nrkVssInUwcHUc4PEhYuilXvEp6H37dtudUuipX+72r0SKKlPb1fG7loH
-        7lvcHCnzLyos4qOVvJIrPWWPvn4NfpLZz9E6KfvLUY4TXjhqS9H0mf3l+K/Mf9fqJ0VR3qPmj3pS
-        XujZimZTYP1rFE1bNkNiPA50I8QL6TRM24uKxb5M6N8rOMX3NOfRMVzYWPNjtjJid92nwI/U/CtX
-        +DFYXMmtAF1F1L22IB2WzflUbA31JpuQsKrKs580AaPufXelHtVc8WmZeZd9SaJ+jmtLYjaUnAHJ
-        VzYUQ3lBTk6e02TWfiEcvkc9y3PSIFmS9tsztqZwFNrsl1iT6VuYTLxUpIjYwRYKqPQPVlDhaboB
-        UySNuPnt/WgGaL7f0yhsQQLlZYr4MeVPsyEaYNxHTuClqophActJh3bx2nHXcucNy23berDGHTI9
-        Lzz28EoT2yRkr2ufkRGTrgbzEZbZ3sXhAs8Jt8RKd0k6pK1VUfgH15sGJO0WYndJOlDhQzcIpyyl
-        Rs+7zLBr82eu1zW5XvKxJ156Cd8PuS1HoX67Je4oPyR+QPtDL3TTSpvV1zRPGS+UWTjdlf4U65sF
-        MPwLBPvhcoH+9LBsuv1s6ue3vbmyCk/bJx6vyzuI7XtJR712J/ui617yEssPfGeHse5TEKyp/pep
-        CxZxw76t8TwwXboVjc3k18LsenpK7vnCrWpRMsN8BReE/hBZb7OGo2iUL5SLhorYV3ZKSJF1DQ1l
-        0y4NZH2gGqWCqWl2wUxRbc9h33F/kH97aIacEPcLqgoMvL1J2NziCjCVx/wTEXHL9ejLwFD0QtnQ
-        UUnWFFsFrQaKjIYqlhWESwUFq5ZmWSlg7DnsdWAUjXQsoP89oOBngDDGI/ZFmxL/nsy63mk8r1Sy
-        qG3REgjvYnG1bJfNoipjXdNlHWNVRoaOZXWIlaFmalixh2kW32/Y68AoF0vpYDDC+9u8bPDz7zZ6
-        zPQ6RXW1kK4oI7yHoqUCLiKMsGyWypC9DG0gG4aNZN0qDPWBNSjbqp6i+p7DXgcG+5xZOhqc8jZw
-        3LDvudHk800+nsDc/JINPY9PT/8HpjaqSSpOAAA=
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKBhlWVTIcyhVLrcqqZhJZpZotk5pStxS7MtJVozqq
+        1StVtVYxq0pVGdVAMGqzcEAcx7un9lw2LjzoOEgUuupJTceLbKkX10O3qecw6xHaDknALOmMhvee
+        fysA0BrcEJ/OFfOG/6NWKDTVVLNUCMk4ISNIIcRyoPzpqbCksFJKuY5RNgtA18dErLguW15wGT5O
+        ueA2HZHICQvPpZWRBZXJ2OrqwLmGXasXKs2vxi1WeL4uFW68ILS8yA2FComhqkbNIjWzLttU1WSj
+        TjV5ONI1MFdN1zVDV5WKwqkLSRiBhAWfBtGEufwywpeSi0yDAmcwYS8paeVpNOTFckhdMnRoQK3I
+        Z+Fj2fImgCdOmDI+ACkXhp5aTIbB5WjqeGTZ/gOQxAcN1ErN0CtKrVaD67IJ+DaZTOfVpg5E3pDg
+        djjvDGckAq8KfcKcNZdKRuVmegYsC0LPfxSmT8rCT1RVqeqmmhppkBBt+ZSEYMGBDR6/LJpDIOgm
+        ns1GzEIwQs6XWSJLOG6VOBJ9YeUcilN34N4NxbvIAXXIkDksZDSpBBtNMxh+6jDiWjQ+HzEnpH4c
+        HokjcnQZdCmBPMTmBk9dtxEENJROWoVMPnlKVaFQ8Sg6jekDnH9SZMgSo+un+rO8Nz8xnuXik/48
+        P1e1573S1tDiT1mp0ispqqYblWpNJkPLlulIUWVeIVdrdZNX8RqI0oIHUUrAC7i2Bfo7Dz1xnJDQ
+        uuFncQFYGfteNE21ztL6KKI9aZg60Zi5ZQLOyIYRJObyEKXtMBqDu/6+LXH/5Rpf/xzTcv0zrvPZ
+        VeewfSGEf3CoOw5vwBvr76IkfYB4hrw+8gHBE/MAou+OBIjmzcZZv9GT2nEP6SjtgfJg+97UhoiE
+        RgeilcvPb1ZwKpy9cJ2r3XcoE4s+mBLrloxpvgrdOWArweNeUNHSEuX5AHD+4YaFdNCFGIOo9CHq
+        30SrB5+ODprti0u52cR0ghapYd+xAFLi1m7ZbMixR8qpg67WFH/6O+arAPs3/MknLWmP0QMJzjVF
+        0WWlXnyfsJzTkcdFPzvWN8cprjz1Q6l/JYEI1KeQd2MOVCBALe5K/Ho+6vrnF+2djt0pKnW3vZX5
+        ymhevWx/vHwfp7TuaNkn95gG/e00+O8eIGeQaorynmqa5kxTPinqtXDHYhyST0YJ7q/b4fIcuN+G
+        cFUrslmvVUvJGawBFLjlvhdTQTAYkoDCuifHU/u9ngSLBQprhBixffh+/lxOAvgXVP9aubKmJsyZ
+        ADoWx1fxZK4hX2x5PnE2a3mZoL5LU1RRo6y9s6J3sHLz/NwoyGrbF9Atb1TQU/tb+2DvatY9b86O
+        Zsezs1Zx/+L0YO/8aHY5+zC7iiuaAGnOri5mTX4u4uSbehZzQqd9cFyS2gdHa7S+cmx8nceX09fo
+        H+ydzhqzs+J+A7Q9nnVmp1CMDvbOZr1Zp7jf5KXurFncP5mXGmlpzuX3DZNHLIx6VpLg2HhjavUt
+        8s6dXlb+6MlH3zL7CF3/+ClIf0kOWtb5pZF0AL3344wi8snHJJ0k2eRjnEwgl8wu4CSJm5d1+sHp
+        R9+Ww2+ijieQM0ggp7NunEJOZ8fF/e4FrxXFK5E3Lor7Pc5XU2SUY2g6ExklKTXSUpbgVx76hyar
+        eInzoY0Z4MO208kkNL+2ovnQXl3NwHLuTZZyi92qgU0Dy2dTvvmG6XhDrVvpjJ+88tz/FUSfk4UJ
+        PodJFxnYTqiw7mXJlveAWPEO9Lo+rRix/5sLq0GpEeOC3Vkzri9+bW1AHYd5mDZt0bDLa+C59HHf
+        r6rwFiHyprsU5I4wh8uA6ZYo1chgdsQuIh+3W4ey2EzKE7xFQsInmK+75bRTe8NJzU00zOfhWDTu
+        iOUSgRPsgIJ5cmY27SWk1AbktmokXQOJ+FTKuviZJyUCSCyA2+zvEeMPO0XDrcipFO/6llxQezB8
+        HEyIc0/QpUE7hUmHj1JnDtstg8ZKuDQIIuxRxZIOZynqh6ggHsAlD/TXBT2GVl7cP+lKDdv2QdTv
+        SOiqqZXVar2slrWSWuPlMhzkRVFRSqrC/5UrMGXWjJKQjj4QmLdQ8QT4/bbwTxr9BsIIr35hBpU/
+        NeT/EPnLtbycUVfrczKsuOLaHFhV5YasqBX1PR9rgCiHOCeH787JIcrJ4XtyEoRsPAjoHeUvKOC8
+        dKTeon0bdtjdSf/65xydF6PFKp/039n62EMtXv3u1r/88RHB3EF4AyzQeyzFn7jS5Q2F5H6/QwuS
+        /Lvqrt5IM5O7CQ1JICox+eeNu7yAWqiQt4LK6PGHWT2J5NDpHWHJocMs3wu8USgdRo5DQ+Zulyc6
+        vZXH/ysVOZmh0zNN2TRNgCuKXKub78jAea/fwu6Oov5Ps+ia8gEG02joLL2dtq52lwOl7gLIF6A5
+        CQYaRow69hoRT8bzflzQFgWUEv7Sx36ns99qrZmcDy87PGskJZoWx+GiNK8UhInS926XbNxF7Aq8
+        1FoC7dJW3IhMmCNeYswV/khANubXwSRyQrbIsvOrXMDq55iE0qln8ac7yWuekthc5bdM8fJkRqrj
+        rnz1cSNay6BbdMiIuxGuZ+A9zyE+rIE34Y0M/ojank82wisZePPXE4kMo4CmjdVM469gYs/bOFYt
+        K2rUa28E1zPgxslmyswM9gNzwWCBdCCtJ+25QZRsBzqEYf07/kpn0pw1WK9z2ZWmvgduM5kDsjY6
+        8ik97LU2e0DWSlfDyA2jzfislXoOsW75tGZzl6ylOvzNaHL7lR5Z813QiRdSacQcKhHLilfIApW1
+        WhOMfN7bPGrWcEeX3bQasVHq8MqS5BZc4CsRoi6FiMsA6Y2EEZl4FCBAWRt1WGCV04aliIn7SDYN
+        qZVkLwEyli4hNuilK5c9ZPfnBRAPEHC/j71eilmKEwIZx/e8EKb+nHKReAQqS/RFt5lW11Hnvgqo
+        L02IS8Z0QsVjBQE2lyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PQFez3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+j5AW
+        j45SkLlqGiIFN9RxVq1jKEteE0I2Gc9T6hJ7nh9Kycv1c0CWMf5pRrxGEU3LnLlj4HwpxxpLqeCs
+        kwaUkaXs7CRlxqiupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn89IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqTf+3yF39oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsblVZ
+        Coj7Hv8IRWr+2jvd3E19fr0F7aYZ4bbLnD1l9kmF6Xw8p1dK1efi3ufPwU8yP+ytNhV/2SuJhhf2
+        ylk+feR/JXGUxXFlJaUoylus/uMa5NOeXDY7GehfY/mUsy2S8LGjWyJeFE4jbFcqEfs8bf9WwUP6
+        EJa88AZucbz4Ppsaibtus9SP1fwrr/UTsoSSuQRdxq1bbUY6PJuLofhs6lW2I2F+VeYHTMC4etv9
+        qSe1VHleZN5FXZqov4bKScx1pVSH5CvXlbrygpycvrHJrf1COnwv9CzPwShZNG23e2xN4Syy+ZFZ
+        k+lrmCx7q0BEvKAWCULpH3xpRae4ARFJY7R40B+PAMW3ey+FT0hgoYmIn7T8abZGA0oHxAk8VFUK
+        U1nRtGs3rw3PLzc+uszb4IPZ7ojreerx11g61GYR/3D7mI25dE0Yj/HM9iYOF3hOlBMrvUXTLm2y
+        ZoV/dL1pwLCHib1F044KH7lBNOUpNX7z5Y66tnj7elWTqwWOv/vST3E/5AFdCCu5W+aOyyPmB+Fg
+        5EUutrRZ/mDziGNhmUVxV/pTzG/mxIjfItiOl1Pyp6dl3e3vpn457xuWZXq6PvPEuvyC8B0waa/f
+        vSi+6L6Xfs7yA7/e4dBtFgQrqv9l1gXzuOG/svF1YnphLhvrye+M8vvpEXsQE7eGFbI7KmZwQeSP
+        iPU6c7iQjMu91m8SWIuOPR+dFCw3f8OTPz7CHXEiqpnQKkortdndzHl1HQXXUbBaxcBqFQXrKgbW
+        VXzkCjpyBR/ZQEc2cAVRsIaDdZQNHWdDR9nQcTa0GipGDR8ZBes4WEN51nCeUf1y1FNQIRRcCBSs
+        4WDUP3H3xJAoELUFbgrUIXB/UFFDqLghDB0dWMcJ01DCNFwMlF0VZ1dHQ0nHQ8lARzbwkQ1UZgOX
+        WUPF0HAxcDJwLlCW1RyWUbfQckIUHVnDRzbQqDPwqEMHxsdVUe9Uc9IVPnDOyGjYqXjc6ahF9ByT
+        oFyoOBeoW+BegQYfHnsqKq+Ky6ujTOg4EyqaMqF2/dFPQEP5RvyIUlJyvfBlkwS7PqqPhlUq19SR
+        JRuWYsqmpWmyNTRMalO7YhgVZPKwZbdvmFSInyoUGg/MWjZXrDS8DRmqSZSaIht2TQOtqpo8NEa6
+        bKuaVdcpMWyRytfJ2Krb95FRr2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEJJVaaKMpSN4YjIdTKs
+        yoo1rNQqRtUaWVVEsS27fZ8Vq9UcK/KGtyBDHdVVo2pXQBeTB6quyMSo6rJlUaOqqSPTqGLxvWW3
+        byVD/MRnrLj9CA3MWmUFQbwFPZZdp6QOiumVKuipalXZJPxHAWmtpqlEU1TDROjZstt3pj8zJ/uZ
+        r0TFNf8R2DD9zUefToB0sbqHmqfn5/8DdS/C3F9WAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -2199,12 +2991,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:55:13 GMT
+      - Thu, 21 Nov 2019 15:42:40 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -2214,9 +3006,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 8bbe89ed15d5b6caa9d86858727e3a98
+      - 6f00753ad4809393293a996394027f9d
     status:
       code: 200
       message: OK
@@ -2232,76 +3024,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPfAJuXWQJkkt1AOJDQvdOd5QhbEG2MzdgySTrkv29J
-        tkEEQ0jn0sxMHoisKslVX12ski8POeKN/Fz1IeffejjIVXPIcwJ8+8/QuSn6wThXyHlogqGf4pAO
-        Qht5gxG5o1GAGckfUBSMMc1VR8gNcSE38l0HBwPi5Kpe5LqFnO17NPDdXJUGEdCjEKhTHExIGBLf
-        C3NVVTMLudC+xk7k4kEUsaFwssnURRTLeGgjG+m6rOmWLlcQLsumOipBSy05mmZaqm1aumLYCBkl
-        s6IgtWyAYNghdIBc17/FzkI2JjzoOEgUuuxJddePHKkX98Owqe8S+x5oRygkttTG9NYPbjgDUMNr
-        FOCFYv7wf9imXFNVVQo5isYJGGHKgmwX2l8ecisKA2+CdczlkBB0vU/EivvE9hJLej9lgjt4hCKX
-        5h4LT2bmUCZzq08n3mjYtX52Qm1xNmax3ONVIXfth9T2I49yFRJDmYZljTTFli0HGbJhmRXZBJvJ
-        JcVBFnYsyyjpDDqKaAQS5oLI84jHzsJdKTnHNMwxABPwkpZWnEZD1ixS7KGhi0NsRwGh90XbnwA/
-        cmkK+ACEXNp5ahMZJpejqeujVfMPQJAAFFBLZV2vmKYCMFEyAddGk+mi21J1UBeFN8PFYDhCETgV
-        DRBx1zwqmZVZ6RF4SUj94J5bPmnHbqKYmqXoqY0GCc52gBEFAw4ccPhV0VwEMTfxHTIidgYPl/Nl
-        hhABzzRKHIcBt/EGhFNnYL4NzVnkgjZoSFxCCU46wURTgYcdugR5No6PR8SlOIiDI3FDxl0EVQo5
-        wMNh9k4dtxaGmEqnjZyQTR5STTB03PNBY3wHx18U2ULy6OrBfJQPFgfGo5x/0B8Xx6r2eFDYmTX/
-        kyhVeiZF1XSjVK7IaGg7Mh4pqsw65DIYhnWxHojRnA8xisAJmLY5/DsLPP47QdS+ZkdxA1AZB340
-        TbUWYb3nsZ4Qpm40Jl4RgS+SYQRpuTjMhO0oGoO3/r4rcP9lGl/9HMNy9XO2zu3L1lGzy4W/c7E3
-        ptfgjOaHKInvIJwhq48C4GBpeQDBN0Nhhub1Wrtf60nNeIR0nI7IxMEJ/KkDAQlEF4KVyc8uVXDI
-        nT13tVG7VygTiz6YIvsGjfFmFToLhp0Ej0dBR0NLlGcTwPGna0LxoAMxBlEZQNC/i1Z3AR5V683u
-        hVyvZ+kEFKnmzEgIGXFnt6zX5Ngj5dRBn/bkf/p7lq8C23/gTz5tSAcEVyU41hRFlxUz/zFhuYBj
-        ExZ9ca7vjtNs5XFApf6lBCLgAEPejTFQAQA1vy/x6weZrn/ebe517E4zpe40dzJfMTOvXjQ/X3yM
-        U9ozXAzQbZYG/d00+O8BcM4h1eTlA9WyrLmmfFHUK+6O+TgkH4wCXF9349vkwP0mhKtakmElUy4k
-        R2VZVeCS+1FIheFgiEIMVc8GT+33ehKUChgqhJhj9/D9+rWYBPAvmfpXiqU1NWHNBKxj/vsmnsw0
-        ZKWWHyB3u5YXCderNM1U1ChqH6zoDOo2P9gYBaK2fc6644UKRmp/a1YPLued8/r8eH4ybzfyh92z
-        6sH58fxi/ml+GXfUgaU+v+zO6+yYx8l3jcxvCJ1m9aQgNavHa7C+cWw8j+PL4av1qwdn89q8nT+s
-        gbYn89b8DJpR9aA9781b+cM6a3Xm9fzh6aJVS1sLLF83zSZgYdZ2QYLf2jtDq++Qd2Z6UfmjJx99
-        x+zDdf3jpyD9JTloVeeXRlIVRh/GGYXnk89JOkmyyec4mUAumXfhIImblw36welH3xXD74KOJZA2
-        JJCzeSdOIWfzk/xhp8t6efOS541u/rDH8KrzjHICpDbPKEmrlrZEgN946h+arOIS51MzywCfdl1O
-        JqH5XEXzqfm0moFy7l1KueVu1cDBoR2QKdt7y9LxGts3UpsdvPHa/w1EX4CVJfiCTeoKbHuhwrqX
-        JRveA2TH+8/r+jRijsN/e1ANSrWYL9yfmnG9+HW0AXZd4mdp0+SEfa6BF9LHY59V4T1C5F13KdAM
-        EZfJkKVbolRN4NkTu/B83GwcyXwzaZPgDUQRW2C+7ZbTXu0NJz3X0XAzDiecuCeWSwROeAcYzLNh
-        ZdNc4ZSawLmrGsnQUEIBlkQXb/tSIoBEQrjM/h4RdquTE254TsXZQ98TC+wMhveDCXJvUWZp0EzZ
-        pKN7qbVg2y+Dxkp4OAyjrFsVKzq0U64fogK/AZfczl8X9ASorHl42pFqjhOAqK9I6KqlFdWyWVSL
-        WkGtsHYRfuRlU1EKqsL+FUuwZNaMApcO3yFYt2B+A/jjtvBPa/1aBiKs+4UZVP5Sk39D8rcreTWj
-        Pu3fkGH5GdfWwKoq12RFLakfeVsDRDnKxuTowzE5ysTk6CMxCSkZD0I8w+z5hGxcWlJvSd8FHTI7
-        7V/9vEHn5Wyxyqf9D7Z+1k0t1v3h1r/48RFBvAG9BhTwbVaKP/Wki2sMyf12jwqSzVfVfb2QCou7
-        CaYo5J1Z8i+I+1xALVXYVEEJevxhqieeHFq946zk0CJ24If+iEpHketiSrzd8kSr9+T2/5OODZmh
-        1bMs2bIsYFcUuWJaH4jAea/fyLo68v4/TdE1ZRMMptHQXXk4bV3tDmOUOktGVoBuSDBAGBHsOmtA
-        PBiPh3FDWzYyIWEPfRy2WoeNxprJ2fSyy7JG0sJpc0yXrUUnB4y3XrtdsnUXscP5pcYK0z5txY3Q
-        hLj8GcaNwh9zlq35dTCJXEqWWXZxli5UPyeISme+ze7uJE95SnxzlV0y+bOTglQnHfny81ZuTeBu
-        4CFB3lZ2XWDv+S4KoAbexm8I/MfY8QO0lb0ksNd/PZXQMApxSiwLxF/BxL6/da6KKGrUa25lNgXm
-        2ul2yCyB9xPxwGChVJXWk/bCIIo4AA9h2mDGHulMyKLBeq2LjjQNfHCbyYJBtNFxgPFRr7HdA0Qr
-        XQ4jj0bb+UUr9Vxk37BlzfYhoqVa7LlodPPMCNF8XTzxKZZGxMUSsu24QuZcotXqYOTz3vZZRcMd
-        X3TS7gwbpQ6vrEhuwwmeiRB1JUQ8Apz+iBuR8FsBnEm0UYuEdjElrERMPEZyMMV2kr04k7FyCr5B
-        L1165E7cn+eM2QEC7ve510t5VuIEQcYJfJ/C0p9BzhMP5xKB7nbqabeZ6dyXIQ6kCfLQGE8wv63A
-        ma3ViITE6KZ5QkQ53URdJBER0Q7GgXzhy+y/dMwconcNacVLH6/XRWTrp736eUoQkT0mAb5Frrs4
-        hYjoEXi04/uLiNNFFHv1WqOWEkToGu0UUV3ECqBwwV+lMLblYk4RuA5/OUJa3jpKmaynpkFSeI1d
-        96l1DGXFayhkk/Eipa6g5wdUSp6tXzCIiLEXM+IahZNWMfPGgPlKjjVWUkG7lQaUIULWPk2RMcpP
-        0wCZbc/whohlv8UTTbO3PQINEdujIGKZww8gjmDdgAQ2Ed1/RZ6//dJUWsHYJuDX7OUB6Yx40d32
-        kaIFWv6QOW0Di95QEk1wHiAbOHaYV7RObYK+wfpvh1GiyTrI9aWaS7dfGkuiNU8idIvJdn7RzMel
-        9G2fZ/CtrGHQb20fIdr51LOJAzaRujic+l6YunBJtHKfBDTyv33brm5ZtPRvF9tXAmX18e3K2G3r
-        wF2LmwNl/kWFRXy8klcK5cf8wdev4U8y+zl4Ssr/clDghBeO2lA0fWZ/Bf4r898n9ZOiKO9R88c9
-        Ge/zbESzJbD+NYqmDZshCR57uhHiR3QaZe1FJWKfp/TvFZziO1rw6TVc2FjzY7YyEnfdpcCP1fwr
-        V/gJWFzJjQBdxNSdtiBdls35VGwN9SabkLCqKrKfLAHj7l13pR7UQulxmXmXfWmifo5rQ2I2lYIJ
-        yVc2FVN5QU5On9Nk1n4hHIFPfdt3syBZknbbM7ancBQ57JfYk+lbmEy8VGSI2MU2Cqn0D1ZQ4Wm2
-        ATMkjbn57f14Bmi+39MobEEC5WWG+AnlT7MhGmI8QG7oZ6qKYQHLSft28dpy13LrDctN23qwxh0x
-        Pc989vBKCzskYm9rn5Axk64O8xGW2d7F4ULfjTbESm9J2qetVVH4e8+fhiTrFmJvSdpT4SMvjKYs
-        pcbPu8yw5/Bnrp9qcrnkY0+89FO+H3JbjkL9dkO8cXFEgpAORn7kZZU2q69pHjNeKLNwtiv9KdY3
-        C2D4Bwh2w+UM/elhWXf72TQobnpzZRWeTkB8Xpd3Edv3kg76nW7+Rde99CWWH/jODmPdpSB4ovpf
-        pi5YxA37tMbzwPToRjTWk18bs+vpMbnjC7eaTckM8xVcGAUjZL/NGo6icVGvlEwVsW/slJEiGxoa
-        yZZTHsrGUDXLuqVpjm5lqLbjsO+4P8i/PDRDboQHuqoCA2+vE9a3uEJM5Wv+iYik5fn0ZWAohl4x
-        DVSWNcVRQauhIqORimUF4bKuYNXWbDsDjB2HvQ6MkpmNBfS/BxT8DBDGeMw+aFPmn5N5qncWzyuV
-        LGkbtATCu1hcrTgVq6TK2NAM2cBYlZFpYFkdYWWkWRpWnFGWxXcb9jowKqVyNhiM8P42r5j8/NuN
-        njC9TlFD1bMVZYT3ULSs4xLCCMtWuQLZy9SGsmk6SDZsfWQM7WHFUY0M1Xcc9jow2MfMstHglLeB
-        44p9zY2mn28K8ATm5pds6Hl4fPw/lwid9ChOAAA=
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKBhlWVTIcyhVLrcqqZhJZpZotk5pStxS7MtJVozqq
+        1StVtVYxq0pVGdVAMGqzcEAcx7un9lw2LjzoOEgUuupJTceLbKkX10O3qecw6xHaDknALOmMhvee
+        fysA0BrcEJ/OFfOG/6NWKDTVVLNUCMk4ISNIIcRyoPzpqbCksFJKuY5RNgtA18dErLguW15wGT5O
+        ueA2HZHICQvPpZWRBZXJ2OrqwLmGXasXKs2vxi1WeL4uFW68ILS8yA2FComhqkbNIjWzLttU1WSj
+        TjV5ONI1MFdN1zVDV5WKwqkLSRiBhAWfBtGEufwywpeSi0yDAmcwYS8paeVpNOTFckhdMnRoQK3I
+        Z+Fj2fImgCdOmDI+ACkXhp5aTIbB5WjqeGTZ/gOQxAcN1ErN0CtKrVaD67IJ+DaZTOfVpg5E3pDg
+        djjvDGckAq8KfcKcNZdKRuVmegYsC0LPfxSmT8rCT1RVqeqmmhppkBBt+ZSEYMGBDR6/LJpDIOgm
+        ns1GzEIwQs6XWSJLOG6VOBJ9YeUcilN34N4NxbvIAXXIkDksZDSpBBtNMxh+6jDiWjQ+HzEnpH4c
+        HokjcnQZdCmBPMTmBk9dtxEENJROWoVMPnlKVaFQ8Sg6jekDnH9SZMgSo+un+rO8Nz8xnuXik/48
+        P1e1573S1tDiT1mp0ispqqYblWpNJkPLlulIUWVeIVdrdZNX8RqI0oIHUUrAC7i2Bfo7Dz1xnJDQ
+        uuFncQFYGfteNE21ztL6KKI9aZg60Zi5ZQLOyIYRJObyEKXtMBqDu/6+LXH/5Rpf/xzTcv0zrvPZ
+        VeewfSGEf3CoOw5vwBvr76IkfYB4hrw+8gHBE/MAou+OBIjmzcZZv9GT2nEP6SjtgfJg+97UhoiE
+        RgeilcvPb1ZwKpy9cJ2r3XcoE4s+mBLrloxpvgrdOWArweNeUNHSEuX5AHD+4YaFdNCFGIOo9CHq
+        30SrB5+ODprti0u52cR0ghapYd+xAFLi1m7ZbMixR8qpg67WFH/6O+arAPs3/MknLWmP0QMJzjVF
+        0WWlXnyfsJzTkcdFPzvWN8cprjz1Q6l/JYEI1KeQd2MOVCBALe5K/Ho+6vrnF+2djt0pKnW3vZX5
+        ymhevWx/vHwfp7TuaNkn95gG/e00+O8eIGeQaorynmqa5kxTPinqtXDHYhyST0YJ7q/b4fIcuN+G
+        cFUrslmvVUvJGawBFLjlvhdTQTAYkoDCuifHU/u9ngSLBQprhBixffh+/lxOAvgXVP9aubKmJsyZ
+        ADoWx1fxZK4hX2x5PnE2a3mZoL5LU1RRo6y9s6J3sHLz/NwoyGrbF9Atb1TQU/tb+2DvatY9b86O
+        Zsezs1Zx/+L0YO/8aHY5+zC7iiuaAGnOri5mTX4u4uSbehZzQqd9cFyS2gdHa7S+cmx8nceX09fo
+        H+ydzhqzs+J+A7Q9nnVmp1CMDvbOZr1Zp7jf5KXurFncP5mXGmlpzuX3DZNHLIx6VpLg2HhjavUt
+        8s6dXlb+6MlH3zL7CF3/+ClIf0kOWtb5pZF0AL3344wi8snHJJ0k2eRjnEwgl8wu4CSJm5d1+sHp
+        R9+Ww2+ijieQM0ggp7NunEJOZ8fF/e4FrxXFK5E3Lor7Pc5XU2SUY2g6ExklKTXSUpbgVx76hyar
+        eInzoY0Z4MO208kkNL+2ovnQXl3NwHLuTZZyi92qgU0Dy2dTvvmG6XhDrVvpjJ+88tz/FUSfk4UJ
+        PodJFxnYTqiw7mXJlveAWPEO9Lo+rRix/5sLq0GpEeOC3Vkzri9+bW1AHYd5mDZt0bDLa+C59HHf
+        r6rwFiHyprsU5I4wh8uA6ZYo1chgdsQuIh+3W4ey2EzKE7xFQsInmK+75bRTe8NJzU00zOfhWDTu
+        iOUSgRPsgIJ5cmY27SWk1AbktmokXQOJ+FTKuviZJyUCSCyA2+zvEeMPO0XDrcipFO/6llxQezB8
+        HEyIc0/QpUE7hUmHj1JnDtstg8ZKuDQIIuxRxZIOZynqh6ggHsAlD/TXBT2GVl7cP+lKDdv2QdTv
+        SOiqqZXVar2slrWSWuPlMhzkRVFRSqrC/5UrMGXWjJKQjj4QmLdQ8QT4/bbwTxr9BsIIr35hBpU/
+        NeT/EPnLtbycUVfrczKsuOLaHFhV5YasqBX1PR9rgCiHOCeH787JIcrJ4XtyEoRsPAjoHeUvKOC8
+        dKTeon0bdtjdSf/65xydF6PFKp/039n62EMtXv3u1r/88RHB3EF4AyzQeyzFn7jS5Q2F5H6/QwuS
+        /Lvqrt5IM5O7CQ1JICox+eeNu7yAWqiQt4LK6PGHWT2J5NDpHWHJocMs3wu8USgdRo5DQ+Zulyc6
+        vZXH/ysVOZmh0zNN2TRNgCuKXKub78jAea/fwu6Oov5Ps+ia8gEG02joLL2dtq52lwOl7gLIF6A5
+        CQYaRow69hoRT8bzflzQFgWUEv7Sx36ns99qrZmcDy87PGskJZoWx+GiNK8UhInS926XbNxF7Aq8
+        1FoC7dJW3IhMmCNeYswV/khANubXwSRyQrbIsvOrXMDq55iE0qln8ac7yWuekthc5bdM8fJkRqrj
+        rnz1cSNay6BbdMiIuxGuZ+A9zyE+rIE34Y0M/ojank82wisZePPXE4kMo4CmjdVM469gYs/bOFYt
+        K2rUa28E1zPgxslmyswM9gNzwWCBdCCtJ+25QZRsBzqEYf07/kpn0pw1WK9z2ZWmvgduM5kDsjY6
+        8ik97LU2e0DWSlfDyA2jzfislXoOsW75tGZzl6ylOvzNaHL7lR5Z813QiRdSacQcKhHLilfIApW1
+        WhOMfN7bPGrWcEeX3bQasVHq8MqS5BZc4CsRoi6FiMsA6Y2EEZl4FCBAWRt1WGCV04aliIn7SDYN
+        qZVkLwEyli4hNuilK5c9ZPfnBRAPEHC/j71eilmKEwIZx/e8EKb+nHKReAQqS/RFt5lW11Hnvgqo
+        L02IS8Z0QsVjBQE2lyMSEqOT5oksy+km6jyJZBntUurLl57M/0tH3CF6N5BW3PQFez3LbPOk1zxP
+        G7LMHjGf3hPHmV8iy+gheLTtefOI07Ms9pqNViNtyFLXOksZ1bNcARUO+KsUxLacj5klris+j5AW
+        j45SkLlqGiIFN9RxVq1jKEteE0I2Gc9T6hJ7nh9Kycv1c0CWMf5pRrxGEU3LnLlj4HwpxxpLqeCs
+        kwaUkaXs7CRlxqiupgF2tznDG1ku+x2RaNq9zRFoZLk99COeOTwf4gjmDSQDy7L7r8j1Nt+aKksc
+        Wwz8mn89IJ0yN3rY3DNrgY435E7bollvqGRNcO4TCxBbjJu1TmNCvsD8b4teWZN1ieNJDSfcfGus
+        ZK15HJF7yjbjs2Y+qqTf+3yF39oaB/3O5h5ZO5+4FrPBJtIFDaaeG6QuXMlauc/8MPK+fNmsblVZ
+        Coj7Hv8IRWr+2jvd3E19fr0F7aYZ4bbLnD1l9kmF6Xw8p1dK1efi3ufPwU8yP+ytNhV/2SuJhhf2
+        ylk+feR/JXGUxXFlJaUoylus/uMa5NOeXDY7GehfY/mUsy2S8LGjWyJeFE4jbFcqEfs8bf9WwUP6
+        EJa88AZucbz4Ppsaibtus9SP1fwrr/UTsoSSuQRdxq1bbUY6PJuLofhs6lW2I2F+VeYHTMC4etv9
+        qSe1VHleZN5FXZqov4bKScx1pVSH5CvXlbrygpycvrHJrf1COnwv9CzPwShZNG23e2xN4Syy+ZFZ
+        k+lrmCx7q0BEvKAWCULpH3xpRae4ARFJY7R40B+PAMW3ey+FT0hgoYmIn7T8abZGA0oHxAk8VFUK
+        U1nRtGs3rw3PLzc+uszb4IPZ7ojreerx11g61GYR/3D7mI25dE0Yj/HM9iYOF3hOlBMrvUXTLm2y
+        ZoV/dL1pwLCHib1F044KH7lBNOUpNX7z5Y66tnj7elWTqwWOv/vST3E/5AFdCCu5W+aOyyPmB+Fg
+        5EUutrRZ/mDziGNhmUVxV/pTzG/mxIjfItiOl1Pyp6dl3e3vpn457xuWZXq6PvPEuvyC8B0waa/f
+        vSi+6L6Xfs7yA7/e4dBtFgQrqv9l1gXzuOG/svF1YnphLhvrye+M8vvpEXsQE7eGFbI7KmZwQeSP
+        iPU6c7iQjMu91m8SWIuOPR+dFCw3f8OTPz7CHXEiqpnQKkortdndzHl1HQXXUbBaxcBqFQXrKgbW
+        VXzkCjpyBR/ZQEc2cAVRsIaDdZQNHWdDR9nQcTa0GipGDR8ZBes4WEN51nCeUf1y1FNQIRRcCBSs
+        4WDUP3H3xJAoELUFbgrUIXB/UFFDqLghDB0dWMcJ01DCNFwMlF0VZ1dHQ0nHQ8lARzbwkQ1UZgOX
+        WUPF0HAxcDJwLlCW1RyWUbfQckIUHVnDRzbQqDPwqEMHxsdVUe9Uc9IVPnDOyGjYqXjc6ahF9ByT
+        oFyoOBeoW+BegQYfHnsqKq+Ky6ujTOg4EyqaMqF2/dFPQEP5RvyIUlJyvfBlkwS7PqqPhlUq19SR
+        JRuWYsqmpWmyNTRMalO7YhgVZPKwZbdvmFSInyoUGg/MWjZXrDS8DRmqSZSaIht2TQOtqpo8NEa6
+        bKuaVdcpMWyRytfJ2Krb95FRr2g4GbzhLcjgl0CUTaq/UZkVFd5EcMXSLEJJVaaKMpSN4YjIdTKs
+        yoo1rNQqRtUaWVVEsS27fZ8Vq9UcK/KGtyBDHdVVo2pXQBeTB6quyMSo6rJlUaOqqSPTqGLxvWW3
+        byVD/MRnrLj9CA3MWmUFQbwFPZZdp6QOiumVKuipalXZJPxHAWmtpqlEU1TDROjZstt3pj8zJ/uZ
+        r0TFNf8R2DD9zUefToB0sbqHmqfn5/8DdS/C3F9WAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -2312,12 +3109,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:55:23 GMT
+      - Thu, 21 Nov 2019 15:42:51 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -2327,9 +3124,127 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 2ecf2fce62fe452158a72e34557bf375
+      - e0b1292980a51b7a7ec565012d6438e6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/219
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKBhlWVTIcyhVLrcqqZhJZpZotk5pStxS7MtJVozqq
+        1StVtVYxq0pVGdVAMGqzcEAcx7un9lw2LjzoOEgUuupJTceLbKkX10O3qecw6xHaDknALOmMhvee
+        fysA0BrcEJ/OFfOG/6NWKDTVVLNUCMk4ISNIIcRyoPzpqbCksFJKuY5RNgtA18dErLguW15wGT5O
+        ueA2HZHICQvPpZWRBZXJ2OrqwLmGXasXKs2vxi1WeL4uFW68ILS8yA2FComhqkbNIjWzLttU1WSj
+        TjV5ONI1MFdN1zVDV5WKwqkLSRiBhAU/cl3m8qsIV0quMQ0KnMCEvKSklafRkBfLIXXJ0KEBtSKf
+        hY9ly5sAnjhhSvgAhFzYeWoxGQaXo6njkWXzD0AQHxRQKzVDryi1Wg2uyybg2mQynVebtSqoS4Lb
+        4bwznJEInCr0CXPWPCoZlVvpGbAsCD3/UVg+KQs3UVWlqptqaqNBwrPlUxKCAQc2OPyyaA6BmJt4
+        NhsxC8EIOV9miCzhqFHiOPSFjXMYTp2B+zYU7yIHtCFD5rCQ0aQSTDTNYPipw4hr0fh8xJyQ+nFw
+        JG7I0WVQpVQAPmxu79RxG0FAQ+mkVchkk6dUEwoVj6LTmD7A+SdFhhwxun6qP8t78xPjWS4+6c/z
+        c1V73ittDS3+lJUqvZKiarpRqdZkMrRsmY4UVeYVcrVWN3kVr4EYLXgQowScgGtboL/zwBPHCQmt
+        G34WF4CVse9F01TrLK2PItaThqkTjZlbJuCLbBhBWi4PUdoOozF46+/bEvdfrvH1zzEt1z/jOp9d
+        dQ7bF0L4B4e64/AGnLH+LkrSBwhnyOojHxA8LQ8g+O5IgGjebJz1Gz2pHfeQjtIeKA+2701tCEho
+        dCBYufz8VgWnwtkL17nafYcyseiDKbFuyZjmq9CdA7YSPO4FFS0tUZ4PAOcfblhIB12IMYhKH4L+
+        TbR68OnooNm+uJSbTUwnaJEa9h0LICNu7ZbNhhx7pJw66GpN8ae/Y74KsH/Dn3zSkvYYPZDgXFMU
+        XVbqxfcJyzkdeVz0s2N9c5ziylM/lPpXEohAfQp5N+ZABQLU4q7Er+ejrn9+0d7p2J2iUnfbW5mv
+        jObVy/bHy/dxSuuOln1yj2nQ306D/+4BcgappijvqaZpzjTlk6JeC3csxiH5ZJTg/rodLs+B+20I
+        V7Uim3WY5SRnsAJQ4Jb7XkwFwWBIAgqrnhxP7fd6EiwVKKwQYsT24fv5czkJ4F9Q/WvlypqaMGcC
+        6FgcX8WTuYZ8qeX5xNms5WWC+i5NUUWNsvbOit7Bus3zc6Mgq21fQLe8UUFP7W/tg72rWfe8OTua
+        Hc/OWsX9i9ODvfOj2eXsw+wqrmgCpDm7upg1+bmIk2/qWcwJnfbBcUlqHxyt0frKsfF1Hl9OX6N/
+        sHc6a8zOivsN0PZ41pmdQjE62Dub9Wad4n6Tl7qzZnH/ZF5qpKU5l983TB6xMOpZSYJj442p1bfI
+        O3d6WfmjJx99y+wjdP3jpyD9JTloWeeXRtIB9N6PM4rIJx+TdJJkk49xMoFcMruAkyRuXtbpB6cf
+        fVsOv4k6nkDOIIGczrpxCjmdHRf3uxe8VhSvRN64KO73OF9NkVGOoelMZJSk1EhLWYJfeegfmqzi
+        Jc6HNmaAD9tOJ5PQ/NqK5kN7dTUDy7k3WcotdqsGNg0sn0353hum4w21bqUzfvLKc/9XEH1OFib4
+        HCZdZGA7ocK6lyUb3gNixfvP6/q0YsT+by6sBqVGjAt2Z824vvi1tQF1HOZh2rRFwy6vgefSx32/
+        qsJbhMib7lKQO8IcLgOmW6JUI4PZEbuIfNxuHcpiMylP8BYJCZ9gvu6W007tDSc1N9Ewn4dj0bgj
+        lksETrADCubJmdm0l5BSG5DbqpF0DSTiUynr4meelAggsQBus79HjD/qFA23IqdSvOtbckHtwfBx
+        MCHOPUGXBu0UJh0+Sp05bLcMGivh0iCIsEcVSzqcpagfooJ4AJc8zl8X9BhaeXH/pCs1bNsHUb8j
+        oaumVlar9bJa1kpqjZfLcJAXRUUpqQr/V67AlFkzSkI6+kBg3kLFA+D328I/afQbCCO8+oUZVP7U
+        kP9D5C/X8nJGXa3PybDiimtzYFWVG7KiVtT3fKwBohzinBy+OyeHKCeH78lJELLxIKB3lL+fgPPS
+        kXqL9m3YYXcn/eufc3RejBarfNJ/Z+tjD7V49btb//LHRwRzB+ENsEDvsRR/4kqXNxSS+/0OLUjy
+        76q7eiPNTO4mNCSBqMTknzfu8gJqoULeCiqjxx9m9SSSQ6d3hCWHDrN8L/BGoXQYOQ4Nmbtdnuj0
+        Vh7/r1TkZIZOzzRl0zQBrihyrW6+IwPnvX4LuzuK+j/NomvKBxhMo6Gz9HLautpdDpS6CyBfgOYk
+        GGgYMerYa0Q8Gc/7cUFbFFBK+Esf+53Ofqu1ZnI+vOzwrJGUaFoch4vSvFIQJkrfu12ycRexK/BS
+        awm0S1txIzJhjniHMVf4IwHZmF8Hk8gJ2SLLzq9yAaufYxJKp57Fn+4kb3lKYnOV3zLFu5MZqY67
+        8tXHjWgtg27RISPuRriegfc8h/iwBt6ENzL4I2p7PtkIr2TgzV9PJDKMApo2VjONv4KJPW/jWLWs
+        qFGvvRFcz4AbJ5spMzPYD8wFgwXSgbSetOcGUbId6BCG9e/4K51Jc9Zgvc5lV5r6HrjNZA7I2ujI
+        p/Sw19rsAVkrXQ0jN4w247NW6jnEuuXTms1dspbq8Peiye1XemTNd0EnXkilEXOoRCwrXiELVNZq
+        TTDyeW/zqFnDHV1202rERqnDK0uSW3CBr0SIuhQiLgOkNxJGZOJRgABlbdRhgVVOG5YiJu4j2TSk
+        VpK9BMhYuoTYoJeuXPaQ3Z8XQDxAwP0+9nopZilOCGQc3/NCmPpzykXiEags0RfdZlpdR537KqC+
+        NCEuGdMJFY8VBNhcjkhIjE6aJ7Isp5uo8ySSZbRLqS9fejL/Lx1xh+jdQFpx09fr9SyzzZNe8zxt
+        yDJ7xHx6Txxnfokso4fg0bbnzSNOz7LYazZajbQhS13rLGVUz3IFVDjgr1IQ23I+Zpa4rvg4Qlo8
+        OkpB5qppiBTcUMdZtY6hLHlNCNlkPE+pS+x5figl79bPAVnG+IcZ8RpFNC1z5o6B86UcayylgrNO
+        GlBGlrKzk5QZo7qaBtjd5gxvZLnsd0Siafc2R6CR5fbQj3jm8HyII5g3kAwsy+6/ItfbfGuqLHFs
+        MfBr/vGAdMrc6GFzz6wFOt6QO22LZr2hkjXBuU8sQGwxbtY6jQn5AvO/LXplTdYljic1nHDzrbGS
+        teZxRO4p24zPmvmokn7t8xV+a2sc9Dube2TtfOJazAabSBc0mHpukLpwJWvlPvPDyPvyZbO6VWUp
+        IO57/BsUqflr73RzN/X59Ra0m2aE2y5z9pTZJxWm8/GcXilVn4t7nz8HP8n8sLfaVPxlryQaXtgr
+        Z/n0kf+VxFEWx5WVlKIob7H6j2uQL3ty2exkoH+N5VPOtkjCx45uiXhROI2wXalE7PO0/VsFD+lD
+        WPLCG7jF8eL7bGok7rrNUj9W86+81k/IEkrmEnQZt261GenwbC6G4rOpV9mOhPlVmR8wAePqbfen
+        ntRS5XmReRd1aaL+GionMdeVUh2Sr1xX6soLcnL6xia39gvp8L3QszwHo2TRtN3usTWFs8jmR2ZN
+        pq9hsuytAhHxglokCKV/8KUVneIGRCSN0eJBfzwCFN/uvRQ+IYGFJiJ+0vKn2RoNKB0QJ/BQVSlM
+        ZUXTrt28Njy/3PjoMm+DD2a7I67nqcdfY+lQm0X8u+1jNubSNWE8xjPbmzhc4DlRTqz0Fk27tMma
+        Ff7R9aYBwx4m9hZNOyp85AbRlKfU+M2XO+ra4u3rVU2uFjj+7ks/xf2QB3QhrORumTsuj5gfhIOR
+        F7nY0mb5g80jjoVlFsVd6U8xv5kTI36KYDteTsmfnpZ1t7+b+uW8b1iW6en6zBPr8gvCd8CkvX73
+        ovii+176OcsP/HqHQ7dZEKyo/pdZF8zjhv/IxteJ6YW5bKwnvzPK76dH7EFM3BpWyO6omMEFkT8i
+        1uvM4UIyLvdav0lgLTr2fHRSsNz8DU/++Ah3xImoZkKrKK3UZncz59V1FFxHwWoVA6tVFKyrGFhX
+        8ZEr6MgVfGQDHdnAFUTBGg7WUTZ0nA0dZUPH2dBqqBg1fGQUrONgDeVZw3lG9ctRT0GFUHAhULCG
+        g1H/xN0TQ6JA1Ba4KVCHwP1BRQ2h4oYwdHRgHSdMQwnTcDFQdlWcXR0NJR0PJQMd2cBHNlCZDVxm
+        DRVDw8XAycC5QFlWc1hG3ULLCVF0ZA0f2UCjzsCjDh0YH1dFvVPNSVf4wDkjo2Gn4nGnoxbRc0yC
+        cqHiXKBugXsFGnx47KmovCour44yoeNMqGjKhNr1Rz8BDeUb8SNKScn1wpdNEuz6qD4aVqlcU0eW
+        bFiKKZuWpsnW0DCpTe2KYVSQycOW3b5hUiF+qFBoPDBr2Vyx0vA2ZKgmUWqKbNg1DbSqavLQGOmy
+        rWpWXafEsEUqXydjq27fR0a9ouFk8Ia3IINfAlE2qf5GZVZUeBPBFUuzCCVVmSrKUDaGIyLXybAq
+        K9awUqsYVWtkVRHFtuz2fVasVnOsyBveggx1VFeNql0BXUweqLoiE6Oqy5ZFjaqmjkyjisX3lt2+
+        lQzxA5+x4vYjNDBrlRUE8Rb0WHadkjoopleqoKeqVWWT8B8FpLWaphJNUQ0ToWfLbt+Z/syc7Ge+
+        EhXX/Cdgw/Q3H306AdLF6h5qnp6f/w/1D0TWXVYAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:43:01 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-c-ca-central-1-prod
+      X-Request-Uuid:
+      - b0727dce174ac59ab31f29414519f8f3
     status:
       code: 200
       message: OK
@@ -2349,11 +3264,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/110/stop
+    uri: https://cloud.tenable.com/scans/219/stop
   response:
     body:
       string: ''
@@ -2365,7 +3280,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Wed, 17 Jul 2019 15:55:24 GMT
+      - Thu, 21 Nov 2019 15:43:02 GMT
       Expires:
       - '0'
       Pragma:
@@ -2373,8 +3288,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -2382,9 +3297,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 26444c76e72c81f07b7d72cd8baf5c5d
+      - 768618735afcf192ddf519836f30782f
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -2402,76 +3317,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPfAJuXWQJkkt1AOJDQvdOd5QhbEG2MzdgySTrkv29J
-        tkEEQ0jn0sxMHoisKslVX12ski8POeKN/Fz1IeffejjIVXPIcwJ8+8/QuSn6wThXyHlogqGf4pAO
-        Qht5gxG5o1GAGckfUBSMMc1VR8gNcSE38l0HBwPi5Kpe5LqFnO17NPDdXJUGEdCjEKhTHExIGBLf
-        C3NVVTMLudC+xk7k4kEUsaFwssnURRTLeGgjG+m6rOmWLlcQLsumOipBSy05mmZaqm1aumLYCBkl
-        s6IgtWyAYNghdIBc17/FzkI2JjzoOEgUuuxJddePHKkX98Owqe8S+x5oRygkttTG9NYPbjgDUMNr
-        FOCFYv7wf9imXFNVVQo5isYJGGHKgmwX2l8ecisKA2+CdczlkBB0vU/EivvE9hJLej9lgjt4hCKX
-        5h4LT2bmUCZzq08n3mjYtX52Qm1xNmax3ONVIXfth9T2I49yFRJDmYZljTTFli0HGbJhmRXZBJvJ
-        JcVBFnYsyyjpDDqKaAQSQsOfTonHTsN9KTnJNMwxBBP0kpZWnEZD1ixS7KGhi0NsRwGh90XbnwA/
-        cmmK+ACkXBp6ahMZJpejqeujVfsPQJIANFBLZV2vmKYCOFEyAd9Gk+mi29IM0BeFN8PFYDhCEXgV
-        DRBx11wqmZWZ6RF4CagZ3HPTJ+3YTxRTsxQ9NdIgAdoOMKJgwYEDHr8qmosg6Ca+Q0bEzuDhcr7M
-        EiLg2VaJIzHgVt4AceoOzLuhOYtcUAcNiUsowUkn2Ggq8LBDlyDPxvHxiLgUB3F4JI7IuIugSyEH
-        gDjM4Knr1sIQU+m0kRPyyUOqCoaOez5ojO/g+IsiW0geXT2Yj/LB4sB4lPMP+uPiWNUeDwo7s+Z/
-        EqVKz6Somm6UyhUZDW1HxiNFlVmHXAbLsC7WA1Ga8yFKEXgB0zaHf2ehx38niNrX7ChuACrjwI+m
-        qdYirPc82hPC1I3GxCsicEYyjCAxF4eZsB1FY3DX33cF7r9M46ufY1iufs7WuX3ZOmp2ufB3LvbG
-        9Bq80fwQJfEdxDPk9VEAHCwxDyD6ZijM0Lxea/drPakZj5CO0xGZODiBP3UgIoHoQrQy+dnFCg65
-        s+euNmr3CmVi0QdTZN+gMd6sQmfBsJPg8SjoaGiJ8mwCOP50TSgedCDGICoDiPp30eouwKNqvdm9
-        kOv1LJ2AItWcGQkhJe7slvWaHHuknDro0578T3/P8lVg+w/8yacN6YDgqgTHmqLosmLmPyYsF3Bs
-        wqIvzvXdcZqtPA6o1L+UQAQcYMi7MQYqAKDm9yV+/SDT9c+7zb2O3Wmm1J3mTuYrZubVi+bni49x
-        SnuGiwG6zdKgv5sG/z0Azjmkmrx8oFqWNdeUL4p6xd0xH4fkg1GA6+tufJscuN+EcFVLMixlyoXk
-        qCyrClxyPwqpMBwMUYih7tngqf1eT4JiAUONEHPsHr5fvxaTAP4lU/9KsbSmJqyZgHXMf9/Ek5mG
-        rNjyA+Ru1/Ii4XqVppmKGkXtgxWdQeXmBxujQNS2z1l3vFDBSO1vzerB5bxzXp8fz0/m7Ub+sHtW
-        PTg/nl/MP80v4446sNTnl915nR3zOPmukfkNodOsnhSkZvV4DdY3jo3ncXw5fLV+9eBsXpu384c1
-        0PZk3pqfQTOqHrTnvXkrf1hnrc68nj88XbRqaWuB5eum2QQszNouSPBbe2do9R3yzkwvKn/05KPv
-        mH24rn/8FKS/JAet6vzSSKrC6MM4o/B88jlJJ0k2+RwnE8gl8y4cJHHzskE/OP3ou2L4XdCxBNKG
-        BHI278Qp5Gx+kj/sdFkvb17yvNHNH/YYXnWeUU6A1OYZJWnV0pYI8BtP/UOTVVzifGpmGeDTrsvJ
-        JDSfq2g+NZ9WM1DOvUspt9ytGjg4tAMyZZtvWTpeY/tGarODN177v4HoC7CyBF+wSV2BbS9UWPey
-        ZMt7gOx4B3pdn0bMcfhvD6pBqRbzhftTM64Xv442wK5L/CxtmpywzzXwQvp47LMqvEeIvOsuBZoh
-        4jIZsnRLlKoJPHtiF56Pm40jmW8mbRK8gShiC8y33XLaq73hpOc6Gm7G4YQT98RyicAJ7wCDeTas
-        bJornFITOHdVIxkaSijAkujibV9KBJBICJfZ3yPCbnZywg3PqTh76HtigZ3B8H4wQe4tyiwNmimb
-        dHQvtRZs+2XQWAkPh2GUdatiRYd2yvVDVOA34JIb+uuCngCVNQ9PO1LNcQIQ9RUJXbW0olo2i2pR
-        K6gV1i7Cj7xsKkpBVdi/YgmWzJpR4NLhOwTrFszvAH/cFv5prV/LQIR1vzCDyl9q8m9I/nYlr2bU
-        p/0bMiw/49oaWFXlmqyoJfUjb2uAKEfZmBx9OCZHmZgcfSQmISXjQYhnmD2gkI1LS+ot6bugQ2an
-        /aufN+i8nC1W+bT/wdbPuqnFuj/c+hc/PiKIN6DXgAK+zUrxp550cY0hud/uUUGy+aq6rxdSYXE3
-        wRSFvDNL/gVxnwuopQqbKihBjz9M9cSTQ6t3nJUcWsQO/NAfUekocl1Mibdbnmj1ntz+f9KxITO0
-        epYlW5YF7IoiV0zrAxE47/UbWVdH3v+nKbqmbILBNBq6K0+nravdYYxSZ8nICtANCQYII4JdZw2I
-        B+PxMG5oy0YmJOyhj8NW67DRWDM5m152WdZIWjhtjumytejkgPHWa7dLtu4idji/1Fhh2qetuBGa
-        EJc/xLhR+GPOsjW/DiaRS8kyyy7O0oXq5wRR6cy32d2d5DFPiW+usksmf3hSkOqkI19+3sqtCdwN
-        PCTI28quC+w930UB1MDb+A2B/xg7foC2spcE9vqvpxIaRiFOiWWB+CuY2Pe3zlURRY16za3MpsBc
-        O90OmSXwfiIeGCyUqtJ60l4YRBEH4CFMG8zYI50JWTRYr3XRkaaBD24zWTCINjoOMD7qNbZ7gGil
-        y2Hk0Wg7v2ilnovsG7as2T5EtFSLPRmNbp4ZIZqviyc+xdKIuFhCth1XyJxLtFodjHze2z6raLjj
-        i07anWGj1OGVFcltOMEzEaKuhIhHgNMfcSMSfiuAM4k2apHQLqaElYiJx0gOpthOshdnMlZOwTfo
-        pUuP3In785wxO0DA/T73einPSpwgyDiB71NY+jPIeeLhXCLQ3U497TYznfsyxIE0QR4a4wnmtxU4
-        s7UakZAY3TRPiCinm6iLJCIi2sE4kC98mf2XjplD9K4hrXjpA/a6iGz9tFc/TwkissckwLfIdRen
-        EBE9Ao92fH8RcbqIYq9ea9RSgghdo50iqotYARQu+KsUxrZczCkC1+GvR0jLW0cpk/XUNEgKr7Hr
-        PrWOoax4DYVsMl6k1BX0/IBKycP1CwYRMfZqRlyjcNIqZt4YMF/JscZKKmi30oAyRMjapykyRvlp
-        GiCz7RneELHst3iiafa2R6AhYnsURCxz+AHEEawbkMAmovuvyPO3X5pKKxjbBPyavT0gnREvuts+
-        UrRAyx8yp21g0RtKognOA2QDxw7zitapTdA3WP/tMEo0WQe5vlRz6fZLY0m05kmEbjHZzi+a+biU
-        vu/zDL6VNQz6re0jRDufejZxwCZSF4dT3wtTFy6JVu6TgEb+t2/b1S2Llv7tYvtKoKw+vl0Zu20d
-        uGtxc6DMv6iwiI9X8kqh/Jg/+Po1/ElmPwdPSflfDgqc8MJRG4qmz+yvwH9l/vukflIU5T1q/rgn
-        44WejWi2BNa/RtG0YTMkwWNPN0L8iE6jrL2oROzzlP69glN8Rws+vYYLG2t+zFZG4q67FPixmn/l
-        Cj8Biyu5EaCLmLrTFqTLsjmfiq2h3mQTElZVRfaTJWDcveuu1INaKD0uM++yL03Uz3FtSMymUjAh
-        +cqmYiovyMnpc5rM2i+EI/Cpb/tuFiRL0m57xvYUjiKH/RJ7Mn0Lk4mXigwRu9hGIZX+wQoqPM02
-        YIakMTe/vR/PAM33exqFLUigvMwQP6H8aTZEQ4wHyA39TFUxLGA5ad8uXlvuWm69YblpWw/WuCOm
-        55nPHl5pYYdE7HXtEzJm0tVhPsIy27s4XOi70YZY6S1J+7S1Kgp/7/nTkGTdQuwtSXsqfOSF0ZSl
-        1Ph5lxn2HP7M9VNNLpd87ImXfsr3Q27LUajfbog3Lo5IENLByI+8rNJm9TXNY8YLZRbOdqU/xfpm
-        AQz/AsFuuJyhPz0s624/mwbFTW+urMLTCYjP6/IuYvte0kG/082/6LqXvsTyA9/ZYay7FARPVP/L
-        1AWLuGHf1ngemB7diMZ68mtjdj09Jnd84VazKZlhvoILo2CE7LdZw1E0LuqVkqki9pWdMlJkQ0Mj
-        2XLKQ9kYqmZZtzTN0a0M1XYc9h33B/m3h2bIjfBAV1Vg4O11wvoWV4ipfM0/EZG0PJ++DAzF0Cum
-        gcqypjgqaDVUZDRSsawgXNYVrNqabWeAseOw14FRMrOxgP73gIKfAcIYj9kXbcr8ezJP9c7ieaWS
-        JW2DlkB4F4urFadilVQZG5ohGxirMjINLKsjrIw0S8OKM8qy+G7DXgdGpVTOBoMR3t/mFZOff7vR
-        E6bXKWqoeraijPAeipZ1XEIYYdkqVyB7mdpQNk0HyYatj4yhPaw4qpGh+o7DXgcG+5xZNhqc8jZw
-        XLHvudH0800BnsDc/JINPQ+Pj/8Hev9HrypOAAA=
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKBhlWVTIcyhVLrcqqZhJZpZotk5pStxS7MtJVozqq
+        1StVtVYxq0pVGdVAMGqzcEAcx7un9lw2LjzoOEgUuupJTceLbKkX10O3qecw6xHaDknALOmMhvee
+        fysA0BrcEJ/OFfOG/6NWKDTVVLNUCMk4ISNIIcRyoPzpqbCksFJKuY5RNgtA18dErLguW15wGT5O
+        ueA2HZHICQvPpZWRBZXJ2OrqwLmGXasXKs2vxi1WeL4uFW68ILS8yA2FComhqkbNIjWzLttU1WSj
+        TjV5ONI1MFdN1zVDV5WKwqkLSRiBhFDwplPm8ssIX0ouMg0KnMGEvaSklafRkBfLIXXJ0KEBtSKf
+        hY9ly5sAnjhhyvgApFwYemoxGQaXo6njkWX7D0ASHzRQKzVDryi1Wg2uyybg22QynVebddD/hgS3
+        w3lnOCMReFXoE+asuVQyKjfTM2AZqOk/CtMnZeEnqqpUdVNNjTRIiLZ8SkKw4MAGj18WzSEQdBPP
+        ZiNmIRgh58sskSUct0ocib6wcg7FqTtw74biXeSAOmTIHBYymlSCjaYZDD91GHEtGp+PmBNSPw6P
+        xBE5ugy6lApAiM0NnrpuIwhoKJ20Cpl88pSqQqHiUXQa0wc4/6TIkCVG10/1Z3lvfmI8y8Un/Xl+
+        rmrPe6WtocWfslKlV1JUTTcq1ZpMhpYt05GiyrxCrtbqJq/iNRClBQ+ilIAXcG0L9HceeuI4IaF1
+        w8/iArAy9r1ommqdpfVRRHvSMHWiMXPLBJyRDSNIzOUhStthNAZ3/X1b4v7LNb7+Oabl+mdc57Or
+        zmH7Qgj/4FB3HN6AN9bfRUn6APEMeX3kA4In5gFE3x0JEM2bjbN+oye14x7SUdoD5cH2vakNEQmN
+        DkQrl5/frOBUOHvhOle771AmFn0wJdYtGdN8FbpzwFaCx72goqUlyvMB4PzDDQvpoAsxBlHpQ9S/
+        iVYPPh0dNNsXl3KziekELVLDvmMBpMSt3bLZkGOPlFMHXa0p/vR3zFcB9m/4k09a0h6jBxKca4qi
+        y0q9+D5hOacjj4t+dqxvjlNceeqHUv9KAhGoTyHvxhyoQIBa3JX49XzU9c8v2jsdu1NU6m57K/OV
+        0bx62f54+T5Oad3Rsk/uMQ3622nw3z1AziDVFOU91TTNmaZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlZks16rlpIzWAMocMt9L6aCYDAkAYV1T46n9ns9CRYLFNYIMWL78P38uZwE8C+o/rVyZU1NmDMB
+        dCyOr+LJXEO+2PJ84mzW8jJBfZemqKJGWXtnRe9g5eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z88w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5It7wGx4h3odX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh92ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse6K8LegytvLh/0pUatu2DqN+R
+        0FVTK6vVelktayW1xstlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiCfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yl9QwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnZ5qyaZoAVxS5VjffkYHzXr+F3R1F/Z9m0TXlAwym0dBZejttXe0uB0rdBZAvQHMS
+        DDSMGHXsNSKejOf9uKAtCigl/KWP/U5nv9VaMzkfXnZ41khKNC2Ow0VpXikIE6Xv3S7ZuIvYFXip
+        tQTapa24EZkwR7zEmCv8kYBszK+DSeSEbJFl51e5gNXPMQmlU8/iT3eS1zwlsbnKb5ni5cmMVMdd
+        +erjRrSWQbfokBF3I1zPwHueQ3xYA2/CGxn8EbU9n2yEVzLw5q8nEhlGAU0bq5nGX8HEnrdxrFpW
+        1KjX3giuZ8CNk82UmRnsB+aCwQLpQFpP2nODKNkOdAjD+nf8lc6kOWuwXueyK019D9xmMgdkbXTk
+        U3rYa232gKyVroaRG0ab8Vkr9Rxi3fJpzeYuWUt1+JvR5PYrPbLmu6ATL6TSiDlUIpYVr5AFKmu1
+        Jhj5vLd51Kzhji67aTVio9ThlSXJLbjAVyJEXQoRlwHSGwkjMvEoQICyNuqwwCqnDUsRE/eRbBpS
+        K8leAmQsXUJs0EtXLnvI7s8LIB4g4H4fe70UsxQnBDKO73khTP055SLxCFSW6ItuM62uo859FVBf
+        mhCXjOmEiscKAmwuRyQkRifNE1mW003UeRLJMtql1JcvPZn/l464Q/RuIK246Qv2epbZ5kmveZ42
+        ZJk9Yj69J44zv0SW0UPwaNvz5hGnZ1nsNRutRtqQpa51ljKqZ7kCKhzwVymIbTkfM0tcV3weIS0e
+        HaUgc9U0RApuqOOsWsdQlrwmhGwynqfUJfY8P5SSl+vngCxj/NOMeI0impY5c8fA+VKONZZSwVkn
+        DSgjS9nZScqMUV1NA+xuc4Y3slz2OyLRtHubI9DIcnvoRzxzeD7EEcwbSAaWZfdfkettvjVVlji2
+        GPg1/3pAOmVu9LC5Z9YCHW/InbZFs95QyZrg3CcWILYYN2udxoR8gfnfFr2yJusSx5MaTrj51ljJ
+        WvM4IveUbcZnzXxUSb/3+Qq/tTUO+p3NPbJ2PnEtZoNNpAsaTD03SF24krVyn/lh5H35slndqrIU
+        EPc9/hGK1Py1d7q5m/r8egvaTTPCbZc5e8rskwrT+XhOr5Sqz8W9z5+Dn2R+2FttKv6yVxINL+yV
+        s3z6yP9K4iiL48pKSlGUt1j9xzXIpz25bHYy0L/G8ilnWyThY0e3RLwonEbYrlQi9nna/q2Ch/Qh
+        LHnhDdziePF9NjUSd91mqR+r+Vde6ydkCSVzCbqMW7fajHR4NhdD8dnUq2xHwvyqzA+YgHH1tvtT
+        T2qp8rzIvIu6NFF/DZWTmOtKqQ7JV64rdeUFOTl9Y5Nb+4V0+F7oWZ6DUbJo2m732JrCWWTzI7Mm
+        09cwWfZWgYh4QS0ShNI/+NKKTnEDIpLGaPGgPx4Bim/3XgqfkMBCExE/afnTbI0GlA6IE3ioqhSm
+        sqJp125eG55fbnx0mbfBB7PdEdfz1OOvsXSozSL+4fYxG3PpmjAe45ntTRwu8JwoJ1Z6i6Zd2mTN
+        Cv/oetOAYQ8Te4umHRU+coNoylNq/ObLHXVt8fb1qiZXCxx/96Wf4n7IA7oQVnK3zB2XR8wPwsHI
+        i1xsabP8weYRx8Iyi+Ku9KeY38yJEb9FsB0vp+RPT8u6299N/XLeNyzL9HR95ol1+QXhO2DSXr97
+        UXzRfS/9nOUHfr3DodssCFZU/8usC+Zxw39l4+vE9MJcNtaT3xnl99Mj9iAmbg0rZHdUzOCCyB8R
+        63XmcCEZl3ut3ySwFh17PjopWG7+hid/fIQ74kRUM6FVlFZqs7uZ8+o6Cq6jYLWKgdUqCtZVDKyr
+        +MgVdOQKPrKBjmzgCqJgDQfrKBs6zoaOsqHjbGg1VIwaPjIK1nGwhvKs4Tyj+uWop6BCKLgQKFjD
+        wah/4u6JIVEgagvcFKhD4P6gooZQcUMYOjqwjhOmoYRpuBgouyrOro6Gko6HkoGObOAjG6jMBi6z
+        hoqh4WLgZOBcoCyrOSyjbqHlhCg6soaPbKBRZ+BRhw6Mj6ui3qnmpCt84JyR0bBT8bjTUYvoOSZB
+        uVBxLlC3wL0CDT489lRUXhWXV0eZ0HEmVDRlQu36o5+AhvKN+BGlpOR64csmCXZ9VB8Nq1SuqSNL
+        NizFlE1L02RraJjUpnbFMCrI5GHLbt8wqRA/VSg0Hpi1bK5YaXgbMlSTKDVFNuyaBlpVNXlojHTZ
+        VjWrrlNi2CKVr5OxVbfvI6Ne0XAyeMNbkMEvgSibVH+jMisqvIngiqVZhJKqTBVlKBvDEZHrZFiV
+        FWtYqVWMqjWyqohiW3b7PitWqzlW5A1vQYY6qqtG1a6ALiYPVF2RiVHVZcuiRlVTR6ZRxeJ7y27f
+        Sob4ic9YcfsRGpi1ygqCeAt6LLtOSR0U0ytV0FPVqrJJ+I8C0lpNU4mmqIaJ0LNlt+9Mf2ZO9jNf
+        iYpr/iOwYfqbjz6dAOlidQ81T8/P/wfXHgEFX1YAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -2482,12 +3402,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:55:24 GMT
+      - Thu, 21 Nov 2019 15:43:02 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -2497,9 +3417,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 953cfd8180d1f9ded15ec7ae73e54afc
+      - 3d37a22f6181f1afa2e803e3fc002ab7
     status:
       code: 200
       message: OK
@@ -2515,76 +3435,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPfAJuXWQJkkt1AOJDQvdOd5QhbEG2MzdgySTrkv29J
-        tkEEQ0jn0sxMHoisKslVX12ski8POeKN/Fz1IeffejjIVXPIcwJ8+8/QuSn6wThXyHlogqGf4pAO
-        Qht5gxG5o1GAGckfUBSMMc1VR8gNcSE38l0HBwPi5Kpe5LqFnO17NPDdXJUGEdCjEKhTHExIGBLf
-        C3NVVTMLudC+xk7k4kEUsaFwssnURRTLeGgjG+m6rOmWLlcQLsumOipBSy05mmZaqm1aumLYCBkl
-        s6IgtWyAYNghdIBc17/FzkI2JjzoOEgUuuxJddePHKkX98Owqe8S+x5oRygkttTG9NYPbjgDUMNr
-        FOCFYv7wf9imXFNVVQo5isYJGGHKgmwX2l8ecisKA2+CdczlkBB0vU/EivvE9hJLej9lgjt4hCKX
-        5h4LT2bmUCZzq08n3mjYtX52Qm1xNmax3ONVIXfth9T2I49yFRJDmYZljTTFli0HGbJhmRXZBJvJ
-        JcVBFnYsyyjpDDqKaAQSQsOfTonHTsN9KTnJNMwxBBP0kpZWnEZD1ixS7KGhi0NsRwGh90XbnwA/
-        cmmK+ACkXBp6ahMZJpejqeujVfsPQJIANFBLZV2vmKYCOFEyAd9Gk+mi29IM0BeFN8PFYDhCEXgV
-        DRBx11wqmZWZ6RF4CagZ3HPTJ+3YTxRTsxQ9NdIgAdoOMKJgwYEDHr8qmosg6Ca+Q0bEzuDhcr7M
-        EiLg2VaJIzHgVt4AceoOzLuhOYtcUAcNiUsowUkn2Ggq8LBDlyDPxvHxiLgUB3F4JI7IuIugSyEH
-        gDjM4Knr1sIQU+m0kRPyyUOqCoaOez5ojO/g+IsiW0geXT2Yj/LB4sB4lPMP+uPiWNUeDwo7s+Z/
-        EqVKz6Somm6UyhUZDW1HxiNFlVmHXAbLsC7WA1Ga8yFKEXgB0zaHf2ehx38niNrX7ChuACrjwI+m
-        qdYirPc82hPC1I3GxCsicEYyjCAxF4eZsB1FY3DX33cF7r9M46ufY1iufs7WuX3ZOmp2ufB3LvbG
-        9Bq80fwQJfEdxDPk9VEAHCwxDyD6ZijM0Lxea/drPakZj5CO0xGZODiBP3UgIoHoQrQy+dnFCg65
-        s+euNmr3CmVi0QdTZN+gMd6sQmfBsJPg8SjoaGiJ8mwCOP50TSgedCDGICoDiPp30eouwKNqvdm9
-        kOv1LJ2AItWcGQkhJe7slvWaHHuknDro0578T3/P8lVg+w/8yacN6YDgqgTHmqLosmLmPyYsF3Bs
-        wqIvzvXdcZqtPA6o1L+UQAQcYMi7MQYqAKDm9yV+/SDT9c+7zb2O3Wmm1J3mTuYrZubVi+bni49x
-        SnuGiwG6zdKgv5sG/z0Azjmkmrx8oFqWNdeUL4p6xd0xH4fkg1GA6+tufJscuN+EcFVLMixlyoXk
-        qCyrClxyPwqpMBwMUYih7tngqf1eT4JiAUONEHPsHr5fvxaTAP4lU/9KsbSmJqyZgHXMf9/Ek5mG
-        rNjyA+Ru1/Ii4XqVppmKGkXtgxWdQeXmBxujQNS2z1l3vFDBSO1vzerB5bxzXp8fz0/m7Ub+sHtW
-        PTg/nl/MP80v4446sNTnl915nR3zOPmukfkNodOsnhSkZvV4DdY3jo3ncXw5fLV+9eBsXpu384c1
-        0PZk3pqfQTOqHrTnvXkrf1hnrc68nj88XbRqaWuB5eum2QQszNouSPBbe2do9R3yzkwvKn/05KPv
-        mH24rn/8FKS/JAet6vzSSKrC6MM4o/B88jlJJ0k2+RwnE8gl8y4cJHHzskE/OP3ou2L4XdCxBNKG
-        BHI278Qp5Gx+kj/sdFkvb17yvNHNH/YYXnWeUU6A1OYZJWnV0pYI8BtP/UOTVVzifGpmGeDTrsvJ
-        JDSfq2g+NZ9WM1DOvUspt9ytGjg4tAMyZZtvWTpeY/tGarODN177v4HoC7CyBF+wSV2BbS9UWPey
-        ZMt7gOx4B3pdn0bMcfhvD6pBqRbzhftTM64Xv442wK5L/CxtmpywzzXwQvp47LMqvEeIvOsuBZoh
-        4jIZsnRLlKoJPHtiF56Pm40jmW8mbRK8gShiC8y33XLaq73hpOc6Gm7G4YQT98RyicAJ7wCDeTas
-        bJornFITOHdVIxkaSijAkujibV9KBJBICJfZ3yPCbnZywg3PqTh76HtigZ3B8H4wQe4tyiwNmimb
-        dHQvtRZs+2XQWAkPh2GUdatiRYd2yvVDVOA34JIb+uuCngCVNQ9PO1LNcQIQ9RUJXbW0olo2i2pR
-        K6gV1i7Cj7xsKkpBVdi/YgmWzJpR4NLhOwTrFszvAH/cFv5prV/LQIR1vzCDyl9q8m9I/nYlr2bU
-        p/0bMiw/49oaWFXlmqyoJfUjb2uAKEfZmBx9OCZHmZgcfSQmISXjQYhnmD2gkI1LS+ot6bugQ2an
-        /aufN+i8nC1W+bT/wdbPuqnFuj/c+hc/PiKIN6DXgAK+zUrxp550cY0hud/uUUGy+aq6rxdSYXE3
-        wRSFvDNL/gVxnwuopQqbKihBjz9M9cSTQ6t3nJUcWsQO/NAfUekocl1Mibdbnmj1ntz+f9KxITO0
-        epYlW5YF7IoiV0zrAxE47/UbWVdH3v+nKbqmbILBNBq6K0+nravdYYxSZ8nICtANCQYII4JdZw2I
-        B+PxMG5oy0YmJOyhj8NW67DRWDM5m152WdZIWjhtjumytejkgPHWa7dLtu4idji/1Fhh2qetuBGa
-        EJc/xLhR+GPOsjW/DiaRS8kyyy7O0oXq5wRR6cy32d2d5DFPiW+usksmf3hSkOqkI19+3sqtCdwN
-        PCTI28quC+w930UB1MDb+A2B/xg7foC2spcE9vqvpxIaRiFOiWWB+CuY2Pe3zlURRY16za3MpsBc
-        O90OmSXwfiIeGCyUqtJ60l4YRBEH4CFMG8zYI50JWTRYr3XRkaaBD24zWTCINjoOMD7qNbZ7gGil
-        y2Hk0Wg7v2ilnovsG7as2T5EtFSLPRmNbp4ZIZqviyc+xdKIuFhCth1XyJxLtFodjHze2z6raLjj
-        i07anWGj1OGVFcltOMEzEaKuhIhHgNMfcSMSfiuAM4k2apHQLqaElYiJx0gOpthOshdnMlZOwTfo
-        pUuP3In785wxO0DA/T73einPSpwgyDiB71NY+jPIeeLhXCLQ3U497TYznfsyxIE0QR4a4wnmtxU4
-        s7UakZAY3TRPiCinm6iLJCIi2sE4kC98mf2XjplD9K4hrXjpA/a6iGz9tFc/TwkissckwLfIdRen
-        EBE9Ao92fH8RcbqIYq9ea9RSgghdo50iqotYARQu+KsUxrZczCkC1+GvR0jLW0cpk/XUNEgKr7Hr
-        PrWOoax4DYVsMl6k1BX0/IBKycP1CwYRMfZqRlyjcNIqZt4YMF/JscZKKmi30oAyRMjapykyRvlp
-        GiCz7RneELHst3iiafa2R6AhYnsURCxz+AHEEawbkMAmovuvyPO3X5pKKxjbBPyavT0gnREvuts+
-        UrRAyx8yp21g0RtKognOA2QDxw7zitapTdA3WP/tMEo0WQe5vlRz6fZLY0m05kmEbjHZzi+a+biU
-        vu/zDL6VNQz6re0jRDufejZxwCZSF4dT3wtTFy6JVu6TgEb+t2/b1S2Llv7tYvtKoKw+vl0Zu20d
-        uGtxc6DMv6iwiI9X8kqh/Jg/+Po1/ElmPwdPSflfDgqc8MJRG4qmz+yvwH9l/vukflIU5T1q/rgn
-        44WejWi2BNa/RtG0YTMkwWNPN0L8iE6jrL2oROzzlP69glN8Rws+vYYLG2t+zFZG4q67FPixmn/l
-        Cj8Biyu5EaCLmLrTFqTLsjmfiq2h3mQTElZVRfaTJWDcveuu1INaKD0uM++yL03Uz3FtSMymUjAh
-        +cqmYiovyMnpc5rM2i+EI/Cpb/tuFiRL0m57xvYUjiKH/RJ7Mn0Lk4mXigwRu9hGIZX+wQoqPM02
-        YIakMTe/vR/PAM33exqFLUigvMwQP6H8aTZEQ4wHyA39TFUxLGA5ad8uXlvuWm69YblpWw/WuCOm
-        55nPHl5pYYdE7HXtEzJm0tVhPsIy27s4XOi70YZY6S1J+7S1Kgp/7/nTkGTdQuwtSXsqfOSF0ZSl
-        1Ph5lxn2HP7M9VNNLpd87ImXfsr3Q27LUajfbog3Lo5IENLByI+8rNJm9TXNY8YLZRbOdqU/xfpm
-        AQz/AsFuuJyhPz0s624/mwbFTW+urMLTCYjP6/IuYvte0kG/082/6LqXvsTyA9/ZYay7FARPVP/L
-        1AWLuGHf1ngemB7diMZ68mtjdj09Jnd84VazKZlhvoILo2CE7LdZw1E0LuqVkqki9pWdMlJkQ0Mj
-        2XLKQ9kYqmZZtzTN0a0M1XYc9h33B/m3h2bIjfBAV1Vg4O11wvoWV4ipfM0/EZG0PJ++DAzF0Cum
-        gcqypjgqaDVUZDRSsawgXNYVrNqabWeAseOw14FRMrOxgP73gIKfAcIYj9kXbcr8ezJP9c7ieaWS
-        JW2DlkB4F4urFadilVQZG5ohGxirMjINLKsjrIw0S8OKM8qy+G7DXgdGpVTOBoMR3t/mFZOff7vR
-        E6bXKWqoeraijPAeipZ1XEIYYdkqVyB7mdpQNk0HyYatj4yhPaw4qpGh+o7DXgcG+5xZNhqc8jZw
-        XLHvudH0800BnsDc/JINPQ+Pj/8Hev9HrypOAAA=
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKBhlWVTIcyhVLrcqqZhJZpZotk5pStxS7MtJVozqq
+        1StVtVYxq0pVGdVAMGqzcEAcx7un9lw2LjzoOEgUuupJTceLbKkX10O3qecw6xHaDknALOmMhvee
+        fysA0BrcEJ/OFfOG/6NWKDTVVLNUCMk4ISNIIcRyoPzpqbCksFJKuY5RNgtA18dErLguW15wGT5O
+        ueA2HZHICQvPpZWRBZXJ2OrqwLmGXasXKs2vxi1WeL4uFW68ILS8yA2FComhqkbNIjWzLttU1WSj
+        TjV5ONI1MFdN1zVDV5WKwqkLSRiBhFDwplPm8ssIX0ouMg0KnMGEvaSklafRkBfLIXXJ0KEBtSKf
+        hY9ly5sAnjhhyvgApFwYemoxGQaXo6njkWX7D0ASHzRQKzVDryi1Wg2uyybg22QynVebddD/hgS3
+        w3lnOCMReFXoE+asuVQyKjfTM2AZqOk/CtMnZeEnqqpUdVNNjTRIiLZ8SkKw4MAGj18WzSEQdBPP
+        ZiNmIRgh58sskSUct0ocib6wcg7FqTtw74biXeSAOmTIHBYymlSCjaYZDD91GHEtGp+PmBNSPw6P
+        xBE5ugy6lApAiM0NnrpuIwhoKJ20Cpl88pSqQqHiUXQa0wc4/6TIkCVG10/1Z3lvfmI8y8Un/Xl+
+        rmrPe6WtocWfslKlV1JUTTcq1ZpMhpYt05GiyrxCrtbqJq/iNRClBQ+ilIAXcG0L9HceeuI4IaF1
+        w8/iArAy9r1ommqdpfVRRHvSMHWiMXPLBJyRDSNIzOUhStthNAZ3/X1b4v7LNb7+Oabl+mdc57Or
+        zmH7Qgj/4FB3HN6AN9bfRUn6APEMeX3kA4In5gFE3x0JEM2bjbN+oye14x7SUdoD5cH2vakNEQmN
+        DkQrl5/frOBUOHvhOle771AmFn0wJdYtGdN8FbpzwFaCx72goqUlyvMB4PzDDQvpoAsxBlHpQ9S/
+        iVYPPh0dNNsXl3KziekELVLDvmMBpMSt3bLZkGOPlFMHXa0p/vR3zFcB9m/4k09a0h6jBxKca4qi
+        y0q9+D5hOacjj4t+dqxvjlNceeqHUv9KAhGoTyHvxhyoQIBa3JX49XzU9c8v2jsdu1NU6m57K/OV
+        0bx62f54+T5Oad3Rsk/uMQ3622nw3z1AziDVFOU91TTNmaZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlZks16rlpIzWAMocMt9L6aCYDAkAYV1T46n9ns9CRYLFNYIMWL78P38uZwE8C+o/rVyZU1NmDMB
+        dCyOr+LJXEO+2PJ84mzW8jJBfZemqKJGWXtnRe9g5eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z88w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5It7wGx4h3odX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh92ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse6K8LegytvLh/0pUatu2DqN+R
+        0FVTK6vVelktayW1xstlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiCfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yl9QwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnZ5qyaZoAVxS5VjffkYHzXr+F3R1F/Z9m0TXlAwym0dBZejttXe0uB0rdBZAvQHMS
+        DDSMGHXsNSKejOf9uKAtCigl/KWP/U5nv9VaMzkfXnZ41khKNC2Ow0VpXikIE6Xv3S7ZuIvYFXip
+        tQTapa24EZkwR7zEmCv8kYBszK+DSeSEbJFl51e5gNXPMQmlU8/iT3eS1zwlsbnKb5ni5cmMVMdd
+        +erjRrSWQbfokBF3I1zPwHueQ3xYA2/CGxn8EbU9n2yEVzLw5q8nEhlGAU0bq5nGX8HEnrdxrFpW
+        1KjX3giuZ8CNk82UmRnsB+aCwQLpQFpP2nODKNkOdAjD+nf8lc6kOWuwXueyK019D9xmMgdkbXTk
+        U3rYa232gKyVroaRG0ab8Vkr9Rxi3fJpzeYuWUt1+JvR5PYrPbLmu6ATL6TSiDlUIpYVr5AFKmu1
+        Jhj5vLd51Kzhji67aTVio9ThlSXJLbjAVyJEXQoRlwHSGwkjMvEoQICyNuqwwCqnDUsRE/eRbBpS
+        K8leAmQsXUJs0EtXLnvI7s8LIB4g4H4fe70UsxQnBDKO73khTP055SLxCFSW6ItuM62uo859FVBf
+        mhCXjOmEiscKAmwuRyQkRifNE1mW003UeRLJMtql1JcvPZn/l464Q/RuIK246Qv2epbZ5kmveZ42
+        ZJk9Yj69J44zv0SW0UPwaNvz5hGnZ1nsNRutRtqQpa51ljKqZ7kCKhzwVymIbTkfM0tcV3weIS0e
+        HaUgc9U0RApuqOOsWsdQlrwmhGwynqfUJfY8P5SSl+vngCxj/NOMeI0impY5c8fA+VKONZZSwVkn
+        DSgjS9nZScqMUV1NA+xuc4Y3slz2OyLRtHubI9DIcnvoRzxzeD7EEcwbSAaWZfdfkettvjVVlji2
+        GPg1/3pAOmVu9LC5Z9YCHW/InbZFs95QyZrg3CcWILYYN2udxoR8gfnfFr2yJusSx5MaTrj51ljJ
+        WvM4IveUbcZnzXxUSb/3+Qq/tTUO+p3NPbJ2PnEtZoNNpAsaTD03SF24krVyn/lh5H35slndqrIU
+        EPc9/hGK1Py1d7q5m/r8egvaTTPCbZc5e8rskwrT+XhOr5Sqz8W9z5+Dn2R+2FttKv6yVxINL+yV
+        s3z6yP9K4iiL48pKSlGUt1j9xzXIpz25bHYy0L/G8ilnWyThY0e3RLwonEbYrlQi9nna/q2Ch/Qh
+        LHnhDdziePF9NjUSd91mqR+r+Vde6ydkCSVzCbqMW7fajHR4NhdD8dnUq2xHwvyqzA+YgHH1tvtT
+        T2qp8rzIvIu6NFF/DZWTmOtKqQ7JV64rdeUFOTl9Y5Nb+4V0+F7oWZ6DUbJo2m732JrCWWTzI7Mm
+        09cwWfZWgYh4QS0ShNI/+NKKTnEDIpLGaPGgPx4Bim/3XgqfkMBCExE/afnTbI0GlA6IE3ioqhSm
+        sqJp125eG55fbnx0mbfBB7PdEdfz1OOvsXSozSL+4fYxG3PpmjAe45ntTRwu8JwoJ1Z6i6Zd2mTN
+        Cv/oetOAYQ8Te4umHRU+coNoylNq/ObLHXVt8fb1qiZXCxx/96Wf4n7IA7oQVnK3zB2XR8wPwsHI
+        i1xsabP8weYRx8Iyi+Ku9KeY38yJEb9FsB0vp+RPT8u6299N/XLeNyzL9HR95ol1+QXhO2DSXr97
+        UXzRfS/9nOUHfr3DodssCFZU/8usC+Zxw39l4+vE9MJcNtaT3xnl99Mj9iAmbg0rZHdUzOCCyB8R
+        63XmcCEZl3ut3ySwFh17PjopWG7+hid/fIQ74kRUM6FVlFZqs7uZ8+o6Cq6jYLWKgdUqCtZVDKyr
+        +MgVdOQKPrKBjmzgCqJgDQfrKBs6zoaOsqHjbGg1VIwaPjIK1nGwhvKs4Tyj+uWop6BCKLgQKFjD
+        wah/4u6JIVEgagvcFKhD4P6gooZQcUMYOjqwjhOmoYRpuBgouyrOro6Gko6HkoGObOAjG6jMBi6z
+        hoqh4WLgZOBcoCyrOSyjbqHlhCg6soaPbKBRZ+BRhw6Mj6ui3qnmpCt84JyR0bBT8bjTUYvoOSZB
+        uVBxLlC3wL0CDT489lRUXhWXV0eZ0HEmVDRlQu36o5+AhvKN+BGlpOR64csmCXZ9VB8Nq1SuqSNL
+        NizFlE1L02RraJjUpnbFMCrI5GHLbt8wqRA/VSg0Hpi1bK5YaXgbMlSTKDVFNuyaBlpVNXlojHTZ
+        VjWrrlNi2CKVr5OxVbfvI6Ne0XAyeMNbkMEvgSibVH+jMisqvIngiqVZhJKqTBVlKBvDEZHrZFiV
+        FWtYqVWMqjWyqohiW3b7PitWqzlW5A1vQYY6qqtG1a6ALiYPVF2RiVHVZcuiRlVTR6ZRxeJ7y27f
+        Sob4ic9YcfsRGpi1ygqCeAt6LLtOSR0U0ytV0FPVqrJJ+I8C0lpNU4mmqIaJ0LNlt+9Mf2ZO9jNf
+        iYpr/iOwYfqbjz6dAOlidQ81T8/P/wfXHgEFX1YAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -2595,12 +3520,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:55:25 GMT
+      - Thu, 21 Nov 2019 15:43:03 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -2610,9 +3535,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 7b328414807712abe71fd167658c645a
+      - f8656e45db16622ae960f581d1cb9e08
     status:
       code: 200
       message: OK
@@ -2628,76 +3553,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPfAJuXWQJkkt1AOJDQvdOd5QhbEG2MzdgySTrkv29J
-        tkEEQ0jn0sxMHoisKslVX12ski8POeKN/Fz1IeffejjIVXPIcwJ8+8/QuSn6wThXyHlogqGf4pAO
-        Qht5gxG5o1GAGckfUBSMMc1VR8gNcSE38l0HBwPi5Kpe5LqFnO17NPDdXJUGEdCjEKhTHExIGBLf
-        C3NVVTMLudC+xk7k4kEUsaFwssnURRTLeGgjG+m6rOmWLlcQLsumOipBSy05mmZaqm1aumLYCBkl
-        s6IgtWyAYNghdIBc17/FzkI2JjzoOEgUuuxJddePHKkX98Owqe8S+x5oRygkttTG9NYPbjgDUMNr
-        FOCFYv7wf9imXFNVVQo5isYJGGHKgmwX2l8ecisKA2+CdczlkBB0vU/EivvE9hJLej9lgjt4hCKX
-        5h4LT2bmUCZzq08n3mjYtX52Qm1xNmax3ONVIXfth9T2I49yFRJDmYZljTTFli0HGbJhmRXZBJvJ
-        JcVBFnYsyyjpDDqKaAQSQsOfTonHTsN9KTnJNMwxBBP0kpZWnEZD1ixS7KGhi0NsRwGh90XbnwA/
-        cmmK+ACkXBp6ahMZJpejqeujVfsPQJIANFBLZV2vmKYCOFEyAd9Gk+mi29IM0BeFN8PFYDhCEXgV
-        DRBx11wqmZWZ6RF4CagZ3HPTJ+3YTxRTsxQ9NdIgAdoOMKJgwYEDHr8qmosg6Ca+Q0bEzuDhcr7M
-        EiLg2VaJIzHgVt4AceoOzLuhOYtcUAcNiUsowUkn2Ggq8LBDlyDPxvHxiLgUB3F4JI7IuIugSyEH
-        gDjM4Knr1sIQU+m0kRPyyUOqCoaOez5ojO/g+IsiW0geXT2Yj/LB4sB4lPMP+uPiWNUeDwo7s+Z/
-        EqVKz6Somm6UyhUZDW1HxiNFlVmHXAbLsC7WA1Ga8yFKEXgB0zaHf2ehx38niNrX7ChuACrjwI+m
-        qdYirPc82hPC1I3GxCsicEYyjCAxF4eZsB1FY3DX33cF7r9M46ufY1iufs7WuX3ZOmp2ufB3LvbG
-        9Bq80fwQJfEdxDPk9VEAHCwxDyD6ZijM0Lxea/drPakZj5CO0xGZODiBP3UgIoHoQrQy+dnFCg65
-        s+euNmr3CmVi0QdTZN+gMd6sQmfBsJPg8SjoaGiJ8mwCOP50TSgedCDGICoDiPp30eouwKNqvdm9
-        kOv1LJ2AItWcGQkhJe7slvWaHHuknDro0578T3/P8lVg+w/8yacN6YDgqgTHmqLosmLmPyYsF3Bs
-        wqIvzvXdcZqtPA6o1L+UQAQcYMi7MQYqAKDm9yV+/SDT9c+7zb2O3Wmm1J3mTuYrZubVi+bni49x
-        SnuGiwG6zdKgv5sG/z0Azjmkmrx8oFqWNdeUL4p6xd0xH4fkg1GA6+tufJscuN+EcFVLMixlyoXk
-        qCyrClxyPwqpMBwMUYih7tngqf1eT4JiAUONEHPsHr5fvxaTAP4lU/9KsbSmJqyZgHXMf9/Ek5mG
-        rNjyA+Ru1/Ii4XqVppmKGkXtgxWdQeXmBxujQNS2z1l3vFDBSO1vzerB5bxzXp8fz0/m7Ub+sHtW
-        PTg/nl/MP80v4446sNTnl915nR3zOPmukfkNodOsnhSkZvV4DdY3jo3ncXw5fLV+9eBsXpu384c1
-        0PZk3pqfQTOqHrTnvXkrf1hnrc68nj88XbRqaWuB5eum2QQszNouSPBbe2do9R3yzkwvKn/05KPv
-        mH24rn/8FKS/JAet6vzSSKrC6MM4o/B88jlJJ0k2+RwnE8gl8y4cJHHzskE/OP3ou2L4XdCxBNKG
-        BHI278Qp5Gx+kj/sdFkvb17yvNHNH/YYXnWeUU6A1OYZJWnV0pYI8BtP/UOTVVzifGpmGeDTrsvJ
-        JDSfq2g+NZ9WM1DOvUspt9ytGjg4tAMyZZtvWTpeY/tGarODN177v4HoC7CyBF+wSV2BbS9UWPey
-        ZMt7gOx4B3pdn0bMcfhvD6pBqRbzhftTM64Xv442wK5L/CxtmpywzzXwQvp47LMqvEeIvOsuBZoh
-        4jIZsnRLlKoJPHtiF56Pm40jmW8mbRK8gShiC8y33XLaq73hpOc6Gm7G4YQT98RyicAJ7wCDeTas
-        bJornFITOHdVIxkaSijAkujibV9KBJBICJfZ3yPCbnZywg3PqTh76HtigZ3B8H4wQe4tyiwNmimb
-        dHQvtRZs+2XQWAkPh2GUdatiRYd2yvVDVOA34JIb+uuCngCVNQ9PO1LNcQIQ9RUJXbW0olo2i2pR
-        K6gV1i7Cj7xsKkpBVdi/YgmWzJpR4NLhOwTrFszvAH/cFv5prV/LQIR1vzCDyl9q8m9I/nYlr2bU
-        p/0bMiw/49oaWFXlmqyoJfUjb2uAKEfZmBx9OCZHmZgcfSQmISXjQYhnmD2gkI1LS+ot6bugQ2an
-        /aufN+i8nC1W+bT/wdbPuqnFuj/c+hc/PiKIN6DXgAK+zUrxp550cY0hud/uUUGy+aq6rxdSYXE3
-        wRSFvDNL/gVxnwuopQqbKihBjz9M9cSTQ6t3nJUcWsQO/NAfUekocl1Mibdbnmj1ntz+f9KxITO0
-        epYlW5YF7IoiV0zrAxE47/UbWVdH3v+nKbqmbILBNBq6K0+nravdYYxSZ8nICtANCQYII4JdZw2I
-        B+PxMG5oy0YmJOyhj8NW67DRWDM5m152WdZIWjhtjumytejkgPHWa7dLtu4idji/1Fhh2qetuBGa
-        EJc/xLhR+GPOsjW/DiaRS8kyyy7O0oXq5wRR6cy32d2d5DFPiW+usksmf3hSkOqkI19+3sqtCdwN
-        PCTI28quC+w930UB1MDb+A2B/xg7foC2spcE9vqvpxIaRiFOiWWB+CuY2Pe3zlURRY16za3MpsBc
-        O90OmSXwfiIeGCyUqtJ60l4YRBEH4CFMG8zYI50JWTRYr3XRkaaBD24zWTCINjoOMD7qNbZ7gGil
-        y2Hk0Wg7v2ilnovsG7as2T5EtFSLPRmNbp4ZIZqviyc+xdKIuFhCth1XyJxLtFodjHze2z6raLjj
-        i07anWGj1OGVFcltOMEzEaKuhIhHgNMfcSMSfiuAM4k2apHQLqaElYiJx0gOpthOshdnMlZOwTfo
-        pUuP3In785wxO0DA/T73einPSpwgyDiB71NY+jPIeeLhXCLQ3U497TYznfsyxIE0QR4a4wnmtxU4
-        s7UakZAY3TRPiCinm6iLJCIi2sE4kC98mf2XjplD9K4hrXjpA/a6iGz9tFc/TwkissckwLfIdRen
-        EBE9Ao92fH8RcbqIYq9ea9RSgghdo50iqotYARQu+KsUxrZczCkC1+GvR0jLW0cpk/XUNEgKr7Hr
-        PrWOoax4DYVsMl6k1BX0/IBKycP1CwYRMfZqRlyjcNIqZt4YMF/JscZKKmi30oAyRMjapykyRvlp
-        GiCz7RneELHst3iiafa2R6AhYnsURCxz+AHEEawbkMAmovuvyPO3X5pKKxjbBPyavT0gnREvuts+
-        UrRAyx8yp21g0RtKognOA2QDxw7zitapTdA3WP/tMEo0WQe5vlRz6fZLY0m05kmEbjHZzi+a+biU
-        vu/zDL6VNQz6re0jRDufejZxwCZSF4dT3wtTFy6JVu6TgEb+t2/b1S2Llv7tYvtKoKw+vl0Zu20d
-        uGtxc6DMv6iwiI9X8kqh/Jg/+Po1/ElmPwdPSflfDgqc8MJRG4qmz+yvwH9l/vukflIU5T1q/rgn
-        44WejWi2BNa/RtG0YTMkwWNPN0L8iE6jrL2oROzzlP69glN8Rws+vYYLG2t+zFZG4q67FPixmn/l
-        Cj8Biyu5EaCLmLrTFqTLsjmfiq2h3mQTElZVRfaTJWDcveuu1INaKD0uM++yL03Uz3FtSMymUjAh
-        +cqmYiovyMnpc5rM2i+EI/Cpb/tuFiRL0m57xvYUjiKH/RJ7Mn0Lk4mXigwRu9hGIZX+wQoqPM02
-        YIakMTe/vR/PAM33exqFLUigvMwQP6H8aTZEQ4wHyA39TFUxLGA5ad8uXlvuWm69YblpWw/WuCOm
-        55nPHl5pYYdE7HXtEzJm0tVhPsIy27s4XOi70YZY6S1J+7S1Kgp/7/nTkGTdQuwtSXsqfOSF0ZSl
-        1Ph5lxn2HP7M9VNNLpd87ImXfsr3Q27LUajfbog3Lo5IENLByI+8rNJm9TXNY8YLZRbOdqU/xfpm
-        AQz/AsFuuJyhPz0s624/mwbFTW+urMLTCYjP6/IuYvte0kG/082/6LqXvsTyA9/ZYay7FARPVP/L
-        1AWLuGHf1ngemB7diMZ68mtjdj09Jnd84VazKZlhvoILo2CE7LdZw1E0LuqVkqki9pWdMlJkQ0Mj
-        2XLKQ9kYqmZZtzTN0a0M1XYc9h33B/m3h2bIjfBAV1Vg4O11wvoWV4ipfM0/EZG0PJ++DAzF0Cum
-        gcqypjgqaDVUZDRSsawgXNYVrNqabWeAseOw14FRMrOxgP73gIKfAcIYj9kXbcr8ezJP9c7ieaWS
-        JW2DlkB4F4urFadilVQZG5ohGxirMjINLKsjrIw0S8OKM8qy+G7DXgdGpVTOBoMR3t/mFZOff7vR
-        E6bXKWqoeraijPAeipZ1XEIYYdkqVyB7mdpQNk0HyYatj4yhPaw4qpGh+o7DXgcG+5xZNhqc8jZw
-        XLHvudH0800BnsDc/JINPQ+Pj/8Hev9HrypOAAA=
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKBhlWVTIcyhVLrcqqZhJZpZotk5pStxS7MtJVozqq
+        1StVtVYxq0pVGdVAMGqzcEAcx7un9lw2LjzoOEgUuupJTceLbKkX10O3qecw6xHaDknALOmMhvee
+        fysA0BrcEJ/OFfOG/6NWKDTVVLNUCMk4ISNIIcRyoPzpqbCksFJKuY5RNgtA18dErLguW15wGT5O
+        ueA2HZHICQvPpZWRBZXJ2OrqwLmGXasXKs2vxi1WeL4uFW68ILS8yA2FComhqkbNIjWzLttU1WSj
+        TjV5ONI1MFdN1zVDV5WKwqkLSRiBhFDwplPm8ssIX0ouMg0KnMGEvaSklafRkBfLIXXJ0KEBtSKf
+        hY9ly5sAnjhhyvgApFwYemoxGQaXo6njkWX7D0ASHzRQKzVDryi1Wg2uyybg22QynVebddD/hgS3
+        w3lnOCMReFXoE+asuVQyKjfTM2AZqOk/CtMnZeEnqqpUdVNNjTRIiLZ8SkKw4MAGj18WzSEQdBPP
+        ZiNmIRgh58sskSUct0ocib6wcg7FqTtw74biXeSAOmTIHBYymlSCjaYZDD91GHEtGp+PmBNSPw6P
+        xBE5ugy6lApAiM0NnrpuIwhoKJ20Cpl88pSqQqHiUXQa0wc4/6TIkCVG10/1Z3lvfmI8y8Un/Xl+
+        rmrPe6WtocWfslKlV1JUTTcq1ZpMhpYt05GiyrxCrtbqJq/iNRClBQ+ilIAXcG0L9HceeuI4IaF1
+        w8/iArAy9r1ommqdpfVRRHvSMHWiMXPLBJyRDSNIzOUhStthNAZ3/X1b4v7LNb7+Oabl+mdc57Or
+        zmH7Qgj/4FB3HN6AN9bfRUn6APEMeX3kA4In5gFE3x0JEM2bjbN+oye14x7SUdoD5cH2vakNEQmN
+        DkQrl5/frOBUOHvhOle771AmFn0wJdYtGdN8FbpzwFaCx72goqUlyvMB4PzDDQvpoAsxBlHpQ9S/
+        iVYPPh0dNNsXl3KziekELVLDvmMBpMSt3bLZkGOPlFMHXa0p/vR3zFcB9m/4k09a0h6jBxKca4qi
+        y0q9+D5hOacjj4t+dqxvjlNceeqHUv9KAhGoTyHvxhyoQIBa3JX49XzU9c8v2jsdu1NU6m57K/OV
+        0bx62f54+T5Oad3Rsk/uMQ3622nw3z1AziDVFOU91TTNmaZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlZks16rlpIzWAMocMt9L6aCYDAkAYV1T46n9ns9CRYLFNYIMWL78P38uZwE8C+o/rVyZU1NmDMB
+        dCyOr+LJXEO+2PJ84mzW8jJBfZemqKJGWXtnRe9g5eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z88w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5It7wGx4h3odX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh92ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse6K8LegytvLh/0pUatu2DqN+R
+        0FVTK6vVelktayW1xstlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiCfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yl9QwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnZ5qyaZoAVxS5VjffkYHzXr+F3R1F/Z9m0TXlAwym0dBZejttXe0uB0rdBZAvQHMS
+        DDSMGHXsNSKejOf9uKAtCigl/KWP/U5nv9VaMzkfXnZ41khKNC2Ow0VpXikIE6Xv3S7ZuIvYFXip
+        tQTapa24EZkwR7zEmCv8kYBszK+DSeSEbJFl51e5gNXPMQmlU8/iT3eS1zwlsbnKb5ni5cmMVMdd
+        +erjRrSWQbfokBF3I1zPwHueQ3xYA2/CGxn8EbU9n2yEVzLw5q8nEhlGAU0bq5nGX8HEnrdxrFpW
+        1KjX3giuZ8CNk82UmRnsB+aCwQLpQFpP2nODKNkOdAjD+nf8lc6kOWuwXueyK019D9xmMgdkbXTk
+        U3rYa232gKyVroaRG0ab8Vkr9Rxi3fJpzeYuWUt1+JvR5PYrPbLmu6ATL6TSiDlUIpYVr5AFKmu1
+        Jhj5vLd51Kzhji67aTVio9ThlSXJLbjAVyJEXQoRlwHSGwkjMvEoQICyNuqwwCqnDUsRE/eRbBpS
+        K8leAmQsXUJs0EtXLnvI7s8LIB4g4H4fe70UsxQnBDKO73khTP055SLxCFSW6ItuM62uo859FVBf
+        mhCXjOmEiscKAmwuRyQkRifNE1mW003UeRLJMtql1JcvPZn/l464Q/RuIK246Qv2epbZ5kmveZ42
+        ZJk9Yj69J44zv0SW0UPwaNvz5hGnZ1nsNRutRtqQpa51ljKqZ7kCKhzwVymIbTkfM0tcV3weIS0e
+        HaUgc9U0RApuqOOsWsdQlrwmhGwynqfUJfY8P5SSl+vngCxj/NOMeI0impY5c8fA+VKONZZSwVkn
+        DSgjS9nZScqMUV1NA+xuc4Y3slz2OyLRtHubI9DIcnvoRzxzeD7EEcwbSAaWZfdfkettvjVVlji2
+        GPg1/3pAOmVu9LC5Z9YCHW/InbZFs95QyZrg3CcWILYYN2udxoR8gfnfFr2yJusSx5MaTrj51ljJ
+        WvM4IveUbcZnzXxUSb/3+Qq/tTUO+p3NPbJ2PnEtZoNNpAsaTD03SF24krVyn/lh5H35slndqrIU
+        EPc9/hGK1Py1d7q5m/r8egvaTTPCbZc5e8rskwrT+XhOr5Sqz8W9z5+Dn2R+2FttKv6yVxINL+yV
+        s3z6yP9K4iiL48pKSlGUt1j9xzXIpz25bHYy0L/G8ilnWyThY0e3RLwonEbYrlQi9nna/q2Ch/Qh
+        LHnhDdziePF9NjUSd91mqR+r+Vde6ydkCSVzCbqMW7fajHR4NhdD8dnUq2xHwvyqzA+YgHH1tvtT
+        T2qp8rzIvIu6NFF/DZWTmOtKqQ7JV64rdeUFOTl9Y5Nb+4V0+F7oWZ6DUbJo2m732JrCWWTzI7Mm
+        09cwWfZWgYh4QS0ShNI/+NKKTnEDIpLGaPGgPx4Bim/3XgqfkMBCExE/afnTbI0GlA6IE3ioqhSm
+        sqJp125eG55fbnx0mbfBB7PdEdfz1OOvsXSozSL+4fYxG3PpmjAe45ntTRwu8JwoJ1Z6i6Zd2mTN
+        Cv/oetOAYQ8Te4umHRU+coNoylNq/ObLHXVt8fb1qiZXCxx/96Wf4n7IA7oQVnK3zB2XR8wPwsHI
+        i1xsabP8weYRx8Iyi+Ku9KeY38yJEb9FsB0vp+RPT8u6299N/XLeNyzL9HR95ol1+QXhO2DSXr97
+        UXzRfS/9nOUHfr3DodssCFZU/8usC+Zxw39l4+vE9MJcNtaT3xnl99Mj9iAmbg0rZHdUzOCCyB8R
+        63XmcCEZl3ut3ySwFh17PjopWG7+hid/fIQ74kRUM6FVlFZqs7uZ8+o6Cq6jYLWKgdUqCtZVDKyr
+        +MgVdOQKPrKBjmzgCqJgDQfrKBs6zoaOsqHjbGg1VIwaPjIK1nGwhvKs4Tyj+uWop6BCKLgQKFjD
+        wah/4u6JIVEgagvcFKhD4P6gooZQcUMYOjqwjhOmoYRpuBgouyrOro6Gko6HkoGObOAjG6jMBi6z
+        hoqh4WLgZOBcoCyrOSyjbqHlhCg6soaPbKBRZ+BRhw6Mj6ui3qnmpCt84JyR0bBT8bjTUYvoOSZB
+        uVBxLlC3wL0CDT489lRUXhWXV0eZ0HEmVDRlQu36o5+AhvKN+BGlpOR64csmCXZ9VB8Nq1SuqSNL
+        NizFlE1L02RraJjUpnbFMCrI5GHLbt8wqRA/VSg0Hpi1bK5YaXgbMlSTKDVFNuyaBlpVNXlojHTZ
+        VjWrrlNi2CKVr5OxVbfvI6Ne0XAyeMNbkMEvgSibVH+jMisqvIngiqVZhJKqTBVlKBvDEZHrZFiV
+        FWtYqVWMqjWyqohiW3b7PitWqzlW5A1vQYY6qqtG1a6ALiYPVF2RiVHVZcuiRlVTR6ZRxeJ7y27f
+        Sob4ic9YcfsRGpi1ygqCeAt6LLtOSR0U0ytV0FPVqrJJ+I8C0lpNU4mmqIaJ0LNlt+9Mf2ZO9jNf
+        iYpr/iOwYfqbjz6dAOlidQ81T8/P/wfXHgEFX1YAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -2708,12 +3638,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:55:36 GMT
+      - Thu, 21 Nov 2019 15:43:13 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -2723,9 +3653,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - acc9ca94f3cbe9962425be6a2a3a9341
+      - 8f161c1ae78c25c4cb518378fc48ef25
     status:
       code: 200
       message: OK
@@ -2741,77 +3671,81 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPbGLB5mSVAJtkNhAMJ3TvdWY6wBWhjbMaWSdIh/31L
-        sg0CDCGdSzMzeSCyqiRXfXWxSr48Zog79DKVx4x352I/U8kg1/bx3T8D+zbv+aNMLuOiCYZ+igPa
-        Dyzk9ofknoY+ZiSvT5E/wjRTGSInwLnM0HNs7PeJnam4oePkMpbnUt9zMhXqh0APA6BOsT8hQUA8
-        N8hUVM3IZQJrjO3Qwf0wZEPhZJOpgyiW8cBCFioUZK1gFuQywiXZUIdFaKlFW9MMU7UMs6DoFkJ6
-        0SgrSC3pIBi2Ce0jx/HusL2QjQkPOvZjha67Us3xQlvqRv0wbOo5xHoA2gkKiCW1ML3z/FvOANRg
-        jHy8UMwb/A9blGuqqkouQ9EoBiNIWJDlQPvLY2ZFYeCNsY64bBKArg+xWFGf2F5iSR+mTHAbD1Ho
-        0MxTbm1mDmU8t7o+8VbDbvSzE2qLszGLZZ5ucpmxF1DLC13KVYgNZeimOdQUSzZtpMu6aZRlA2wm
-        FxUbmdg2Tb1YYNBRREOQEBredEpcdhruS/FJpkGGIRijF7e0/DQcsGaeYhcNHBxgK/QJfchb3gT4
-        kUMTxPsg5dLQU4vIMLkcTh0Prdq/D5L4oIFaLBUKZcNQACdKJuDbaDJddJuaDvqi4HaQ+C0coBCc
-        ivqILJw5cah4TmakJ2AloKT/wA0ftyMvUQzNVAqJifoxzJaPEQX79W3w91XBHAQhN/FsMiRWCg+X
-        8mV2EOFOt0kUhz638RaAE2dgvg3NWeiAOmhAHEIJjjvBQlOBhx06BLkWjo6HxKHYj4IjdkPGnQdd
-        chkAxGbmThy3GgSYSuf1jJBNHhNVMHQ88EEjfA/HXxTZRPLw5tF4ko8WB/qTnH0sPC2OVe3pKLc3
-        a/YnUarkTIqqFfRiqSyjgWXLeKioMuuQS2AZ1sV6IEYzHsQoAi9g2mbw7yzw+O8EUWvMjqIGoDLy
-        vXCaaC3C+sBjPSZMnXBE3DwCXySDENJyfpAK20k4Am/9fV/g/ss0vvk5guXm53SdW9fNk0aHC3/v
-        YHdEx+CNxocoie8hmiGrD33gYGm5D9E3Q0GK5rVqq1ftSo1ohHSajEjFwfa9qQ0RCUQHopXJz6Ib
-        DrmzZ262avcKZSLR+1Nk3aIR3q5Ce8Gwl+DRKOioa7HybAI4/jQmFPfbEGMQlT5E/btode/jYaXW
-        6FzJtVqaTkCRqvaMBJAS93bLWlWOPFJOHHS9J/vT39N8Fdj+A3/yeV06IrgiwbGmKAVZMbIfE5YL
-        OLZh0RPn+u44TVce+1TqXUsgAvYx5N0IAxUAULOHEr+en+r6l53GQcfuNFXqdmMv8+VT8+pV4/PV
-        xzilNcN5H92ladDbT4P/HgHnHFJNVj5STdOca8oXRb3h7piNQvJRz8H1dT++bQ7ca0C4qkUZljKl
-        XHxUklUFLrkfhVQQ9AcowFD1bPHUXrcrQamAoUKIOPYP369f83EA/5Kqfzlf3FAT1kzAOuK/b+LJ
-        TENWank+cnZreRVzvUrTVEX1vPbBis6gbvP8rVEgatvjrHteqGCk9rdG5eh63r6szU/nZ/NWPXvc
-        uagcXZ7Or+af5tdRRw1YavPrzrzGjnmcfNfI7JbQaVTOclKjcroB6xvHxvM4vhy+aq9ydDGvzlvZ
-        4ypoezZvzi+gGVaOWvPuvJk9rrFWe17LHp8vWtWktcDyddNsAxZmbeUk+K2+M7SFPfLOrJBX/ujJ
-        p7Bn9uG6/vFTUOElOWhV55dGUgVGH0cZheeTz3E6ibPJ5yiZQC6Zd+AgjpuXDfrB6aewL4bfBR1L
-        IC1IIBfzdpRCLuZn2eN2h/Xy5jXPG53scZfhVeMZ5QxILZ5R4lY1aYkAv/HUPzRZRSXOp0aaAT7t
-        u5yMQ/O5iuZTY72agXLuXUq55W5V38aB5ZMp23xL03GMrVupxQ7eeO3/BqIvwEoTfMEmdQS2g1Bh
-        08viDe8+sqL950196hHH8b9dqAalasQXHE7NuFn82lofOw7x0rRpcMIh18AL6aOxz6rwHiHyrrsU
-        aIaIw2RI0y1WqirwHIhdeD5u1E9kvpm0TfA6oogtMN92y+mg9objnnE42I7DGSceiOVigWPePgbz
-        bFnZNFY4pQZw7qtGPDSQkI8l0cVbnhQLIJEALrO/h4Td6uSEW55TcfrQ98QC2/3BQ3+CnDuUWho0
-        Ejbp5EFqLtgOy6CREi4OgjDtVsWKDq2E64eowG/AxbfzNwU9AyprHp+3papt+yDqKxK6amp5tWTk
-        1byWU8usnYcfedlUlJyqsH/5IiyZNT3HpcP3CNYtmN///bgt/PNqr5qCCOt+YQaVv1Tl35D87UZe
-        zajr/VsyLD/jxhpYVeWqrKhF9SNva4AoJ+mYnHw4JiepmJx8JCYBJaN+gGeYPZ6QjktT6i7p+6BD
-        Zue9m5+36LycLVL5vPfB1k+7qcW6P9z6Vz8+Iojbp2NAAd+lpfhzV7oaY0judwdUkGy/qh7qhVRY
-        3E0wRQHvTJN/QTzkAmqpwrYKStDjD1M98eTQ7J6mJYcmsXwv8IZUOgkdB1Pi7pcnmt212/9rHVsy
-        Q7NrmrJpmsCuKHLZMD8Qgctur552deT9f5qia8om6E/DgbPydNqm2m3GKLWXjKwA3ZJggDAk2LE3
-        gHjUn46jhrZspELCHvo4bjaP6/UNk7PpZYdljbiFk+aILluLTg4Yb712u2TnLmKb80v1FaZD2oob
-        oglx+EOMW4U/5Sw782t/EjqULLPs4iwdqH7OEJUuPIvd3Ykf8pT45iq7ZPKHJwWpztry9eed3JrA
-        XccDgtyd7AWBves5yIcaeBe/LvCfYtvz0U72osBe+/VcQoMwwAmxJBB/BRN73s65yqKoYbexk9kQ
-        mKvnuyEzBd5PxAWDBVJF2kzaC4Mo4gA8gGn9GXukMyaLBus2r9rS1PfAbSYLBtFGpz7GJ936bg8Q
-        rXQ9CF0a7uYXrdR1kHXLljW7h4iWarLnotHtMyNE83XwxKNYGhIHS8iyogqZc4lWq4GRL7u7ZxUN
-        d3rVTrpTbJQ4vLIiuQUneCZC1JUQcQlwekNuRMJvBXAm0UZNElj5hLASMdEYycYUW3H24kz6yin4
-        Br107ZJ7cX+eM6YHCLjf52434VmJEwQZx/c8Ckt/BjlPPJxLBLrTriXdRqpzXwfYlybIRSM8wfy2
-        Amc2VyMSEqOT5AkR5WQTdZFERETbGPvylSez/9Ipc4juGNKKmzxeXxCRrZ13a5cJQUT2lPj4DjnO
-        4hQioifg0bbnLSKuIKLYrVXr1YQgQldvJYgWRKwACgf8VQoiWy7mFIFr85cjpOWto4TJXDcNkoIx
-        dpx16+jKitdQyCajRUpdQc/zqRQ/XL9gEBFjL2ZENQonrWLmjgDzlRyrr6SCVjMJKF2ErHWeIKOX
-        1tMAme3O8LqIZa/JE02juzsCdRHbEz9kmcPzIY5g3YAENhHdf4Wut/vSVFzB2CLg1+ztAemCuOH9
-        7pGiBZregDltHYveUBRNcOkjCzj2mFe0TnWCvsH6b49RosnayPGkqkN3XxqLojXPQnSHyW5+0cyn
-        xeRtn2fwLW9g0GvuHiHa+dy1iA02kTo4mHpukLhwUbRyj/g09L59261uSbT0b1e7VwIl9entythd
-        68B9i5sjZf5FhUV8tJJXcqWn7NHXr8FPMvs5WidlfznKccILR20pmj6zvxz/lfnvWv2kKMp71PxR
-        T8oLPVvRbAqsf42iactmSIzHgW6EeCGdhml7UbHYlwn9ewWn+J7mPDqGCxtrfsxWRuyu+xT4kZp/
-        5Qo/BosruRWgq4i61xakw7I5n4qtod5kExJWVXn2kyZg1L3vrtSjmis+LTPvsi9J1M9xbUnMhpIz
-        IPnKhmIoL8jJyXOazNovhMP3qGd5ThokS9J+e8bWFI5Cm/0SazJ9C5OJl4oUETvYQgGV/sEKKjxN
-        N2CKpBE3v70fzQDN93sahS1IoLxMET+m/Gk2RAOM+8gJvFRVMSxgOenQLl477lruvGG5bVsP1rhD
-        pueFxx5eaWKbhOxl7TMyYtLVYD7CMtu7OFzgOeGWWOkuSYe0tSoK/+B604Ck3ULsLkkHKnzoBuGU
-        pdToeZcZdm3+zPW6JtdLPvbESy/h+yG35SjUb7fEHeWHxA9of+iFblpps/qa5injhTILp7vSn2J9
-        swCGf4FgP1wu0J8elk23n039/LY3V1bhafvE43V5B7F9L+mo1+5kX3TdS15i+YHv7DDWfQqCNdX/
-        MnXBIm7YtzWeB6ZLt6KxmfxamF1PT8k9X7hVLUpmmK/ggtAfIutt1nAUjfKFctFQEfvGTgkpsq6h
-        oWzapYGsD1SjVDA1zS6YKartOew77g/yLw/NkBPifkFVgYG3NwmbW1wBpvKYfyIibrkefRkYil4o
-        GzoqyZpiq6DVQJHRUMWygnCpoGDV0iwrBYw9h70OjKKRjgX0vwcU/AwQxnjEvmhT4t+TWdc7jeeV
-        Sha1LVoC4V0srpbtsllUZaxruqxjrMrI0LGsDrEy1EwNK/YwzeL7DXsdGOViKR0MRnh/m5cNfv7d
-        Ro+ZXqeorhbSFWWE91C0VMBFhBGWzVIZspehDWTDsJGsW4WhPrAGZVvVU1Tfc9jrwGAfM0tHg1Pe
-        Bo4b9jU3mny+yccTmJtfsgMmtRtO+tYMR18vYwfxt53U6Chhh8X/CheZTJHFemN2ZX3mLzdPT/8H
-        F55XIINOAAA=
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKBhlWVTIcyhVLrcqqZhJZpZotk5pStxS7MtJVozqq
+        1StVtVYxq0pVGdVAMGqzcEAcx7un9lw2LjzoOEgUuupJTceLbKkX10O3qecw6xHaDknALOmMhvee
+        fysA0BrcEJ/OFfOG/6NWKDTVVLNUCMk4ISNIIcRyoPzpqbCksFJKuY5RNgtA18dErLguW15wGT5O
+        ueA2HZHICQvPpZWRBZXJ2OrqwLmGXasXKs2vxi1WeL4uFW68ILS8yA2FComhqkbNIjWzLttU1WSj
+        TjV5ONI1MFdN1zVDV5WKwqkLSRiBhFDwplPm8ssIX0ouMg0KnMGEvaSklafRkBfLIXXJ0KEBtSKf
+        hY9ly5sAnjhhyvgApFwYemoxGQaXo6njkWX7D0ASHzRQKzVDryi1Wg2uyybg22QynVebddD/hgS3
+        w3lnOCMReFXoE+asuVQyKjfTM2AZqOk/CtMnZeEnqqpUdVNNjTRIiLZ8SkKw4MAGj18WzSEQdBPP
+        ZiNmIRgh58sskSUct0ocib6wcg7FqTtw74biXeSAOmTIHBYymlSCjaYZDD91GHEtGp+PmBNSPw6P
+        xBE5ugy6lApAiM0NnrpuIwhoKJ20Cpl88pSqQqHiUXQa0wc4/6TIkCVG10/1Z3lvfmI8y8Un/Xl+
+        rmrPe6WtocWfslKlV1JUTTcq1ZpMhpYt05GiyrxCrtbqJq/iNRClBQ+ilIAXcG0L9HceeuI4IaF1
+        w8/iArAy9r1ommqdpfVRRHvSMHWiMXPLBJyRDSNIzOUhStthNAZ3/X1b4v7LNb7+Oabl+mdc57Or
+        zmH7Qgj/4FB3HN6AN9bfRUn6APEMeX3kA4In5gFE3x0JEM2bjbN+oye14x7SUdoD5cH2vakNEQmN
+        DkQrl5/frOBUOHvhOle771AmFn0wJdYtGdN8FbpzwFaCx72goqUlyvMB4PzDDQvpoAsxBlHpQ9S/
+        iVYPPh0dNNsXl3KziekELVLDvmMBpMSt3bLZkGOPlFMHXa0p/vR3zFcB9m/4k09a0h6jBxKca4qi
+        y0q9+D5hOacjj4t+dqxvjlNceeqHUv9KAhGoTyHvxhyoQIBa3JX49XzU9c8v2jsdu1NU6m57K/OV
+        0bx62f54+T5Oad3Rsk/uMQ3622nw3z1AziDVFOU91TTNmaZ8UtRr4Y7FOCSfjBLcX7fD5Tlwvw3h
+        qlZks16rlpIzWAMocMt9L6aCYDAkAYV1T46n9ns9CRYLFNYIMWL78P38uZwE8C+o/rVyZU1NmDMB
+        dCyOr+LJXEO+2PJ84mzW8jJBfZemqKJGWXtnRe9g5eb5uVGQ1bYvoFveqKCn9rf2wd7VrHvenB3N
+        jmdnreL+xenB3vnR7HL2YXYVVzQB0pxdXcya/FzEyTf1LOaETvvguCS1D47WaH3l2Pg6jy+nr9E/
+        2DudNWZnxf0GaHs868xOoRgd7J3NerNOcb/JS91Zs7h/Mi810tKcy+8bJo9YGPWsJMGx8cbU6lvk
+        nTu9rPzRk4++ZfYRuv7xU5D+khy0rPNLI+kAeu/HGUXkk49JOkmyycc4mUAumV3ASRI3L+v0g9OP
+        vi2H30QdTyBnkEBOZ904hZzOjov73QteK4pXIm9cFPd7nK+myCjH0HQmMkpSaqSlLMGvPPQPTVbx
+        EudDGzPAh22nk0lofm1F86G9upqB5dybLOUWu1UDmwaWz6Z88w3T8YZat9IZP3nluf8riD4nCxN8
+        DpMuMrCdUGHdy5It7wGx4h3odX1aMWL/NxdWg1IjxgW7s2ZcX/za2oA6DvMwbdqiYZfXwHPp475f
+        VeEtQuRNdynIHWEOlwHTLVGqkcHsiF1EPm63DmWxmZQneIuEhE8wX3fLaaf2hpOam2iYz8OxaNwR
+        yyUCJ9gBBfPkzGzaS0ipDcht1Ui6BhLxqZR18TNPSgSQWAC32d8jxh92ioZbkVMp3vUtuaD2YPg4
+        mBDnnqBLg3YKkw4fpc4ctlsGjZVwaRBE2KOKJR3OUtQPUUE8gEse6K8LegytvLh/0pUatu2DqN+R
+        0FVTK6vVelktayW1xstlOMiLoqKUVIX/K1dgyqwZJSEdfSAwb6HiCfD7beGfNPoNhBFe/cIMKn9q
+        yP8h8pdreTmjrtbnZFhxxbU5sKrKDVlRK+p7PtYAUQ5xTg7fnZNDlJPD9+QkCNl4ENA7yl9QwHnp
+        SL1F+zbssLuT/vXPOTovRotVPum/s/Wxh1q8+t2tf/njI4K5g/AGWKD3WIo/caXLGwrJ/X6HFiT5
+        d9VdvZFmJncTGpJAVGLyzxt3eQG1UCFvBZXR4w+zehLJodM7wpJDh1m+F3ijUDqMHIeGzN0uT3R6
+        K4//VypyMkOnZ5qyaZoAVxS5VjffkYHzXr+F3R1F/Z9m0TXlAwym0dBZejttXe0uB0rdBZAvQHMS
+        DDSMGHXsNSKejOf9uKAtCigl/KWP/U5nv9VaMzkfXnZ41khKNC2Ow0VpXikIE6Xv3S7ZuIvYFXip
+        tQTapa24EZkwR7zEmCv8kYBszK+DSeSEbJFl51e5gNXPMQmlU8/iT3eS1zwlsbnKb5ni5cmMVMdd
+        +erjRrSWQbfokBF3I1zPwHueQ3xYA2/CGxn8EbU9n2yEVzLw5q8nEhlGAU0bq5nGX8HEnrdxrFpW
+        1KjX3giuZ8CNk82UmRnsB+aCwQLpQFpP2nODKNkOdAjD+nf8lc6kOWuwXueyK019D9xmMgdkbXTk
+        U3rYa232gKyVroaRG0ab8Vkr9Rxi3fJpzeYuWUt1+JvR5PYrPbLmu6ATL6TSiDlUIpYVr5AFKmu1
+        Jhj5vLd51Kzhji67aTVio9ThlSXJLbjAVyJEXQoRlwHSGwkjMvEoQICyNuqwwCqnDUsRE/eRbBpS
+        K8leAmQsXUJs0EtXLnvI7s8LIB4g4H4fe70UsxQnBDKO73khTP055SLxCFSW6ItuM62uo859FVBf
+        mhCXjOmEiscKAmwuRyQkRifNE1mW003UeRLJMtql1JcvPZn/l464Q/RuIK246Qv2epbZ5kmveZ42
+        ZJk9Yj69J44zv0SW0UPwaNvz5hGnZ1nsNRutRtqQpa51ljKqZ7kCKhzwVymIbTkfM0tcV3weIS0e
+        HaUgc9U0RApuqOOsWsdQlrwmhGwynqfUJfY8P5SSl+vngCxj/NOMeI0impY5c8fA+VKONZZSwVkn
+        DSgjS9nZScqMUV1NA+xuc4Y3slz2OyLRtHubI9DIcnvoRzxzeD7EEcwbSAaWZfdfkettvjVVlji2
+        GPg1/3pAOmVu9LC5Z9YCHW/InbZFs95QyZrg3CcWILYYN2udxoR8gfnfFr2yJusSx5MaTrj51ljJ
+        WvM4IveUbcZnzXxUSb/3+Qq/tTUO+p3NPbJ2PnEtZoNNpAsaTD03SF24krVyn/lh5H35slndqrIU
+        EPc9/hGK1Py1d7q5m/r8egvaTTPCbZc5e8rskwrT+XhOr5Sqz8W9z5+Dn2R+2FttKv6yVxINL+yV
+        s3z6yP9K4iiL48pKSlGUt1j9xzXIpz25bHYy0L/G8ilnWyThY0e3RLwonEbYrlQi9nna/q2Ch/Qh
+        LHnhDdziePF9NjUSd91mqR+r+Vde6ydkCSVzCbqMW7fajHR4NhdD8dnUq2xHwvyqzA+YgHH1tvtT
+        T2qp8rzIvIu6NFF/DZWTmOtKqQ7JV64rdeUFOTl9Y5Nb+4V0+F7oWZ6DUbJo2m732JrCWWTzI7Mm
+        09cwWfZWgYh4QS0ShNI/+NKKTnEDIpLGaPGgPx4Bim/3XgqfkMBCExE/afnTbI0GlA6IE3ioqhSm
+        sqJp125eG55fbnx0mbfBB7PdEdfz1OOvsXSozSL+4fYxG3PpmjAe45ntTRwu8JwoJ1Z6i6Zd2mTN
+        Cv/oetOAYQ8Te4umHRU+coNoylNq/ObLHXVt8fb1qiZXCxx/96Wf4n7IA7oQVnK3zB2XR8wPwsHI
+        i1xsabP8weYRx8Iyi+Ku9KeY38yJEb9FsB0vp+RPT8u6299N/XLeNyzL9HR95ol1+QXhO2DSXr97
+        UXzRfS/9nOUHfr3DodssCFZU/8usC+Zxw39l4+vE9MJcNtaT3xnl99Mj9iAmbg0rZHdUzOCCyB8R
+        63XmcCEZl3ut3ySwFh17PjopWG7+hid/fIQ74kRUM6FVlFZqs7uZ8+o6Cq6jYLWKgdUqCtZVDKyr
+        +MgVdOQKPrKBjmzgCqJgDQfrKBs6zoaOsqHjbGg1VIwaPjIK1nGwhvKs4Tyj+uWop6BCKLgQKFjD
+        wah/4u6JIVEgagvcFKhD4P6gooZQcUMYOjqwjhOmoYRpuBgouyrOro6Gko6HkoGObOAjG6jMBi6z
+        hoqh4WLgZOBcoCyrOSyjbqHlhCg6soaPbKBRZ+BRhw6Mj6ui3qnmpCt84JyR0bBT8bjTUYvoOSZB
+        uVBxLlC3wL0CDT489lRUXhWXV0eZ0HEmVDRlQu36o5+AhvKN+BGlpOR64csmCXZ9VB8Nq1SuqSNL
+        NizFlE1L02RraJjUpnbFMCrI5GHLbt8wqRA/VSg0Hpi1bK5YaXgbMlSTKDVFNuyaBlpVNXlojHTZ
+        VjWrrlNi2CKVr5OxVbfvI6Ne0XAyeMNbkMEvgSibVH+jMisqvIngiqVZhJKqTBVlKBvDEZHrZFiV
+        FWtYqVWMqjWyqohiW3b7PitWqzlW5A1vQYY6qqtG1a6ALiYPVF2RiVHVZcuiRlVTR6ZRxeJ7y27f
+        Sob4ic9YcfsRGpi1ygqCeAt6LLtOSR0U0ytV0FPVqrJJ+I8C0lpNU4mmqIaJ0LNlt+9Mf2ZO9jNf
+        iYpr/iOwYfqbjz6dAOlidQ81T8/P/wfXHgEFX1YAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -2822,12 +3756,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:55:46 GMT
+      - Thu, 21 Nov 2019 15:43:24 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -2837,9 +3771,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - e37aa0b72d85c67a3b8ae89697373dc8
+      - e454f6be17c60f01c0a07044974cab1a
     status:
       code: 200
       message: OK
@@ -2855,81 +3789,82 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VceXPaSBb/Kip2a8vMIKyLQ/wziwHH3jWYAptkJvFQjdTgXgs10YHtGH/3fd2S
-        oAGBcXyEyaQquNXvdeu93zv6kvSQIe6QZioPGXrrYi9TySDX9vDtv337Jk+9USaXcdEYQ32A/aDv
-        W8jtD8ldEHqYkWg/QN4IB5nKEDk+zmWG1LGx1yd2puKGjpPLWNQNPOpkKoEXAj30gTrB3pj4PqGu
-        n6moWjmX8a1rbIcO7ochawo3G08cFGAZDyxkIV2XNd3U5RLCRbmsDgtQUgu2ppVN1SqbumJYCBmF
-        cklBatEAwbBNgj5yHHqL7blsTHjQsR8rdNmVag4Nbakb1UOzCXWIdQ+0I+QTS2rh4JZ6N5wBqP41
-        8vBcMTr4H7YCrqmqKrlMgEYxGH7CgiwHyp8fMksKA2+MdcRlEx90vY/FiurE8gLL4H7CBLfxEIVO
-        kHnMrfTMoYz7Vlc73mjYtXp2Q21+N2axzONVLnNN/cCioRvwzmNDlQ3THGqKJZs2MmTDLJfkMthM
-        Lig2MrFtmkZBZ9AFKAhBQijQyYS47Dbcl+KbTPwMQzBGLy5p+Uk4YMV8gF00cLCPrdAjwX3eomPg
-        R06QIN4HKReGnlhEhs7lcOJQtGz/PkjiMQ0KRV0vlcsKqBKQMfg2Gk/m1aZmgL7IvxkkfgsXKASn
-        CjxE5s6cOFTcJzPSI7ASUNK754aPy5GXKGXNVPTERP0YZsvDKAD79W3w92XBHAQhN6Y2GRIrhYdL
-        +Tw7iHCn2ySKQ4+76QaAE2eIfBv5Pg4SZVi1WE5yx072nHh05GGfiaQqigz/DzX4C/9jb0kYoJWH
-        uR8qyjIloAFy4no3HIM21o0PKcgnkJWwHVM41waaj6eYyRR7+kOGQC7iisY12oLHgb9wN4UFYkxV
-        1qjqVqq2lapvpRqPV4+Lykgyi0JiZqUorUMBciBvPIacGI558ZqMrnnBgobgWk5Uy23n2viOqQQ2
-        noYO+CkaEAe4sL8CwsQJR8SN85+mmvOa2OYtMEfoS93fW5I/T7ALYZU5/xCNicOSbpt6QcLLHJTd
-        PxFIRFFdvrmiqsbqzU9rzbZ0kcS11MFfQyjC3zENsFRH7If4lkP9aCDbKtcHzGBwViTSGETguJMk
-        FOJLhyDXwtH1kDgB04UhF0vGuPMgdy4DcW+zKEhkrrJAkk7rGWHQfEgiFtwdUgprNGI3z3xWZBPJ
-        w6uH8qN8ML8wHuXsg/44v1a1x4PczqzZX0SpkjspqqYbhWJJRgPLlvFQUWVWIRchAbEqVgNDUYbC
-        UIQg2TFtM/grG1/47xgF1jW7igqAysij4STRWnSyez6kxYTICnkEKZcMQph95AepsB2FI0jKX3cF
-        7k+m8dWvESxXv6br3LpsHjU6XPg7B7ujAMJFLb+LkvgOBi2YvAw94GCzjz4ExBT5KZrXqq1etSs1
-        ohbScdIiFQfboxMbBh4gOjAoMfnZIAaXPKdnrjZq9wJlItH7E2TdoBHerEJ7zrCT4FErqKhrsfKs
-        A7j+eA3Zut+GGIOo9GBwexOt7jw8rNQanQu5VkvTCShS1Z4SH0b+nd2yVpUjj5QTB12tyf7yzzRf
-        Bbbf4Z98WpcOCK5IcA0jpi4r5ez7hOUcjk1Y9MS+vjtO05XHMGT0LiUQAcZwyLsRBjCS62p2X+KX
-        eqmuf95p7HXsTlKlbjd2Ml8+Na9eND5dvI9TWlOc99Btmga93TT48wA4Z5BqsvKBaprmTFM+K+oV
-        d8dsFJIPRg7G1934NjlwrwHhqhZkmLEXc/FVEea+MOS+F1K+3x8gH/f9TZ7a63YlWBFjWAhHHLuH
-        75cv+TiAf0vVv5QvrKkJcyZgHfHfV/FkpiHbUaAwi9uu5UXM9SJNUxU18to7KzrFFtxoYxSI2vY4
-        644DFbTU/tGoHFzO2ue12fHsZNaqZw87Z5WD8+PZxezj7DKqqAFLbXbZmdXYNY+T72qZ3RA6jcpJ
-        TmpUjtdgfeXYeBrH58NX7VUOzmbVWSt7WAVtT2bN2RkUw8pBa9adNbOHNVZqz2rZw9N5qZqU5li+
-        rJtNwEKvrZwEv9U3hlbfIe9M9bzyV08++o7Zh+v6109B+nNy0LLOz42kCrQ+jDIKzyef4nQSZ5NP
-        UTKBXDLrwEUcN89r9IPTj74rht8FHUsgLUggZ7N2lELOZifZw3aH1fLiJc8bnexhl+FV4xnlBEgt
-        nlHiUjUpiQC/ctc/NFlFS5yPjTQDfNx1OhmH5lMrmo+N1dUMLOfeZCm32K3q29i3PDJhe8xpOrKt
-        UqnFLl557v8Kos/BShN8ziZ1BLa9UGHdy+JznT6yoo3OdX3qEcfhf11YDUrViM/fnzXj+uLX1vrY
-        cQhN06bBCfu8Bp5LH7V9UoW3CJE33aVAU0QcJkOabrFSVYFnT+zC83GjfiTzzaRNgtdRgNgE83W3
-        nPZqbziuuQ4Hm3E44cQ9sVwscMzbx2CeDTObxhKn1ADOXdWIm/oS8rAkuniLSrEAEvFhmP0aEnby
-        xwk3PKfi9KZviQW2+4P7/hg5tyh1adBI2KSje6k5Z9svg0ZKuPzM7ykdWgnXD1GBH8DFT62sC3oS
-        H1ofnralqm3z4+jvT+iqqeXVYjmv5rWcWmLlPPzIi6Ki5FSF/ckXYMqsGTkuHb5DMG/B/Fj8/bbw
-        T6u9agoirPqZGVT+XJX/QPK3K3k5o67Wb8iw/I5rc2BVlauyohbU9zzWAFGO0jE5endMjlIxOXpP
-        TPyAjPrzs/JUXJpSd0HfBR0yPe1d/bpB50VvkcqnvXe2ftqhFqt+d+tf/PiIIG4/uAYU8G1aij91
-        pYtrDMn9do8WJJtH1X0dSIXJ3RgHyOeVafLPifu8gFqosGkFJejxl1k98eTQ7B6nJYcmsTzq02Eg
-        HYWOgwPi7pYnmt2V4/+Vig2Zodk1Tdk0TWBXFLlUNt8RgfNur542OvL6n2bRNWEd9CfhwFl6CHNd
-        7TZjlNoLRv6cWXosAmFIsGOvAfFgPB5GBW1RSIWEPfRx2Gwe1utrJmfdyw7LGnEJJ8VRsCjNKzlg
-        vPTS7ZKtu4htzi/Vl5j2aSsueuCvn/qUWSz8cfRM4Lb82h+HTkAWWXZ+lw6sfk5QIJ1Ri53uxM++
-        SnxzlQ2Z/GFGQaqTtnz5aSu3JnDX8YAgdyu7LrB3qYM8WANv4zcE/mNsUw9tZS8I7LUPpxIahD5O
-        iEWB+AFMTOnWvkqiqGG3sZW5LDBXT7dDZgq8H4kLBvOlirSetOcGUcQGeADdetPo8dToyVdR0OZF
-        W5p4FNxmPGcQbXTsYXzUrW/3ANFKl4PQDcLt/KKVug6ybti0ZnsT0VJN9vg/unmihWi++CHaIXGw
-        hCwrWiFzLtFqNTDyeXd7r6Lhji/aSXWKjRKHV5Ykt+AGT0SIuhQiLgFOOuRGJPwogDOJNmoS38on
-        hKWIidpINg6wFWcvzmQs3YJv0EuXLrkT9+c5Y3qAgPt96nYTnqU4QZBxPEoDmPozyHni4Vwi0J12
-        Lakupzr3pY89aYxcNMJjzI8VOLO5HJHxE848T4goJ5uo8yQiItrG2JMvqMz+SsfMIbrXkFbc5C0S
-        XUS2dtqtnScEEdlj4uFb5DjzW4iIHoFH25TOI04XUezWqvVqQhChq7cSRHURK4DCAX+V/MiW8z5F
-        4Nr8HSBpcXSUMJmrpkGSf40dZ9U6hrLkNQFkk9E8pS6ht/K8O2cQEWPvH0VrFE5axswdAeZLOdZY
-        SgWtZhJQhghZ6zRBxiiupgEy3Z7hDRHLXpMnmkZ3ewQaIrZHXsgyB/UgjmDegAQ2Ed3/hC7dPjQV
-        ljC2CPg1e0lGOiNueLe9pWiBJh0wp61j0RsKognOPWQBxw79itapjtE3mP/t0Eo0WRs5VKo6wfah
-        sSBa8yREt5hs5xfNfFxIXmp7At/SGga95vYWop1PXYvYYBOpg/0Jdf3EhQuilXvEC0L67dt2dYui
-        pf+42D4TKKqPr7eM3TYP3HVxc6DMPqswiY9m8kqu+Jg9+PLF/0VmPwerpOxvBzlOeGarDYumT+xf
-        jv/K/Hdl/aQoylus+ePXZ9bfW9uIZlNg/XssmjZshsR47OlGCA2DSZi2FxWLfZ7Qv1fwAN8FORpc
-        w8DGiu+zlRG76y4L/EjNv/MKPwaLK7kRoIuIutMWpMOyOe+KzaFeZRMSZlV59pMmYFS9667Ug5or
-        PC4y76IuSdRPcW1IzGUlV4bkK5eVsvKMnJw8p8ms/Uw4PBpQizppkCxIu+0ZWxO4Cm32S6zx5DVM
-        Jg4VKSJ2sIX8QPoXW1DhSboBUySNuPnxftQDFN/uaRQ2IYHlZYr4MeWn2RD1Me4jx6epqmKYwHLS
-        vg1eW04ttx5YbtrWgznukOl5RtnDK83o5epc5oS9Wp3L1JIXq9/E4XzqhBtipbsg7dPWqij8vUsn
-        Pkk7QuwuSHsqfOj64YSl1Oh5lyl2bf7M9aomlws+9sRLL+H7IcdyAazfbog7yg+J5wf9IQ3dtKXN
-        8muax4wXllk43ZV+ivnNHBj+oY3dcDlDPz0s624/nXj5TW+uLMPT9gjl6/IOYvte0kGv3ck+a9xL
-        XmL5ge/s8M887LAgWFH9b7MumMcN+4TM08B0g41orCe/Fmbj6TG54xO3qhWQKeYzOD/0hsh6nTlc
-        gEZ5vVQoq4h9SqqIFNnQ0FA27eJANgZquaibmmbrZopqOzb7jvNB/oGtKXJC3NdVFRh4eZ2wvsXl
-        40C+5p+IiEsuDZ4HhmLopbKBirKm2CpoNVBkNFSxrCBc1BWsWpplpYCxY7OXgVEop2MB9W8BBb8D
-        hDEesQ83Fflnk1b1TuN5oZIFbYOWQHgTi6slu2QWVBkbmiEbGKsyKhtYVodYGWqmhhV7mGbx3Zq9
-        DIxSoZgOBiO8vc1LZX7/7UaPmV6mqKHq6YoywlsoWtRxAWGEZbNYguxV1gZyuWwj2bD0oTGwBiVb
-        NVJU37HZy8Bg3+xLR4NTXgeOK/bRwgDH32vyMPsqFh+yfSa1G4771hRHH+ljF/G3ndToKmGHyf8S
-        FxlPkMVqY3ZltefPV4+P/wfnXsYbalEAAA==
+        H4sIAAAAAAAAA+VcaXfiOBb9Kz7MnDmhGxNvLM6XHgKkk+mQcEJC1UxVhiNsQTQxNu0lS4X893mS
+        bTDwTJGqJEV35wORpSv5vfsWS/LyVGDuyCscPBW8e5f6hYMCcW2f3v8zsG/Lnj8ulAoumVCoD2kQ
+        DgKLuIMRewgjn/ImbxASf0zDwsGIOAEtFUaeY1N/wOzCgRs5TqlgeW7oe07hIPQjaI8CaJ1Sf8KC
+        gHluUDhQtXqpEFg31I4cOogi3hVONpk6JKSyQYZVlQyHcsVSq7KqmURWqWbLpKbULcWujHTVqI5q
+        9UpVrVXMqlJVRjUQjNosHBDH8e6pPZeNCw86DhKFrnpS0/EiW+rF9dBt6jnMeoS2QxIwSzqj4b3n
+        3woAtAY3xKdzxbzh/6gVCk011SwVQjJOyAhSCLEcKH96KiwprJRSrmOUzQLQ9TERK67Llhdcho9T
+        LrhNRyRywsJzaWVkQWUytro6cK5h1+qFSvOzcYsVnq9LhRsvCC0vckOhQmKoqlGzSM2syzZVNdmo
+        U00ejnQNzFXTdc3QVaWicOpCEkYgIRS86ZS5/DTCl5KTTIMCZzBhLylp5Wk05MVySF0ydGhArchn
+        4WPZ8iaAJ06YMj4AKReGnlpMhsHlaOp4ZNn+A5DEBw3USs3QK0qtVoPzsgn4NplM59VmHfS/IcHt
+        MPVbOCAROFXoEzZ35tShkjG5kZ4BykBJ/1EYPikLL1FVpaqbamqiQUKz5VMSgv0GNvj7smAOgZCb
+        eDYbMQvBCClfZocs3bhN4jj0hY1zCE6dgfs2FO8iB9QhQ+awkNGkEiw0zWD4ocOIa9H4eMSckPpx
+        cCRuyNFl0KVUAEJsbu7UcRtBQEPppFXIZJOnVBUKFY+i05g+wPEnRYYcMbp+qj/Le/MD41kuPunP
+        82NVe94rbQ0t/pSVKj2Tomq6UanWZDK0bJmOFFXmFXK1Vjd5Fa+BGC14EKMEvIBrW6C/88ATvxMS
+        Wjf8KC4AK2Pfi6ap1llaH0WsJw1TJxozt0zAF9kwgrRcHqK0HUZj8NbftyXuv1zj659jWq5/xnU+
+        u+octi+E8A8OdcfhDXhj/V2UpA8QzZDVRz4geFoeQPTdkQDRvNk46zd6UjvuIR2lPVAebN+b2hCR
+        0OhAtHL5eXTDoXD2wnWudt+hTCz6YEqsWzKm+Sp054CtBI97QUVLS5TnA8DxhxsW0kEXYgyi0oeo
+        fxOtHnw6Omi2Ly7lZhPTCVqkhn3HAkiJW7tlsyHHHimnDrpaU/zp75ivAuzf8CeftKQ9Rg8kONYU
+        RZeVevF9wnJORx4X/exY3xynuPLUD6X+lQQiUJ9C3o05UIEAtbgr8ev5qOufX7R3OnanqNTd9lbm
+        K6N59bL98fJ9nNK6o2Wf3GMa9LfT4L97gJxBqinKe6ppmjNN+aSo18Idi3FIPhkluL5uh8tz4H4b
+        wlWtyGa9Vi0lR7ACUOCS+15MBcFgSAIKq54cT+33ehIsFSisEGLE9uH7+XM5CeBfUP1r5cqamjBn
+        AuhY/L6KJ3MN+VLL84mzWcvLBPVdmqKKGmXtnRW9g3Wb5+dGQVbbvoBueaGCntrf2gd7V7PueXN2
+        NDuenbWK+xenB3vnR7PL2YfZVVzRBEhzdnUxa/JjESff1LOYEzrtg+OS1D44WqP1lWPj6zy+nL5G
+        /2DvdNaYnRX3G6Dt8awzO4VidLB3NuvNOsX9Ji91Z83i/sm81EhLcy6/b5g8YmHUs5IEv403plbf
+        Iu/c6WXlj5589C2zj9D1j5+C9JfkoGWdXxpJB9B7P84oIp98TNJJkk0+xskEcsnsAg6SuHlZpx+c
+        fvRtOfwm6ngCOYMEcjrrxinkdHZc3O9e8FpRvBJ546K43+N8NUVGOYamM5FRklIjLWUJfuWhf2iy
+        ipc4H9qYAT5sO51MQvNrK5oP7dXVDCzn3mQpt9itGtg0sHw25ZtvmI431LqVzvjBK8/9X0H0OVmY
+        4HOYdJGB7YQK616WbHgPiBXvP6/r04oR+7+5sBqUGjEu2J014/ri19YG1HGYh2nTFg27vAaeSx/3
+        /aoKbxEib7pLQe4Ic7gMmG6JUo0MZkfsIvJxu3Uoi82kPMFbJCR8gvm6W047tTec1NxEw3wejkXj
+        jlguETjBDiiYJ2dm015CSm1AbqtG0jWQiE+lrIufeVIigMQCuMz+HjF+q1M03IqcSvGub8kFtQfD
+        x8GEOPcEXRq0U5h0+Ch15rDdMmishEuDIMJuVSzpcJaifogK4gZccjt/XdBjaOXF/ZOu1LBtH0T9
+        joSumlpZrdbLalkrqTVeLsOPvCgqSklV+L9yBabMmlES0tEHAvMWKu7/vt8W/kmj30AY4dUvzKDy
+        p4b8HyJ/uZaXM+pqfU6GFWdcmwOrqtyQFbWivudtDRDlEOfk8N05OUQ5OXxPToKQjQcBvaP88QSc
+        l47UW7Rvww67O+lf/5yj82K0WOWT/jtbH7upxavf3fqXPz4imDsIb4AFeo+l+BNXuryhkNzvd2hB
+        kn9V3dULaWZyN6EhCUQlJv+8cZcXUAsV8lZQGT3+MKsnkRw6vSMsOXSY5XuBNwqlw8hxaMjc7fJE
+        p7dy+3+lIiczdHqmKZumCXBFkWt18x0ZOO/1W9jVUdT/aRZdUz7AYBoNnaWn09bV7nKg1F0A+QI0
+        J8FAw4hRx14j4sl43o8L2qKAUsIf+tjvdPZbrTWT8+Flh2eNpETT4jhclOaVgjBR+t7tko27iF2B
+        l1pLoF3aihuRCXPEQ4y5wh8JyMb8OphETsgWWXZ+lgtY/RyTUDr1LH53J3nIUxKbq/ySKR6ezEh1
+        3JWvPm5Eaxl0iw4ZcTfC9Qy85znEhzXwJryRwR9R2/PJRnglA2/+eiKRYRTQtLGaafwVTOx5G8eq
+        ZUWNeu2N4HoG3DjZTJmZwX5gLhgskA6k9aQ9N4iS7UCHMKx/xx/pTJqzBut1LrvS1PfAbSZzQNZG
+        Rz6lh73WZg/IWulqGLlhtBmftVLPIdYtn9Zs7pK1VIc/F01uv9Ija74LOvFCKo2YQyViWfEKWaCy
+        VmuCkc97m0fNGu7osptWIzZKHV5ZktyCE3wlQtSlEHEZIL2RMCITtwIEKGujDgusctqwFDFxH8mm
+        IbWS7CVAxtIpxAa9dOWyh+z+vADiAQLu97HXSzFLcUIg4/ieF8LUn1MuEo9AZYm+6DbT6jrq3FcB
+        9aUJccmYTqi4rSDA5nJEQmJ00jyRZTndRJ0nkSyjXUp9+dKT+X/piDtE7wbSips+Xq9nmW2e9Jrn
+        aUOW2SPm03viOPNTZBk9BI+2PW8ecXqWxV6z0WqkDVnqWmcpo3qWK6DCAX+VgtiW8zGzxHXFyxHS
+        4tZRCjJXTUOk4IY6zqp1DGXJa0LIJuN5Sl1iz/NDKXm4fg7IMsZfzIjXKKJpmTN3DJwv5VhjKRWc
+        ddKAMrKUnZ2kzBjV1TTA7jZneCPLZb8jEk27tzkCjSy3h37EM4fnQxzBvIFkYFl2/xW53uZLU2WJ
+        Y4uBX/O3B6RT5kYPm3tmLdDxhtxpWzTrDZWsCc59YgFii3Gz1mlMyBeY/23RK2uyLnE8qeGEmy+N
+        law1jyNyT9lmfNbMR5X0bZ+v8Ftb46Df2dwja+cT12I22ES6oMHUc4PUhStZK/eZH0bely+b1a0q
+        SwFx3+MvoUjNX3unm7upz6+3oN00I9x2mbOnzD6pMJ2P5/RKqfpc3Pv8OfhJ5j97q03FX/ZKouGF
+        vXKWTx/5X0n8yuJ3ZSWlKMpbrP7jGuTVnlw2OxnoX2P5lLMtkvCxo1siXhROI2xXKhH7PG3/VsFD
+        +hCWvPAGLnG8+D6bGom7brPUj9X8K6/1E7KEkrkEXcatW21GOjybi6H4bOpVtiNhflXmP5iAcfW2
+        +1NPaqnyvMi8i7o0UX8NlZOY60qpDslXrit15QU5OX1ik1v7hXT4XuhZnoNRsmjabvfYmsJRZPNf
+        Zk2mr2Gy7KUCEfGCWiQIpX/wpRWd4gZEJI3R4kZ/PAIU3+65FD4hgYUmIn7S8qfZGg0oHRAn8FBV
+        KUxlRdOuXbw23L/ceOsyb4MPZrsjruepxx9j6VCbRfy17WM25tI1YTzGM9ubOFzgOVFOrPQWTbu0
+        yZoV/tH1pgHDbib2Fk07KnzkBtGUp9T4yZc76tri6etVTa4WOP7sSz/F/ZAbdCGs5G6ZOy6PmB+E
+        g5EXudjSZvmFzSOOhWUWxV3pTzG/mRMjvkWwHS+n5E9Py7rb3039ct47LMv0dH3miXX5BeE7YNJe
+        v3tRfNF1L32d5Qe+vcOh2ywIVlT/y6wL5nHDv7LxdWJ6YS4b68nvjPLr6RF7EBO3hhWyOypmcEHk
+        j4j1OnO4kIzLvdZvEliLjj0fnRQsN3/DnT8+wh1xIqqZ0CpKK7XZ3cx5dR0F11GwWsXAahUF6yoG
+        1lV85Ao6cgUf2UBHNnAFUbCGg3WUDR1nQ0fZ0HE2tBoqRg0fGQXrOFhDedZwnlH9ctRTUCEUXAgU
+        rOFg1D9x98SQKBC1BW4K1CFwf1BRQ6i4IQwdHVjHCdNQwjRcDJRdFWdXR0NJx0PJQEc28JENVGYD
+        l1lDxdBwMXAycC5QltUcllG30HJCFB1Zw0c20Kgz8KhDB8bHVVHvVHPSFT5wzsho2Kl43OmoRfQc
+        k6BcqDgXqFvgXoEGHx57Kiqvisuro0zoOBMqmjKhdv3WT0BD+UZ8RCkpuV74skmCXR/VR8MqlWvq
+        yJINSzFl09I02RoaJrWpXTGMCjJ52LLbN0wqxIcKhcYDs5bNFSsNb0OGahKlpsiGXdNAq6omD42R
+        LtuqZtV1SgxbpPJ1Mrbq9n1k1CsaTgZveAsy+CkQZZPqb1RmRYU3EVyxNItQUpWpogxlYzgicp0M
+        q7JiDSu1ilG1RlYVUWzLbt9nxWo1x4q84S3IUEd11ajaFdDF5IGqKzIxqrpsWdSoaurINKpYfG/Z
+        7VvJEB/4jBW3H6GBWausIIi3oMey65TUQTG9UgU9Va0qm4R/FJDWappKNEU1TISeLbt9Z/ozc7Kf
+        +UpUXPNPwIbpNx99OgHSxeo+4BK70WRg3dH4k6f8IPkgpBofpXBqL6PYZEosXpvAldWRP10/P/8f
+        PCxmkbhWAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -2940,12 +3875,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:55:57 GMT
+      - Thu, 21 Nov 2019 15:43:34 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -2955,9 +3890,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 6eee8df0fa2c2b2c14745f555865dd6e
+      - 76f449affd332f8d67ceaf837196772f
     status:
       code: 200
       message: OK
@@ -2973,80 +3908,86 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+Vc+3PiOBL+V1zc1VXYxcQvwOaXPQJkk7vAUJAwszuTpYQtiC/GYv0gyQT+92vJ
-        DwQYQiaPYWenaogsteTur1ufXrYfc7Y7IrnqY47cudjLVXPItTx892/fui0Sb5wr5Fw0wZAfYD8Y
-        +CZyByP7Pgg9TIvIIEDeGAe56gg5Pi7kRsSxsDewrVzVDR2nkDOJG3jEyVUDL4Ty0IfSKfYmtu/b
-        xPVzVVnRCznfvMFW6OBBGNKqcLPJ1EEBFvHQRCZSVVFRDVWsIFwWdXlUgpRcshRFN2RTN1RJMxHS
-        SnpFQnJZA8WwZQcD5DjkDlupblR5sHEQG3TVE+oOCS2hF+VDtSlxbPMByk6Qb5tCGwd3xLtlAlDq
-        3yAPp4aR4f+wGTBLZVkq5AI0jsHwExFkOpD+/JhbMRhkY6wjKcv2wdaHWK0oj08vsQweplRxC49Q
-        6AS5RWGtZQZl3La83vBWx27k0xsq6d2ox3KL60LuhviBSUI3YI3HjtI1wxgpkikaFtJEzdArog4+
-        E0uShQxsGYZWUil0AQpC0BASZDq1XXobFkvxTaZ+jiIYoxenlOI0HNJkMcAuGjrYx2bo2cFD0SQT
-        kEdOkCA+AC2Xjp6atgiNi+HUIWjV/wPQxKMWlMqqWtF1CUwJ7AnENppM02xD0cBe5N8Ok7iFCxRC
-        UAUestNgTgIqbpM6aQGiNhjpPTDHx+koSiRdMSQ1cdEghtn0MArAfwML4n1VMQdBl5sQyx7ZZoYM
-        0/J5fuDhzvZJ1A89FqZbAE6CIYpt5Ps4SIyh2Xw64Y69/Dn1yNjDPlVJliQR/h8r8Bf+x9GSCEAt
-        D7M4lKTVkoAEyInz3XAC1pi3PlCQbwMrYSsuYVJbynw8w1SnONIfczZwETM0zlGWMg78hbtJtCPG
-        pdJGqbyzVNlZqu4s1RbXi2VmpJlJgJhpKqJ1SAAHssoT4MRwwpI39viGJUyoCKHlRLnMd66F76lJ
-        4ONZ6ECcoqHtgBT210CYOuHYdmP+U2QjzYl93gZ3hL7Q+60t+CnBLpWVUvkRmtgOJd0O8YJElgYo
-        vX+ikEwVgjCZJoEXXzo2ck0cXY9sJ6A1qZ6xElS6CCoWctDLLBpziXo1GrbCeSPHDVGPSf+A4IIO
-        TCuN6c1znyXRQOLo+lFfiEfphbYQ84/qIr2WlcVRYW/R/E+8VsmdJFlRtVK5IqKhaYl4JMkizRDL
-        0N1pFs0B4s8RIH4E1EKtzeE/KZuz3wkKzBt6FSUAlbFHwmliNe/SBzaAxAWRL4oICM4ehjDWF4eZ
-        sJ2EY6DAP/cF7g9q8fXPESzXP2fb3L5qnTS7TPl7B7vjAIJT1t/FSHwPQwRMFUYeSNCxfgDhN0N+
-        huX1Wrtf6wnNqIZwmtTIxMHyyNQCmodCB4YAqj8dMuCSMWjueqt1LzAmUn0wReYtGuPtJnRSgb0U
-        j2pBRkOJjacNwPXHG+DGQQf6GPRKD4aSN7Hq3sOjar3ZvRTr9SyboESoWTPbh3F277Cs18QoIsUk
-        QNdz8j/9MytWQew3+CeeN4QjG1cFuIbxSRUlPf8+3TKFYxsWfb6tb+6n2cZjIOj+lQAqwIgJvBth
-        AOOmKucPpf8SLzP0P3SbB913p5lad5p7ua+YyauXzU+X7xOU5gwXPXSXZUF/Pwv+OALJOVBNXjyS
-        DcOYK9JnSb5m4ZiPuuSjVoDxdT+5bQHcb0J3lUsizI/LhfiqDDNNGHLfCynfHwyRjwf+tkjt93oC
-        rD8xLDsjif2775cvxbgD/5Jpf6VY2jAT5kwgOma/rxLJ1EK6ficecnZbeRlLvcjSTEO1ovLOhs6w
-        CTfa2gt4a/tMdM+BCmoq/2hWj67mnQ/1+en8bN5u5I+7F9WjD6fzy/nH+VWUUQeR+vyqO6/Ta9ZP
-        vqlmfkvXaVbPCkKzeroB6yv3jadxfD58tX716GJem7fzxzWw9mzeml9AMqwetee9eSt/XKepzrye
-        Pz5PU7UklWL5sma2AQuttgsC/NbeGFp1D96ZqUXpr04+6p7sw2z961OQ+hwOWrX5uT2pCrWPI0Zh
-        fPIpppOYTT5FZAJcMu/CRdxvnlfpO9OPui+G3wQdJZA2EMjFvBNRyMX8LH/c6dJclrxivNHNH/co
-        XnXGKGdQ1GaMEqdqSYoH+JWb/q5kFS1xPjazHPBx3+lk3DWfWtF8bK6vZmA59yZLueVu1cDCvunZ
-        U7qjm2Uj3ZgU2vTilef+r6B6ClaW4qmY0OXEDsKEzSiLT1EGyIz2NDftaUQSx/91YTUo1CI5/3DW
-        jJuLX0sZYMexSZY1TVZwyGvgVPuo7pMmvEUXedNdCjRDtkN1yLItNqrGyRyIXxgfNxsnIttM2qZ4
-        AwWITjBfd8vpoPaG45ybcLgdhzNWeCCeixWOZQcY3LNlZtNckRSaILmvGXFVX0AeFvgQbxMhVkCw
-        fRhm/wxtes7GCm4Zp+Lsqm+JBbYGw4fBBDl3KHNp0EzEhJMHoZWKHZZDIyNcdsL2lA3tROq7mMAO
-        4OJnRDYVPYuPiI/PO0LNstjh77cTumwoRbmsF+WiUpArNF2EH3GZlKSCLNE/xRJMmRWtwLTD9wjm
-        LZgdQr/fFv55rV/LQIRmP5NBxc818Xckfr0WVxl1PX8Lw7I7bsyBZVmsiZJckt/zWANUOcnG5OTd
-        MTnJxOTkPTHxA3s8SE/MM3FpCb1l+T7o2LPz/vXPW2xethaZfN5/Z+9nHWrR7Hf3/uX37xG2Owhu
-        AAV8l0Xx565weYOB3O8OaEGyfVQ91IGUm9xNcIB8lpmlf1p4yAuopQnbVlCcHX+Z1RMjh1bvNIsc
-        WrbpEZ+MAuEkdBwc2O5+PNHqrR3/r2VsYYZWzzBEwzBAXJLEim68IwIfev1G1ujI8n+YRdeUNjCY
-        hkNn5ZHHTbM7VFDoLAXpAnQLwUDByMaOtQHEo7Y4jhLKMpEJCX3o47jVOm40NlxOmxcdyhpxCifJ
-        cbBMpZkMMJZ66XbJzl3EDpMXGitCh7QVFz32N8h8yixW/jR6MnAXvw4moRPYS5ZN79KF1c8ZCoQL
-        YtLTnfhJU4FtrtIhkz23yGl11hGvPu2UVjjpBh7ayN0prnLiPeIgD9bAu+Q1Tv4UW8RDO8VLnHj9
-        13MBDUMfJ4VlrvBXcDEhO9uq8KqGveZOYZ0Trp3vhszgZD/aLjjMF6rCJmmnDpH4CngIzXqz6GHQ
-        6DlTXtHWZUeYegTCZpIK8D469TA+6TV2RwDvpath6AbhbnneSz0Hmbd0WrO7Cu+pFn3YHt0+UYN3
-        XxdPSICFke1gAZlmtEJmUrzX6uDkD73drfKOO73sJNkZPkoCXlrR3IQbPNFD5JUu4togSUbMiTY7
-        CmBCvI9atm8Wk4KVHhPVESwcYDNmLyakrdyCbdALV659z+/PM8HsDgLh96nXS2RW+gkCxvEICWDq
-        TyFnxMOkeKC7nXqSrWcG95WPPWGCXDTGE8yOFZiwsdojgRidhCd4lJNN1JREeEQ7GHviJRHpX+GU
-        BkTvBmjFTd7ZUHlk6+e9+oekgEf21PbwHXKc9BY8oicQ0RYhaY9TeRR79VqjlhTw0DXaCaIqjxVA
-        4UC8Cn7ky7RNHrgOe+NGWB4dJULGumuQ4N9gx1n3jiatRE0AbDJOKXUFvbWny5kAjxh92ydao7Ci
-        VczcMWC+wrHaChW0W0mH0njI2ucJMlp5nQbs2W6G13gs+y1GNM3e7h6o8dieeCFlDuJBP4J5A+LE
-        eHT/E7pk99BUWsHYtCGu6SspwoXthve7a/IeaJEhDdoG5qOhxLvgg4dMkNijXd47tQn6CvO/PWrx
-        Lusghwg1J9g9NJZ4b56F6A7bu+V5N5+WklfInsC3soFBv7W7Bu/nc9e0LfCJ0MX+lLh+EsIl3st9
-        2wtC8vXrbnPLvKd/v9w9EyjLi9dbxu6aB+67uDmS5p9lmMRHM3mpUF7kj7588X8S6c/RelH+l6MC
-        K3hmrS2Lpk/0X4H9iux3bf0kSdJbrPnjl2g23xLbimaLE/17LJq2bIbEeBzoRggJg2mYtRcVq/0h
-        Kf9WxQN8HxRIcAMDG02+z1ZGHK77LPAjM//OK/wYLGbkVoAuo9K9tiAdyuasKTqHepVNSJhVFelP
-        loJR9r67Uo9yobRYMu8yLyHqp6S2ELMuFXQgX1GXdOkZnJw8p0m9/Uw4PBIQkzhZkCyL9tszNqdw
-        FVr01zYn09dwGT9UZKjYxSbyA+FfdEGFp9kOzNA0kmbH+1ELkHy7p1HohASWlxnqxyU/zIaoj/EA
-        OT7JNBXDBJYVHdrgtePUcueB5bZtPZjjjqidF4Q+vNKKXmUu5M7oi8yFXD15jflNAs4nTrilr/SW
-        RYe0tcor/+CSqW9nHSH2lkUHqnzo+uGUUmr0vMsMuxZ75nrdkqulHH3ipZ/IfZdjuQDWb7e2Oy6O
-        bM8PBiMSullLm9XXNE+pLCyzcHYo/RDzmxQY9lmL/XC5QD88LJthP5t6xW1vrqzC0/FswtblXUT3
-        vYSjfqebf9a4l7zE8h3f2WGfedhjQbBm+t9mXZD2G/rBlqeB6QVb0dgkvzam4+mpfc8mbjUzsGeY
-        zeD80Bsh83XmcAEaF9VKSZcR/XBTGUmipqCRaFjloagNZb2sGopiqUaGaXtW+4bzQfY5qxlyQjxQ
-        ZRkEWHqzYHOLy8eBeMM+ERGnXBI8DwxJUyu6hsqiIlkyWDWURDSSsSghXFYlLJuKaWaAsWe1l4FR
-        0rOxgPy3gILdAboxHtPPJJXZR4rW7c6SeaGRJWWLlVDwJh6XK1bFKMki1hRN1DCWRaRrWJRHWBop
-        hoIla5Tl8f2qvQyMSqmcDQYteHufV3R2/91Oj4VeZqgmq9mG0oK3MLSs4hLCCItGuQLspStDUdct
-        JGqmOtKG5rBiyVqG6XtWexkY9At52WiwkteB45p+IjDA8feaPEy/QcWGbJ9q7YaTgTnD0Sfx6EX8
-        bSc5ukrEYfK/ImVPpsikubG4tN7y5+vF4v+secaE2FAAAA==
+        H4sIAAAAAAAAA+VcbXfiNhb+Kz7snj2hxcSyjcH50iVAJtkGhhMIM91pyhG2INoYm/olLw3573sl
+        22BAJmQmydA2H4gsXcn3PvdFurLsxwJ1x17h6LHg3bnELxwVsGv75O7fgX1T9vxJoVRw8ZRAfUiC
+        cBhY2B2O6X0Y+YQ1ecMQ+xMSFo7G2AlIqTD2HJv4Q2oXjtzIcUoFy3ND33MKR6EfQXsUQOuM+FMa
+        BNRzg8IRUmulQmBdEztyyDCKWFe42XTm4JDIOh4ZCI9GcsVChoxUE8uIqLaMq0rNUuzKWEO6Ma7W
+        KgaqVkxDMZRxFRgjNg2H2HG8O2IveGPMg4zDRKDLntRwvMiWenE9dJt5DrUeoO0YB9SSOiS88/wb
+        TgCtwTX2yUIwb/Q/YoVcUhWZpUKIJwkYQUqCLQfKXx4LKwIrpRTrmMqmAcj6kLAV12XLSyzDhxlj
+        3CZjHDlh4am0NjKHMhkbrQ+cq9iNei7S4m5MY4Wnq1Lh2gtCy4vckIuQKMrQqxaumjXZJkiV9RpR
+        5dFYU0FdVU1TdQ0pFYVBF+IwAg6h4M1m1GW34baU3GQWFBiCCXpJSS3PohErlkPi4pFDAmJFPg0f
+        ypY3BXrshCniQ+ByqeiZRWUYXI5mjodX9T8ETnyQAFWqulZRqtUq3JdOwbbxdLaoNmsg/zUObkap
+        3cIFjsCoQh/ThTGnBpWMyZT0BKQUhPQfuOKTMrcShBRDM1GqomECs+UTHIL+hjbY+ypjDgaXm3o2
+        HVNLQMO5fJkesnCLdRL7oc91nANwagzMtqF4GzkgDh5Rh4aUxAaf2AnwN3OiCXVjYVXT0Bc1ifX1
+        iH9LLSI1SQjuBDIyLsgtYXrmTCTkYzylzkOmg53pwFgYUtcm9wAOc4vk/mjl/khBSnX9/qf9fldi
+        YxJf6gM6EriDNCB+sAMrn8go6RqsMaFuYwJtgHDWaHelfmqG0gX5PYIi/J96IUCD2Q8NLMcL4ri7
+        lasPhKnDWeNIy+cI8fi1ylGHBEEUSL1fOlKwCI9bb9v1/DClXYdDz725qquGsqET0IPfJ/eh1Pex
+        G4xBNV3fCz3Lc6QDprCidAazlj/FuxhMvpYquWxVkaJvYNLrnUqfCL6R2vWGVHcmHtzyehpILR6c
+        7BU+0CYfbdBgeY0Dg/kSRLNZxp/YpUOxa5H4ekydkPHO/CrhhFGXKbsjBA+b3T3lsR4EJJTOmoXM
+        zPuYuj2BigfeacJuXviiyDCfjq8ea0/yweJCf5KLj9rT4hqpTwelnUmLP2S5Su+kIFXTK0ZVxiPL
+        lslYQTKrkI1qzWRVrAbms4IHiscQMZm0BfI7m6T4L2jaumZXcQFQmfheNEulzoagBz4vJg2xDsoY
+        4jYdRbCEKY+EsB1HE4jsv+8K3G9M4qsfY1iufhTL3LlsH7cuOPP3DnEn4TWYRe1dhCT3MPPBCmjs
+        AwVbwgzBL29xIJC8Ue8M6j2pFfeQTtIeQhxs35vZMHtBowMzG+OfzYRwySeGwlWudN8gTMz6cIat
+        Gzwh+SJ0FwQ7MR73goqmmgjPBoDrT9c0JMMu+Bh4pQ8z5JtIde+T8VGjddGXGw2RTNAi1e1bGsDy
+        YWezbNTl2CLl1EDXa4o//FNkq0D2C/zJZ03pgJIjCa5VRdFkpVZ8H7dcwJGHxSA71lf7qVh4AjPX
+        4FICFohPIO7GGCAAABX3xX89X2j6Hy9ae+27MyHX3dZO6isL42q/9bn/PkZp3ZKyj+9EEgx2k+C3
+        A6CcQ6gpygfINM25qnxR0BU3x2Lsko96CebX3ejyDHjQAndFFdmsVY1ScgXZsgJT7nshFQTDEQ7I
+        MMiz1EGvJ0FaTSCbjil2d99ffy0nDvyTUP5qubIhJqyZgHTCf1/FkpmEbFvCg7X1din7CdU3SSoU
+        VC+r7yzoLeRYnp/rBVlpB5x0x4kKeqr/aB0dXM67Hxvzk/npvNMsHl6cHx18PJn355/ml3FFA0ga
+        88uLeYNdcz/5qp7FHNdpHZ2WpNbRyQasr+wbz+P4cvjqg6OD83l93ike1kHa03l7fg7F6OigM+/N
+        28XDBit1543i4dmiVE9LCyy/bZg8YGHUTkmC3/obQ6vtEHdutbLyZw8+2o7Rh8v65w9B2kti0KrM
+        L/WkI+h9GEcUHk8+J+EkiSaf42ACsWR+AReJ37ys03cOP9quGH4VdCyAdCCAnM+7cQg5n58WD7sX
+        rJYXL3ncuCge9hheDR5RTqGpwyNKUqqnpSzArzz0dw1WcYrzqSVSwKddl5OJaz6X0XxqrWczkM69
+        SSq33K0a2iSwfDpL9uQ2ZLwm1o3UYRevvPZ/BdYXYIkYX5BJFxmyvRBh08qSh0NDbMUbm5vyNGOK
+        w59dyAalekwX7E/OuJn82uqQOA71RNK0eMM+58AL7uO+z4rwFi7yprsU+BZTh/Egki0Rqp6h2RO9
+        8Hjcah7LfDMpj/EmDjFbYL7ultNe7Q0nNdfRKB+HU964J5pLGE5ohwTUk7Oyaa1QSi2g3FWMpGsg
+        YZ9IWRPveFLCgEQDmGZ/j6jPn/5Aww2PqUTc9S2xIPZw9DCcYucOC1ODVkomHT9I7QXZfik0FsLl
+        jx6fk6GTUn0XEfgDuOToyyajp9DKiodnXalu2z6w+g0BHZlqGRm1MiqrJVRl5TL8yMuiopSQwv6V
+        K7BkVvUS547cY1i3EH5W4v228M/qg7oAEVb9wggqf6nL/8XyH1fyakRdr8+JsPyOG2tghOS6rKAK
+        es/HGsDKsRiT43fH5FiIyfF7YhKEdDJcPCkX4tKWesv2XdCht2eDqx9zZF6OFot8Nnhn7YsearHq
+        d9d+//t7BHWH4TWgQO5EIf7MlfrXBIL73R4lJPmz6r5OpJnF3ZSEOOCVIv4XjfucQC1FyMugMnL8
+        abInHhzavRNRcGhTy/cCbxxKx5HjkJC6u8WJdm/t8f9aRU5kaPdMUzZNE8gVRa7WzHdE4GNv0BTN
+        jrz+L5N0zdgAw1k0clZOcm6K3WWEUndJyE//iX0RGsaUOPYGEI/602FcUJcFISTs0Mdhu33YbG6o
+        nA0vOyxqJCWSFifhsrSo5IDx0rdul2zdRexyeqm5QrRPW3Hxcb+h8JRZwvxJfCJwW3wdTiMnpMso
+        u7jLBWQ/pziUzj2LPd1JDkRLfHOVTZn8QGeGq9OufPl5K7WaoW6SEcXuVnItQ97zHOxDDryNXs/Q
+        nxDb8/FW8kqGvPHhTMKjKCBpo5Fp/AAq9rytY1WzrEa91lbiWoa4frYdMjND+4m6oLBAOpI2g/ZC
+        IUq2w8px1PgAbpbRdr8rzXwPzGa6IMjq6MQn5LjX3G4BWS1djiI3jLbTZ7XUc7B1w5Y127tkNdVm
+        7xDgm2d6ZNWXHG0eU4dI2LLiDJlTZbXWACV/7G0fNau4k343rRboKDV4ZYVzC27wjIegFRdxKVB6
+        Yyk5iJ4SZXWUHvXlDSseIzi8Hh+DXrkF36CXLl16n92f54RiBwHz+9zrpTQrfoIh4vieF8LSn0HO
+        Aw+nygJ90W2k1TWhcV8GxJem2MUTMiX8sQInNlc9Mjl3zuNEFuV0E3URRLKIdgnx5b4ns//SCTOI
+        3jWEFTd9FUXLIts46zU+pg1ZZE+oT+6w4yxukUX0GCza9ryFx2lZFHuNerOeNmSha3ZSRLUsVgCF
+        A/YqBbEuF2NmgevyF4mk5aOjlMhcVw2WgmviOOva0ZUVqwkhmkwWIXUFvbVj95wgixh7iSnOUXjT
+        KmbuBDBfibH6SijotFOH0rOQdc5SZHRjPQzQ2+0RXs9iOWjzQNPqbfdAPYvtsR+xyOH54EewbsAZ
+        siy6/4lcb/vUVFnB2KJg1+xNG+mcutH99p5ZDbS9ETPaJslaQyWrgo8+toBih3Gz2qlP8R+w/tuh
+        V1ZlXex4Ut0Jt0+Nlaw2TyN8R+h2+qyaTyrpm3HP4FvdwGDQ3t4jq+cz16I26ES6IMHMc4PUhCtZ
+        LQ+oH0beH39sF9dQVhzirsde2JIaH3rn27uhp9dLaLetCHdNcw6U+RcEy/l4Ta+UjKfiwa+/Bj/I
+        7Odgvan400GJN7ywV0769Jn9lfivzH/XMilFUd4i+09eo9l8DS4XzXaG9O+RPuVsiyR47OmWiBeF
+        s0i0K5Ww/TFt/1rGQ3IflrzwGqY4VnyfTY3EXHdJ9WMx/865fgIWFzIXoH7cutNmpMOiOR+KraZe
+        ZTsS1ldl9iNiMK7edX/qEZUqT8vIu6xLA/VzVDmBuaaUahB85ZpSU14Qk9MTm0zbL4QjeRlTBMmy
+        abfdY2sGV5HNfqk1nb2GyrJThYDFC2LhIJT+xVIrMhMrUMBpTM0f9McjQPHtzqWwBQkkmgL2k5a/
+        zNZoQMgQO4EnFJXAUpY37dvkteX55dZHl3kbfAX2QjNcnnvsGEub2DRinzg4pRPGXQPGoyyyvYnB
+        BZ4T5fhKb9m0T5usWeYfXG8WUNHDxN6yaU+Zj9wgmrGQGp98uSWuzU9fr0tyuaRjZ18GKd13eUAX
+        QiZ3Q91JeUz9IByOvcgVpTarL2yeMFpIs4jYlP4S65sFMPy7Hbvhco7/8rBsmv3tzC/nvcOyCk/X
+        px7Pyy8w2wGTDgbdi+KL5r30dZbv+PYO/+DDDgnBmuh/m7xg4TfsizTPA9MLc9HYDH4dwubTE3rP
+        F251K6S3hK/ggsgfY+t11nAhnpR7zZ8l0BaZeL5wUbDa/BVP/tgIt9iJiGpCKy+t1WZ3MxfVNSFx
+        TUiMDBExMoTEGhIRa0g8ckU4ckU8si4cWRcLKCRWxcSaEA1NjIYmREMTo6FWhWxUxSMLiTUxsSrE
+        WRXjLJQvRzxFyIQiZkJIrIqJhfYpNk8RpZBQqAuxKoQGIbYHJFQEEitC14QDa2LAVCFgqpgNIbpI
+        jK4mdCVN7Eq6cGRdPLIu5FkX86wK2VDFbIjBEGMhRBnloCw0CzXHRYUjq+KRdaHX6WKvEw4sHhcJ
+        rRPlhCvxwDkjC90Oif1OE2pEy1GJEAskxkJoFmKrEDqf2PeQkF8k5lcTIqGJkUDCkAm1m49+AhLK
+        1/wjSknJ9cKXLRLs2rg2HhlErqKxJeuWYsqmpaqyNdJNYhO7ousVweJhx25fsajgH/XkEg/NajZW
+        rDW8DRjIxEpVkXW7qoJUhiqP9LEm20i1ahrBus1D+SYYO3X7NjBqFVUMBmt4CzDYLQTCJtVfKcya
+        CG/CuGKpFibYkImijGR9NMZyDY8MWbFGlWpFN6yxZQgE27Hbt2nRMHK0yBreAgw0riHdsCsgi8kc
+        VVNkrBuabFlEN1Q0NnVD5N87dvtaMPjHcGPB7QdooNY6KgKKt4DHsmsE10AwrWKAnEg1ZBOzjwKS
+        alVFWFWQbgrg2bHbN4Y/Myf6ma8ExRX7XHJIko88+mQKoPPsPmAcu9F0aN2S+PPA7CL5ICSKr1Jy
+        Yq9S0ekMW6w2IVfWR/5y9fT0fwilYwPkWQAA
     headers:
       Cache-Control:
       - no-cache
@@ -3057,12 +3998,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:56:08 GMT
+      - Thu, 21 Nov 2019 15:43:45 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -3072,9 +4013,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - b6af80be90795c88ec225d69fdf947ae
+      - 772478fbbf5b3df3ca4282fdd6efe70a
     status:
       code: 200
       message: OK
@@ -3090,82 +4031,88 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VceXfiOBL/Kn7svn1hBhNfHOafWcIxyW4gTEjonunO8IQtiDbGon2QpEO++5Zk
-        GwQYQjpHMz39XhNZVZKrfnXosv2QIe6QZioPGXrrYi9TySDX9vDtv337Jk+9USaXcdEYQ32A/aDv
-        W8jtD8ldEHqYkWg/QN4IB5nKEDk+zmWG1LGx1yd2puKGjpPLWNQNPOpkKoEXAj30gTrB3pj4PqGu
-        n6moWjmX8a1rbIcO7ochawo3G08cFGAZDyxkIV2XNd3U5RLCRbmsDgtQUgu2ppVN1SqbumJYCBmF
-        cklBatEAwbBNgj5yHHqL7blsTHjQsR8rdNmVag4Nbakb1UOzCXWIdQ+0I+QTS2rj4JZ6N5wBqP41
-        8vBcMTr4H7YCrqmqKrlMgEYxGH7CgiwHyp8eMksKA2+MdcRlEx90vY/FiurE8gLL4H7CBLfxEIVO
-        kHnMrfTMoYz7Vlc73mjYtXp2Q21+N2axzONVLnNN/cCioRvwzmNDlQ3THGqKJZs2MmTDLJfkMthM
-        Lig2MrFtmkZBZ9AFKAhBQijQyYS47Dbcl+KbTPwMQzBGLy5p+Uk4YMV8gF00cLCPrdAjwX3eomPg
-        R06QIN4HKReGnlhEhs7lcOJQtGz/PkjiMQ0KRV0vlcsKqBKQMfg2Gk/m1aZmgL7IvxkkfgsXKASn
-        CjxE5s6cOFTcJzPSI7ASUNK754aPy5GXKGXNVPTERP0YZsvDKAD79W3w92XBHAQhN6Y2GRIrhYdL
-        +Tw7iHCn2ySKQ4+76QaAE2eIfBv5Pg4SZVi1WE5yx072nHh05GGfiaQqigz/DzX4C/9jb0kYoJWH
-        uR8qyjIloAFy4no3HIM21o0PKcgnkJWwHVM41waaj6eYyRR7+kOGQC7iisY1+oLHgb9wN4UFYkxV
-        1qjqVqq2lapvpRqPV4+Lykgyi0JiZqUorUMBciBvPIacGI558ZqMrnnBgobgWk5Uy23n2viOqQQ2
-        noYO+CkaEAe4sC+CAM45ccIRcWPPVlVjXhPb/KTW6kgXSWhJ5/hLCEX4O6YBluqI/RDfcqgfjSUL
-        PZR5V0M0Jg7Lx79iJomTiYRKpBShXZFI1VRzVaI2OEjoS93f25I/T/lbb9uhXpDw+is31zbfXFMK
-        +urNjwFdqQkZ4l76LUQOhDS2pTodI+JKbWCRDpq/1dtZwMenTsiC/dsw0ZnlIJ4mSYTGlw5BroWj
-        6yFxAqYQM2gsHuPOg/C5DKQjmwVnIniVxbd0Us8IY/lDkkggCiHTsUYjdvPMJ0U2kTy8eig/ygfz
-        C+NRzj7oj/NrVXs8yO3Mmv1JlCq5k6JqulEolmQ0sGwZDxVVZhVyEfIiq2I1MEJmKIyQCHIw0zaD
-        v7Bhj/+OUWBds6uoAKiMPBpOEq1F37/nI21MiKyQRzASkEEIk6L8IBW2o3AEY8WXXYH7k2l89XME
-        y9XP6Tq3L1tHjXMu/J2D3VEAUayW30VJfAdjKcyphh5wsElRH6JiivwUzWvVdq/alRpRC6mZtEjF
-        wfboxIbxEIgOjJVMfja2wiUfajJXG7V7gTKR6P0Jsm7QCG9WoTNn2EnwqBVU1LVYedYBXH+4hkGk
-        34EYg6j0YMx9E63uPDys1BrnF3KtlqYTUKSqPSU+TEh2dstaVY48Uk4cdLUm+9M/03wV2H6Hf/JJ
-        XToguCLBNQzkuqyUs+8TlnM4NmHRE/v65jhNVx7DuNG7lEAEmFpA3o0wgAmGrmb3JX6pl+r6Z+eN
-        vY7dSarUncZO5sun5tWLxseL93FKa4rzHrpN06C3mwZ/HgDnDFJNVj5QTdOcaconRb3i7piNQvLB
-        yMH4uhvfJgfuNSBc1YIMC4liLr4qwpQchtz3Qsr3+wPk476/yVN73a4EC3UM6/OIY/fw/fw5Hwfw
-        L6n6l/KFNTVhzgSsI/77Kp7MNGQbHRRmcdu1vIi5XqRpqqJGXntnRafYghttjAJR2x5n3XGggpba
-        PxqVg8tZ56w2a86OZ+169vD8tHJw1pxdzD7MLqOKGrDUZpfnsxq75nHyTS2zG0KnUTnOSY1Kcw3W
-        V46Np3F8PnzVXuXgdFadtbOHVdD2eNaanUIxrBy0Z91ZK3tYY6XOrJY9PJmXqklpjuXLutkELPTa
-        zknwW31jaPUd8s5Uzyt/9eSj75h9uK5//RSkPycHLev83EiqQOvDKKPwfPIxTidxNvkYJRPIJbNz
-        uIjj5nmNvnP60XfF8JugYwmkDQnkdNaJUsjp7Dh72Dlntbx4yfPGefawy/Cq8YxyDKQ2zyhxqZqU
-        RIBfuevvmqyiJc6HRpoBPuw6nYxD86kVzYfG6moGlnNvspRb7Fb1bexbHpnEu2FrOrIdXL559tpz
-        /1cQfQ5WmuBzNulcYNsLFda9LD5u6iMr2u1c16cecRz+14XVoFSN+Pz9WTOuL35trY8dh9A0bRqc
-        sM9r4Ln0UdsnVXiLEHnTXQo0RcRhMqTpFitVFXj2xC48HzfqRzLfTNokeB0FiE0wX3fLaa/2huOa
-        63CwGYdjTtwTy8UCx7x9DObZMLNpLHFKDeDcVY24qS8hD0uii7epFAsgER+G2S8hYQeSnHDDcypO
-        b/qWWGC7P7jvj5Fzi1KXBo2ETTq6l1pztv0yaKSEyw/+ntKhnXB9FxX4AVz8MM26oMfxWfrhSUeq
-        2jY/Jf/2hK6aWl4tlvNqXsupJVbOw4+8KCpKTlXYn3wBpsyakePS4TsE8xbMT+vfbwv/pNqrpiDC
-        qp+ZQeVPVfkPJH+9kpcz6mr9hgzL77g2B1ZVuSorakF9z2MNEOUoHZOjd8fkKBWTo/fExA/IqD8/
-        K0/FpSV1F/Rd0CHTk97Vzxt0XvQWqXzSe2frpx1qsep3t/7F948I4vaDa0AB36al+BNXurjGkNxv
-        92hBsnlU3deBVJjcjXGAfF6ZJv+cuM8LqIUKm1ZQgh5/mdUTTw6tbjMtObSI5VGfDgPpKHQcHBB3
-        tzzR6q4c/69UbMgMra5pyqZpAruiyKWy+Y4InHV79bTRkdf/MIuuCeugPwkHztKzoetqdxij1Fkw
-        8mfv0mMRCEOCHXsNiAfj8TAqaItCKiTsoY/DVuuwXl8zOetedljWiEs4KY6CRWleyQHjpZdul2zd
-        Rexwfqm+xLRPW3HRA3/91KfMYuGb0TOB2/Jrfxw6AVlk2fldzmH1c4wC6ZRa7HQnfiRX4purbMjk
-        TzQKUh135MuPW7k1gbuOBwS5W9l1gb1LHeTBGngbvyHwN7FNPbSVvSCw1349kdAg9HFCLArEX8HE
-        lG7tqySKGnYbW5nLAnP1ZDtkpsD7gbhgMF+qSOtJe24QRWyAB9CtN42eUY0efxUFbV10pIlHwW3G
-        cwbRRk0P46NufbsHiFa6HIRuEG7nF63UdZB1w6Y125uIlmqxtxLQzRMtRPPFDxYPiYMlZFnRCplz
-        iVargZHPutt7FQ3XvOgk1Sk2ShxeWZLcghs8ESHqUoi4BDjpkBuR8KMAziTaqEV8K58QliImaiPZ
-        OMBWnL04k7F0C75BL1265E7cn+eM6QEC7vex2014luKEPbLsURrA1J9BzhMP5xKBPu/UkupyqnNf
-        +tiTxshFIzzG/FiBM5vLERk/4czzhIhysok6TyIioh2MPfmCyuyv1GQO0b2GtOImL7foIrK1k27t
-        LCGIyDaJh2+R48xvISJ6BB5tUzqPOF1EsVur1qsJQYSu3k4Q1UWsAAoH/FXyI1vO+xSB6/BXk6TF
-        0VHCZK6aBkn+NXacVesYypLXBJBNRvOUuoTeykPvnEFEjL0WFa1ROGkZM3cEmC/lWGMpFbRbSUAZ
-        ImTtkwQZo7iaBsh0e4Y3RCx7LZ5oGt3tEWiI2B55Icsc1IM4gnkDEthEdP8TunT70FRYwtgi4Nfs
-        3R3plLjh3faWogVadMCcto5FbyiIJjjzkAUcO/QrWqc6Rl9h/rdDK9FkHeRQqeoE24fGgmjN4xDd
-        YrKdXzRzs5C8a/cEvqU1DHqt7S1EO5+4FrHBJuwliwl1/cSFC6KVe8QLQvr163Z1i6Kl/7jYPhMo
-        qo+vt4zdNg/cdXFzoMw+qTCJj2bySq74mD34/Nn/SWY/B6uk7C8HOU54ZqsNi6aP7F+O/8r8d2X9
-        pCjKW6z549dn1l+n24hmS2D9eyyaNmyGxHjs6UYIDYNJmLYXFYt9ltC/VfAA3wU5GlzDwMaK77OV
-        EbvrLgv8SM2/8wo/BosruRGgi4i60xakw7I574rNoV5lExJmVXn2kyZgVL3rrtSDmis8LjLvoi5J
-        1E9xbUjMZSVXhuQrl5Wy8oycnDynyaz9TDg8GlCLOmmQLEi77RlbE7gKbfZLrPHkNUwmDhUpIp5j
-        C/mB9C+2oMKTdAOmSBpx8+P9qAcovt3TKGxCAsvLFPFjyg+zIepj3EeOT1NVxTCB5aR9G7y2nFpu
-        PbDctK0Hc9wh0/OUsodXWtE737nMMXvjO5epJe97v4nDCS8ur+myIO3T1qoo/L1LJz5JO0LsLkh7
-        Knzo+uGEpdToeZcpdm3+zPWqJpcLPvbESy/h+y7HcgGs326IO8oPiecH/SEN3bSlzfJrmk3GC8ss
-        nO5KP8T8Zg4M//7Hbricoh8elnW3n068/KY3V5bh6XiE8nX5OWL7XtJBr3Oefda4l7zE8h3f2eGf
-        edhhQbCi+t9mXTCPG/Zlm6eB6QYb0VhPfm3MxtMmueMTt6oVkCnmMzg/9IbIep05XIBGeb1UKKuI
-        feGqiBTZ0NBQNu3iQDYGarmom5pm62aKajs2+4bzQf7drylyQtzXVRUYeHmdsL7F5eNAvuafiIhL
-        Lg2eB4Zi6KWygYqyptgqaDVQZDRUsawgXNQVrFqaZaWAsWOzl4FRKKdjAfVvAQW/A4QxHrHvSRX5
-        15xW9U7jeaGSBW2DlkB4E4urJbtkFlQZG5ohGxirMiobWFaHWBlqpoYVe5hm8d2avQyMUqGYDgYj
-        vL3NS2V+/+1Gj5lepqih6umKMsJbKFrUcQFhhGWzWILsVdYGcrlsI9mw9KExsAYlWzVSVN+x2cvA
-        YJ8STEeDU14Hjiv2LcUAx99r8jD7WBcfsn0mtRuO+9YUR98OZBfxt53U6Cphh8n/EhcZT5DFamN2
-        ZbXnT1ePj/8HCeuLBAFSAAA=
+        H4sIAAAAAAAAA+Vce3PiOLb/Ki721q0wg4llG4P5Z5cAmeRuSFMhoXu3J0sJWybeGJvxI48J+e73
+        SLZBgEyTdJJmZrqqiaxzJJ/zOw89LPup5PpOUGo+lYJ7n4SlZgn7dkju/xHZt9UgnJQqJR9PCdTH
+        JIpHkYX9keM+xElIKCkYxTickLjUdLAXkUrJCTybhCPXLjX9xPMqJSvw4zDwSs04TICeRECdkXDq
+        RpEb+FGpidRGpRRZN8ROPDJKEtoUbjadeTgmso7HBsLjsVyzkCEj1cQyIqot47rSsBS75mhIN5x6
+        o2ages00FENx6iAYsd14hD0vuCf2QjYqPOg4yhS6GkhtL0hsaZDWQ7NZ4LnWI9COcORa0jmJ74Pw
+        ljEANbrBIVkoFoz/S6yYaaois1KK8SQDI8pZsOVB+etTaUVhpZJjnXLZbgS6PmZipXV8eYll/Dij
+        gtvEwYkXl54raz0zKLO+0XrHhYbdqGcqLe5GLVZ6vq6UboIotoLEj1nnmaEMvW7hutmQbYJUWW8Q
+        VR47mgrmqmuaqmtIqSkUuhjHCUgIhWA2c316G+ZL2U1mUYkimKGXldTqLBnTYjUmPh57JCJWErrx
+        Y9UKpsCPvThHfARSLg09s1wZOpeTmRfgVfuPQJKQalCr61pNqdfrcF93Cr6Np7NFtdkA/W9wdDvO
+        /RYucAJOFYfYXThz7lBZn9RIz8DqgpLhIzN8VmZegpBiaCbKTTTKYLZCgmOw38gGf18VzMMQctPA
+        dh3XEvAwKV9mBx5usU3SOAyZmxYAnDtD6ts4ikicK0Or83ImmWrXTa1uqrJhQNzqjTqRx6riyETD
+        lqOqOrJVVEpb5plmJ+vPwmASkogqgBRFhv+HKvyF/5lv5QzQKiTMaxVllRIHMfayej+Zgu7WbQQJ
+        K3Ihh1F1GYVxFdAickeoTFlcPJVcyFwMlqzGWPJ48BfuptCwXcbRGhVxVGWDqm6lalup+vP187Ky
+        1KxTLIKQuhMImY4CUICUyeSaQgpNpqyjG3dywwoWtARP9NJaZmrfJg9UJ3CJu8QDt8Zj1wMuEvEo
+        gDfMvGTi+qlvqKahL2oyow9IeOdaROqQGNIq+HqJF1ZZsDt46nqPXAOba0BFyGVCqzhz90cKUurr
+        9z+5vOxLtE8SSpcQJRKkRWlIwmgHUT6TcdY0WhNC3SYE2gDhtN3rS5d5OpIuyG8JFOHvNIgBGkx/
+        3Mjygigdf7dK9Quh5vDWJNK2SKQ2NmC5DLFFwiCBO5+Ci4RTvIttxLfWqZdA8M7y5JFdei72LZJe
+        O64XUxip82QiUO4qCFgpQaa0aSbIhWvR1COddkrcNOMpz3EQ8pCEaaMJvXnpqyLD5MG5fmo8yweL
+        C/1ZLj9pz4trpD4fVHZmLf/ES5XfSUGqpteMuozHli0TR0EyrZCNesOkVbQGBu9SAIM3huGBalsi
+        v9ERmf0CxtYNvUoLgMoELDDLtebj7JFNAjJCaoUqhkHKHYPFoupYCNtRMoFh7LddgfsP1fj65xSW
+        65/FOp9f9Y66F0z4B4/4kxgyBmp8iJLkAYZ5mO45IXDQ+doIUvwdjgSat1vnw9ZA6qYtpOO8hRAH
+        OwxmNgzVQPRgGKfy02EfLtkoWLou1O47lElFH82wdYsnpFiF/oJhJ8HTVlDRUTPlaQdw/fkGRqxR
+        H2IMojKE6cC7aPUQEqfZ7l5cyu22SCegSC37zo1grrSzW7ZbcuqRcu6g6zXln/5H5KvA9i/4J592
+        pAOXNCW4hlmDJiuN8seE5QKOIiyGfF+vjlOx8iSMpeGVBCLAPAbybooBzGY0VN6X+A1Coet/uuju
+        dezOhFL3uzuZryrMq5fdL5cf45TWHamG+F6kwXA3Df5zAJxzSDVl+QCZpjlXla8KumbuWE5D8kmv
+        wPi6G1+RAw+7EK6oJpuNulHJrgyY/8OQ+1FIRdFojCMyioo8dTgYSEfAIQ0yjt3D99dfq1kA/12o
+        f71a21AT5kzAOmG/b+LJVEO6BxPALG67lpcZ13dpKlRUr6ofrOgdLCSCsDAKeG2HjHXHgQpaqn/r
+        Ng+u5v1P7fnx/GR+3ikfXpw1Dz4dzy/nn+dXaUUbWNrzq4t5m16zOHlVy3JB6HSbJxWp2zzegPWN
+        Y+PbOL4cvtaweXA2b83Py4ct0PZk3pufQTFpHpzPB/Ne+bBNS/15u3x4uii18tICy+/rpghY6PW8
+        IsFv652h1XbIO3daVfmjJx9tx+zDdP3jpyDtJTloVeeXRlITWh+mGYXlky9ZOsmyyZc0mUAumV/A
+        RRY3L2v0g9OPtiuGr4KOJpBzSCBn836aQs7mJ+XD/gWtZcUrljcuyocDilebZZQTIJ2zjJKVWnmJ
+        B/iNu/6hySpd4nzuigzwedfpZBaa31rRfO6ur2ZgOfcuS7nlbtXIJpEVurNsN2xDR7pdLJ3Tizee
+        +7+B6AuwRIIv2KQLjm0vVNj0suxJ2Ahb6Y7mpj6dlOPwnz6sBqVWyhftz5pxc/FrqyPieW4g0qbL
+        CPu8Bl5In7b9pgrvESLvukuB77DrURlEumVKtTiePbELy8fdzpHMNpOKBO/gGNMJ5ttuOe3V3nBW
+        c5OMi3E4YcQ9sVwmcMY7ImCegplNd4VT6gLnrmpkTSMJh0TiXfw8kDIBJDeCYfa3xKVPPxnhluVU
+        Im76nlgQezR+HE2xd4+FS4NuziYdPUq9Bdt+GTRVwidRlIgeVazocJ5z/RAV2AO47JzPpqAn2YP7
+        w9O+1LJt9kj+9QkdmWoVGY0qqqoVVKflKvzIy6KiVJBC/1RrMGVW9QqTjjxgmLcQdjTg47bwT1vD
+        lgARWv3CDCp/bcn/xvLv1/JqRl2vL8iw7I4bc2CE5JasoBr6yMcaIMqRGJOjD8fkSIjJ0UdiEsXu
+        ZLR4Vi7EpScNlvRd0HHvTofXPxfovOwtVfl0+MHWFz3UotUfbv3LHx8Rrj+KbwAFci9K8ae+dHlD
+        ILnf79GCpHhU3deBlJvcTUmMI1Ypkn9B3OcF1FKFohUUp8cfZvXEkkNvcCxKDj3XCoMocGLpKPE8
+        Erv+bnmiN1h7/L9WUZAZegPTlE3TBHZFkesN8wMR+DQYdkSjI6v/0yy6ZrSD0SwZeyvHVjfV7lNG
+        qb9kZEfcxLEIBMclnr0BxJP+fJgW1GVBCAk99HHY6x12Ohsmp93LHs0aWYnkxUm8LC0qGWCs9L3b
+        JVt3EfuMX+qsMO3TVlx64G8kPGWWCX+cngncll9H08SL3WWWXdzlAlY/JziWzgKLPt3Jzv9KbHOV
+        Dpns1CIn1UlfvvqylVvluDtk7GJ/K7vGsQ8CD4ewBt7Gr3P8x8QOQryVvcaxt385lfA4iUhONDji
+        L2DiINjaV50XNRl0tzI3OObW6XbITI73s+uDwSKpKW0m7YVBFL7BysnY9BQ8L2jvsi/NwgDcZrpg
+        4G10HBJyNOhs9wDeSlfjxI+T7fy8lQYetm7ptGZ7E95SPfrCBL79RgvefNn5Xcf1iIQtK10hMy7e
+        am0w8qfB9l55wx1f9vNqgY1yh1dWJLfgBt+IELQSIr4LnIEjZaetcybeRj03sqo5YSViBCe0GZO+
+        cgu2QS9d+e4Dvz/PGMUBAu73ZTDIeVbiBEPGCYMghqk/hZwlHsbFA33Rb+fVDaFzX0UklKbYxxMy
+        JeyxAmM2VyMyO+HM8gSPcr6JukgiPKJ9QkL5MpDpX+mYOsTgBtKKn793o/HItk8H7U85gUf22A3J
+        Pfa8xS14RI/Ao+0gWEScxqM4aLc6rZzAQ9c5zxHVeKwACg/8VYpSWy765IHrs7empOWjo5zJXDcN
+        lqIb4nnr1tGVFa+JIZtMFil1Bb0gjKXsrZsFA48YfWMrXaMw0ipm/gQwX8mx+koqOO/lAaXzkJ2f
+        5sjoxnoacO+2Z3idx3LYY4mmO9gegTqP7VFIj947QQhxBPMGzLHx6P5f4gfbh6baCsaWC35NXyuS
+        zlw/edjekrdALxhTp+0Q3htqvAk+hdgCjh365a3TmuLfYf63QyveZH3sBVLLi7cPjTXemicJvifu
+        dn7ezMe1/DXAb+Bb38Bg2NvegrfzqW+5NthEuiDRLPCj3IVrvJWHbhgnwe+/b1fXUFYC4n5A306T
+        2r8MzrY3Q89vt6DdNiPcdZlzoMy/IpjOp3N6pWI8lw9+/TX6SaY/B+uk8t8PKozwwlYFy6cv9F+F
+        /crsd20lpSjKe6z+sxdpNt/5K0Szx7H+NZZPBdsiGR57uiUSJPEsEe1KZWJ/yumvFTwmD3EliG9g
+        iKPFj9nUyNx1l6V+quZfea2fgcWULAToMqXutBnp0WzOuqKzqTfZjoT5VZX+iARMq3fdn3pCldrz
+        MvMu6/JE/S2ugsTcUCoNSL5yQ2koL8jJ+YlNau0XwhEGcWAFngiSJWm33WNrBleJTX9dazp7C5Px
+        Q4VAxAti4SiW/pcurchMbECBpCk3e9Cf9gDF9zuXQicksNAUiJ9R/jRboxEhI+xFgVBVAlNZRtq3
+        wWvL88utjy6LNvhK9FViuDwL6DGWXvqmeaV0Qt8zr5Ta+Vvm7+JwUeAlBbEyWJL2aZOVF/7RD2aR
+        K3qYOFiS9lT4xI+SGU2p6cmXO+Lb7PT1uiZXSz569mWY8/2QB3QxrORuXX9SddwwikdOkPiipc3q
+        C5vHlBeWWUTsSn+K+c0CGPaRkt1wOcN/elg23f5uFlaL3mFZhacfugFbl19gugMmHQz7F+UXjXv5
+        6yw/8O0d9sGHHRYEa6r/ZdYFi7ihn9/5NjCDuBCNzeR3Tuh4euw+sIlby4rdO8JmcFESOth6mzlc
+        jCfVQeefEliLTIJQOClYJb/iyR/t4Q57CVFNoLLSWi2/m7mobgiZG0JmZIiYkSFk1pCIWUPinmvC
+        nmvinnVhz7pYQSGzKmbWhGhoYjQ0IRqaGA21LhSjLu5ZyKyJmVUhzqoYZ6F+BeopQiEUsRBCZlXM
+        LPRPsXuKOIWMQluITSF0CLE/IKEhkNgQuibsWBMDpgoBU8ViCNFFYnQ1YShp4lDShT3r4p51ocy6
+        WGZVKIYqFkMMhhgLIcqoAGWhW6gFISrsWRX3rAujThdHnbBjcb9I6J2oIF2JOy7oWRh2SBx3mtAi
+        WoFJhFggMRZCtxB7hTD4xLGHhPIisbyaEAlNjAQSpkyo3Xz0E5FYvmEfUcpKfhC/bJJgN5yGMzaI
+        XEeOJeuWYsqmpaqyNdZNYhO7pus1weRhx2avmFSwL5gyjUdmnc8Va4T3AQOZWKkrsm7XVdDKUOWx
+        7miyjVSroRGs2yyVb4KxU7PvA6NRU8VgUMJ7gEFvIVA2q36lMmsqvIvgiqVamGBDJooylvWxg+UG
+        HhuyYo1r9ZpuWI5lCBTbsdn3WdEwCqxICe8BBnIaSDfsGuhi0kDVFBnrhiZbFtENFTmmbojie8dm
+        rwWDffk3Vdx+BIJrraMi4HgPeCy7QXADFNNqBuiJVEM2Mf0oIKnXVYRVBemmAJ4dm31n+jMLsp/5
+        RlBc029DxyT7yGNI6NdE2eo+ohL7yXRk3ZH0W8j0IvsgJEqvcnZir3K50xm2aG3Grqz3/PX6+fn/
+        AQhqvQXRWgAA
     headers:
       Cache-Control:
       - no-cache
@@ -3176,12 +4123,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:56:18 GMT
+      - Thu, 21 Nov 2019 15:43:55 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -3191,9 +4138,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 2f49eb274e3da58ddcde341e5ce7d777
+      - 8bace0db1d78929e1d2a2e4877fc901f
     status:
       code: 200
       message: OK
@@ -3209,82 +4156,87 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VceXfiOBL/Kn7svn1hBhNfHOafWcIxyW4gTEjonunO8IQtiDbGon2QpEO++5Zk
-        GwQYQjpHMz39XhNZVZKqflUqnfZDhrhDmqk8ZOiti71MJYNc28O3//btmzz1RplcxkVjDPkB9oO+
-        byG3PyR3QehhRqL9AHkjHGQqQ+T4OJcZUsfGXp/YmYobOk4uY1E38KiTqQReCPTQB+oEe2Pi+4S6
-        fqaiauVcxreusR06uB+GrCg0Np44KMAyHljIQroua7qpyyWEi3JZHRYgpRZsTSubqlU2dcWwEDIK
-        5ZKC1KIBgmGbBH3kOPQW23PZmPCgYz9W6LIr1Rwa2lI3yodiE+oQ6x5oR8gnltTGwS31bjgDUP1r
-        5OG5YnTwP2wFXFNVVXKZAI1iMPyEBVkOpD89ZJYUBt4Y64jLJj7oeh+LFeWJ6QWWwf2ECW7jIQqd
-        IPOYW6mZQxnXra5WvNGwa/msQW3eGrNY5vEql7mmfmDR0A145bGhyoZpDjXFkk0bGbJhlktyGWwm
-        FxQbmdg2TaOgM+gCFIQgISToZEJc1gz3pbiRiZ9hCMboxSktPwkHLJkPsIsGDvaxFXokuM9bdAz8
-        yAkSxPsg5cLQE4vIULkcThyKlu3fB0k8pkGhqOulclkBVQIyBt9G48k829QM0Bf5N4PEb+EBheBU
-        gYfI3JkTh4rrZEZ6BFYCSnr33PBxOvISpayZip6YqB/DbHkYBWC/vg3+viyYg6DLjalNhsRK4eFS
-        Ps8OItzpNon6ocfddAPAiTNEvo18HweJMixbTCexYyd7Tjw68rDPRFIVRYb/hxr8hf+xtyQMUMrD
-        3A8VZZkS0AA5cb4bjkEb68aHEOQTiErYjimcawPNx1PMZIo9/SFDIBZxReMcY8HjwF9oTWEdMaYq
-        a1R1K1XbStW3Uo3Hq8dFZiSZRSEws1QU1iEBMZAXHkNMDMc8eU1G1zxhQUFwLSfK5bZzbXzHVAIb
-        T0MH/BQNiANc2BdBAPNOnHBE3Dj+aao5z4lt3gZzhL7U/b0t+fMAuxBWmfMP0Zg4LOh2qBckvMxB
-        WfuJQCKK6nLjiqoaq42f1Fod6SLp19I5/hJCEv6OaYClOmI/xLcc6kcD2Va5fsUMBmdFIm2zRJpS
-        0FclOgZ0pSZEiHvptxA50KWxLdXpGBFXagOLdND8rd7Ogog+dULW2b9NLH2jWFpB05RVsS5qncMT
-        ASowWDiZgCGgQ3xT+wbzHOjPkyRCxI8OQa6Fo+chcQJmYuZQsRyMO09YmxAObRYcEgmrLL5IJ/WM
-        MJd4SAIZRAGItKzQiDWe+aTIJpKHVw/lR/lg/mA8ytkH/XH+rGqPB7mdWbM/iVIlLSmqphuFYklG
-        A8uW8VBRZZYhFyEusyyWAyN0hsIIjWAMYNpm8Bc27PLfMQqsa/YUJQCVkUfDSaK12Pfu+UgfEyIr
-        5BGMRGQQwqQsP0iF7SgcwVj1ZVfg/mQaX/0cwXL1c7rO7cvWUeOcC3/nYHcUQBRRy++iJL6DsRzm
-        dEMPONikrA9xYor8FM1r1Xav2pUaUQmpmZRIxcH26MSG8RiIDozVTH42tsMjH+oyVxu1e4Eykej9
-        CbJu0AhvVqEzZ9hJ8KgUZNS1WHlWATx/uIZBrN+BPga90oMx/020uvPwsFJrnF/ItVqaTkCRqvaU
-        +DAh2tkta1U58kg5cdDVnOxP/0zzVWD7Hf7JJ3XpgOCKBM8wkdBlpZx9n245h2MTFj2xrm/up+nK
-        YxhJe5cSiABTG4i7EQYwwdHV7L70X+qluv7ZeWOv++4kVepOYyfz5VPj6kXj48X7OKU1xXkP3aZp
-        0NtNgz8PgHMGoSYrH6imac405ZOiXnF3zEZd8sHIwfi6G98mB+41oLuqBRkWMsVc/FSEJQEMue+F
-        lO/3B8jHfX+Tp/a6XekIOKRuzLF79/38OR934F9S9S/lC2tqwpwJWEf891U8mWnINloozOK2a3kR
-        c71I01RFjbz2zopOsQUNbewForY9zrrjQAUltX80KgeXs85ZbdacHc/a9ezh+Wnl4Kw5u5h9mF1G
-        GTVgqc0uz2c19sz7yTeVzG7oOo3KcU5qVJprsL5y33gax+fDV+1VDk5n1Vk7e1gFbY9nrdkpJMPK
-        QXvWnbWyhzWW6sxq2cOTeaqapOZYvqyaTcBCre2cBL/VN4ZW3yHuTPW88lcPPvqO0Yfr+tcPQfpz
-        YtCyzs/tSRUofRhFFB5PPsbhJI4mH6NgArFkdg4Pcb95XqHvHH70XTH8JuhYAGlDADmddaIQcjo7
-        zh52zlkuT17yuHGePewyvGo8ohwDqc0jSpyqJikR4Feu+rsGq2iJ86GRZoAPu04n46751IrmQ2N1
-        NQPLuTdZyi12q/o29i2PTOLduDUd2Q4y37x77bn/K4g+BytN8DmbdC6w7YUK614WH3f1kRVta67r
-        U484Dv/rwmpQqkZ8/v6sGdcXv7bWx45DaJo2DU7Y5zXwXPqo7JMqvEUXedNdCjRFxGEypOkWK1UV
-        ePbELjweN+pHMt9M2iR4HQWITTBfd8tpr/aG45zrcLAZh2NO3BPLxQLHvH0M5tkws2kscUoN4NxV
-        jbioLyEPS6KLt6kUCyARH4bZLyHx+PkPEG54TMXpRd8SC2z3B/f9MXJuUerSoJGwSUf3UmvOtl8G
-        jZRw+VHoUzq0E67vogI/gIsv86wLehyf5bOzwqpt81P6bw/oqqnl1WI5r+a1nFpi6Tz8yIukouRU
-        hf3JF2DKrBk5Lh2+QzBvwfy2wPtt4Z9Ue9UURFj2MyOo/Kkq/4Hkr1fyckRdzd8QYXmLa3NgVZWr
-        sqIW1Pc81gBRjtIxOXp3TI5SMTl6T0z8gIz687PyVFxaUndB3wUdMj3pXf28QedFbZHKJ713tn7a
-        oRbLfnfrX3z/HkHcfnANKODbtBB/4koX1xiC++0eLUg2j6r7OpAKk7sxDpDPM9PknxP3eQG1UGHT
-        CkrQ4y+zeuLBodVtpgWHFrE86tNhIB2FjoMD4u4WJ1rdleP/lYwNkaHVNU3ZNE1gVxS5VDbfEYGz
-        bq+eNjry/B9m0TVhFfQn4cBZupu6rnaHMUqdBSO/fpfeF4EwJNix14B4MB4Po4S2SKRCwi59HLZa
-        h/X6mslZ9bLDokacwklyFCxS80wOGE+9dLtk6y5ih/NL9SWmfdqKiy789VNvmcXCN6M7gdvia38c
-        OgFZRNl5K+ew+jlGgXRKLXa6E18JlvjmKhsy+Y1KQarjjnz5cSu3JnDX8YAgdyu7LrB3qYM8WANv
-        4zcE/ia2qYe2shcE9tqvJxIahD5OiEWB+CuYmNKtdZVEUcNuYytzWWCunmyHzBR4PxAXDOZLFWk9
-        aM8NoogF8ACq9abRrd3oQrAoaOuiI008Cm4znjOINmp6GB9169s9QLTS5SB0g3A7v2ilroOsGzat
-        2V5EtFSLvRWBbp4oIZovvls8JA6WkGVFK2TOJVqtBkY+626vVTRc86KTZKfYKHF4ZUlyCxp4ooeo
-        S13EJcBJh9yIhB8FcCbRRi3iW/mEsNRjojKSjQNsxdGLMxlLTfANeunSJXfi/nx0LTm1g4D7fex2
-        E56lfsKuTHuUBjD1Z5DzwMO5RKDPO7Uku5zq3Jc+9qQxctEIjzE/VuDM5nKPjG848zghopxsos6D
-        iIhoB2NPvqAy+ys1mUN0ryGsuMnLNbqIbO2kWztLCCKyTeLhW+Q48yZERI/Ao21K5z1OF1Hs1qr1
-        akIQoau3E0R1ESuAwgF/lfzIlvM6ReA6/NUoaXF0lDCZq6ZBkn+NHWfVOoay5DUBRJPRPKQuobfy
-        GgBnEBFjr2VFaxROWsbMHQHmSzHWWAoF7VbSoQwRsvZJgoxRXA0DZLo9whsilr0WDzSN7vYeaIjY
-        HnkhixzUg34E8wYksIno/id06fahqbCEsUXAr9m7Q9IpccO77SVFC7TogDltHYveUBBNcOYhCzh2
-        qFe0TnWMvsL8b4dSosk6yKFS1Qm2D40F0ZrHIbrFZDu/aOZmIXnX7wl8S2sY9FrbS4h2PnEtYoNN
-        2EseE+r6iQsXRCv3iBeE9OvX7eoWRUv/cbF9JlBUH19vGbttHrjr4uZAmX1SYRIfzeSVXPExe/D5
-        s/+TzH4OVknZXw5ynPDMUhsWTR/Zvxz/lfnvyvpJUZS3WPPHr8+sv863Ec2WwPr3WDRt2AyJ8djT
-        jRAaBpMwbS8qFvssoX+r4AG+C3I0uIaBjSXfZysjdtddFviRmn/nFX4MFldyI0AXEXWnLUiHRXNe
-        FZtDvcomJMyq8uwnTcAoe9ddqQc1V3hcRN5FXhKon+LaEJjLSq4MwVcuK2XlGTE5uafJrP1MODwa
-        UIs6aZAsSLvtGVsTeApt9kus8eQ1TCYOFSkinmML+YH0L7agwpN0A6ZIGnHz4/2oBki+3W0UNiGB
-        5WWK+DHlh9kQ9THuI8enqapimMBy0r4NXltOLbceWG7a1oM57pDpeUrZ5ZVW9M55LnPM3jjPZWrJ
-        ++Zv4nDCi9NruixI+7S1Kgp/79KJT9KOELsL0p4KH7p+8tY4u+8yxa7N71yvanK54GM3XnoJ33c5
-        lgtg/XZD3FF+SDw/6A9p6KYtbZZf02wyXlhm4XRX+iHmN3Ng+PdHdsPlFP3wsKy7/XTi5Te9ubIM
-        T8cjlK/LzxHb95IOep3z7LPGveQllu/4zg7/zMMOC4IV1f8264J5v2Ff1nkamG6wEY314NfGbDxt
-        kjs+cataAZliPoPzQ2+IrNeZwwVolNdLhbKK2Be2ikiRDQ0NZdMuDmRjoJaLuqlptm6mqLZjsW84
-        H+TfHZsiJ8R9XVWBgafXCetbXD4O5Gv+iYg45dLgeWAohl4qG6goa4qtglYDRUZDFcsKwkVdwaql
-        WVYKGDsWexkYhXI6FpD/FlDwFqAb4xH7nlWRf01qVe80nhcqWdA2aAmEN7G4WrJLZkGVsaEZsoGx
-        KqOygWV1iJWhZmpYsYdpFt+t2MvAKBWK6WAwwtvbvFTm7W83esz0MkUNVU9XlBHeQtGijgsIIyyb
-        xRJEr7I2kMtlG8mGpQ+NgTUo2aqRovqOxV4GBvuUYToanPI6cFyxbzkGOP5ek4fZx8L4kO0zqd1w
-        3LemOPp2IXuIv+2kRk8JO0z+l7jIeIIslhuzK6s1f7p6fPw/3BO5OoFSAAA=
+        H4sIAAAAAAAAA+VcW3fiOBL+Kz7snj1hBhPLNgbnZZYQMsluoDmB0L3bk+EIW4A2xmZ8yWVC/vuW
+        ZBsMyISkkzQzkwciSyWp6quLS7LsxwJ1R17h6LHg3bnELxwVsGv75O6fgX1T9vxxoVRw8ZRAfUiC
+        cBBY2B2M6H0Y+YQ1eYMQ+2MSFo5G2AlIqTDyHJv4A2oXjtzIcUoFy3ND33MKR6EfQXsUQOuM+FMa
+        BNRzg8IRUmulQmBNiB05ZBBFrCtMNp05OCSyjocGwsOhXLGQISPVxDIiqi3jqlKzFLsy0pBujKq1
+        ioGqFdNQDGVUBcaITcMBdhzvjtgL3hjzIOMgEeiqKzUcL7KlblwP3WaeQ60HaDvGAbWkNgnvPP+G
+        E0BrMME+WQjmDf9HrJBLqiKzVAjxOAEjSEmw5UD562NhRWCllGIdU9k0AFkfErbiumx5iWX4MGOM
+        22SEIycsPJXWRuZQJmOj9YFzFbtRz0VazMY0Vni6LhUmXhBaXuSGXIREUYZetXDVrMk2Qaqs14gq
+        D0eaCuqqapqqa0ipKAy6EIcRcAgFbzajLpuG21IyySwoMAQT9JKSWp5FQ1Ysh8TFQ4cExIp8Gj6U
+        LW8K9NgJU8QHwOVS0TOLyjC4HM0cD6/qfwCc+CABqlR1raJUq1WYl07BtvF0tqg2ayD/BAc3w9Ru
+        4QJHYFShj+nCmFODSsZkSnoCUgpC+g9c8UmZWwlCiqGZKFXRIIHZ8gkOQX8DG+x9lTEHg8tNPZuO
+        qCWg4Vy+TA9ZuMU6if3Q5zrOATg1BmbbULyNHBAHD6lDQ0pig0/sBPibOdGYugkA3FGSmsT62iQI
+        okDq/qctBQs/DMgtYYrmXCT0IzylDvPNjueHKS2Tg80/oK5N7mEK5hPJ5Gh1cgUp1fXJz3q9jtQl
+        Pswm9QAaCXxB6sOwgPVzbHwmw6TrOhPqFiZUY4OJbvcsjwfpHIKzP+W6f44fNgS1iGSTEOJS3CHL
+        lZbLlaqrhrIBDbDi98h9KPV87AYj4K7je6FneY50wHArvoS5fLD0fLYqqrrBVq/ROTzvSL3UZcFy
+        otkMLAKs8xkefibMTJ21+Su584PTICS0mBYJJ54dSPX4BiMdAFSSTX3AHZy9+HowjFxmqopREVpO
+        3Rl7MNNkGnDDucDuOMJj8gJcWjSwymuMVPMZQYq+4cSMkc8E30iteiPLUZOH7VUO0G4c1HI5MBUN
+        CaHgHGRmFyOg7ja/yaIc3GdmmUjHLh2KXYvE1yPqhEyJLOIlfDDqMmUzQli3mfQph/UgIKF0flLI
+        5ESPaUAmUPHAO43Z5IWvigyZzuj6sfYkHywu9Ce5+Kg9La6R+nRQ2pm0+EOWq3QmBamaXjGqMh5a
+        tkxGCpJZhWxUayarYjWQaRQ8sHEM5s2kLZDfWPrAf8H/rQm7iguAytj3olkqdfbm8MAzlqQh1kEZ
+        wx2VDiNILstDIWzH0Rjuub/tCtyvTOLrH2NYrn8Uy9y+ah03Lznz9w5xx+EEbKz2IUKSe8hJIDcd
+        +UDBkssB3MhucSCQvFFv9+tdqRn3kE7THkIcbN+b2ZBXQKMDOQfjn+UocMlv2YXrXOm+QZiY9cEM
+        WzcQcvJF6CwIdmI87gUVJ2oiPBsArj9PaEgGHfAx8Eofcpd3kereJ6OjRvOyJzcaIpmgRarbtzSA
+        WL+zWTbqcmyRcmqg6zXFH/4uslUg+w/8yecn0gElRxJcq4qiyUqt+DFuuYAjD4t+dqxX+6lYeAKp
+        Xv9KAhaITyDuxhggAAAV98V/PV9o+p8um3vtuzMh153mTuorC+Nqr/ml9zFGad2Sso/vRBL0d5Pg
+        1wOgnEOoKcoHyDTNuap8VdA1N8di7JKPegnur7vR5RlwvwnuiiqyWasapeTKkCGHqhgfhVQQDIY4
+        IIMgz1L73a50DBRSN6HY3X1/+aWcOPBPQvmr5cqGmJAzAemY/76JJTMJ2YaRB9n9dil7CdU3SSoU
+        VC+rHyzoLV9t5HpBVto+J93xRgU91b81jw6u5p1Pjfnp/GzePikeXl4cHXw6nffmn+dXcUUDSBrz
+        q8t5g11zP3lVz2KO6zSPzkpS8+h0A9Y39o3ncXw5fPX+0cHFvD5vFw/rIO3ZvDW/gGJ0dNCed+et
+        4mGDlTrzRvHwfFGqp6UFlt82TB6wMGq7JMFv/Z2h1XaIO7daWfmjBx9tx+jDZf3jhyDtJTFoVeaX
+        etIR9D6MIwqPJ1+ScJJEky9xMIFYMr+Ei8RvXtbpO4cfbVcMXwUdCyBtCCAX804cQi7mZ8XDziWr
+        5cUrHjcui4ddhleDR5QzaGrziJKU6mkpC/AbD/1dg1W8xPncFCng867pZOKaz61oPjfXVzOwnHuX
+        pdxyt2pgk8Dy6SzZqd2QcUKsG6nNLt44938D1hdgiRhfkEmXGbK9EGHTypLHdgNsxduam/KcxBSH
+        /3ZhNSjVY7pgf9aMm4tfWx0Qx6GeSJomb9jnNfCC+7jvsyK8h4u86y4FvsXUYTyIZEuEqmdo9kQv
+        PB43T45lvpmUx/gJDjFLMN92y2mv9oaTmkk0zMfhjDfuieYShhPaAQH15GQ2zRVKqQmUu4qRdA0k
+        7BMpa+JtT0oYkGgAt9nfIurzpz/QcMNjKhF3fU8siD0YPgym2LnDwqVBMyWTjh+k1oJsvxQaC+Hy
+        Z/XPydBOqb6LCPwBXHIoaZPRM2hlRfYMuW7bPrD6DQEdmWoZGbUyKqslVGXlMvzIy6KilJDC/pUr
+        kDKreolzR+4x5C2En2L5uC3883q/LkCEVb8wgspf6/J/sfz7tbwaUdfrcyIsn3EjB0ZIrssKqqCP
+        fKwBrByLMTn+cEyOhZgcfyQmQUjHg8WTciEuLam7bN8FHXp73r/+MUfm5WixyOf9D9a+6KEWq/5w
+        7fe+v0dQdxBOAAVyJwrx567UmxAI7nd7tCDJv6vu6400k9xNSYgDXinif9G4zwuopQh5K6iMHH+Y
+        1RMPDq3uqSg4tKjle4E3CqXjyHFISN3d4kSru/b4f60iJzK0uqYpm6YJ5IoiV2vmByLwqds/Ed0d
+        ef2fZtE1YwMMZtHQWTljuyl2hxFKnSUhW4DmBBhoGFHi2BtAPOpPh3FBXRaEkLBDH4et1uHJyYbK
+        2fCyw6JGUiJpcRwuS4tKDhgvfet2ydZdxA6nl05WiPZpKy4+7jcQnjJLmD+NTwRui6+DaeSEdBll
+        F7NcwurnDIfShWexpzvJUXWJb66yWyY//5vh6qwjX33ZSq1mqE/IkGJ3K7mWIe96DvZhDbyNXs/Q
+        nxLb8/FW8kqGvPHzuYSHUUDSRiPT+DOo2PO2jlXNshp1m1uJaxni+vl2yMwM7WfqgsIC6UjaDNoL
+        hSjZDivncuMT61lGW72ONPM9MJvpgiCro1OfkOPuyXYLyGrpahi5YbSdPqulroOtG5bWbO+S1VSL
+        vd2Bb57pkVXfJZl6IZFG1CEStqx4hcypslprgJI/dbePmlXcaa+TVgt0lBq8ssK5BRM84yFoxUVc
+        CpTeSEqOwqdEWR2lR315w4rHCI7Px4fjV6bgG/TSlUvvs/vz8XF1oYOA+X3pdlOaFT/BEHF8zwsh
+        9WeQ88DDqbJAX3YaaXVNaNxXAfGlKXbxmEwJf6zAic1Vj0xOvvM4kUU53URdBJEsoh1CfLnnyey/
+        dMoMojuBsOKmLwlpWWQb593Gp7Qhi+wp9ckddpzFFFlEj8Gibc9beJyWRbHbqJ/U04YsdCftFFEt
+        ixVA4YC9SkGsy8WYWeA6/BUvafnoKCUy11WDpWBCHGddO7qyYjUhRJPxIqSuoLf2ngonyCLGXi+L
+        1yjx6wYrmLljwHwlxuoroaDdSh1Kz0LWPk+R0Y31MEBvt0d4PYtlv8UDTbO73QP1LLbHfsQih+eD
+        H0HegDNkWXT/Fbne9ltTZQVji4Jds3egpAvqRvfbe2Y10PKGzGhPSNYaKlkVfPKxBRQ7jJvVTn2K
+        f4f8b4deWZV1sONJdSfcfmusZLV5FuE7QrfTZ9V8WknfWXwG3+oGBv3W9h5ZPZ+7FrVBJ9IlCWae
+        G6QmXMlquU/9MPJ+/327uIay4hB3XfYqndT4uXuxvRt6ersF7baMcNdlzoEy/4ognY9zeqVkPBUP
+        fvkl+EFmPwfrTcWfDkq84YW9cpZPX9hfif/K/HdtJaUoynus/pPXaDZfUMxFs5Uh/Wssn3K2RRI8
+        9nRLxIvCWSTalUrY/pS2v5bxkNyHJS+cwC2OFT9mUyMx112W+rGYf+W1fgIWFzIXoF7cutNmpMOi
+        OR+KZVNvsh0J+VWZ/YgYjKt33Z96RKXK0zLyLuvSQP0cVU5grimlGgRfuabUlBfE5PTEJtP2C+FI
+        XtEVQbJs2m332JrBVWSzX2pNZ2+hsuytQsDiJbFwEEr/YEsrMhMrUMBpTM0f9McjQPH9zqWwhAQW
+        mgL2k5Y/zdZoQMgAO4EnFJVAKsub9u3mteX55dZHl3kbfAX2mjtcXnjsGEuL2DRiH584o2PGXQPG
+        oyyyvYvBBZ4T5fhKd9m0T5usWeYfXG8WUNHDxO6yaU+Zj9wgfXucnXy5Ja7NT1+vS3K1pGNnX/op
+        3Xd5QBfCSu6GuuPyiPpBOBh5kSta2qy+sHnKaGGZRcSm9KfIbxbA8C+q7IbLBf7Tw7Jp9rczv5z3
+        DssqPB2fenxdfonZDph00O9cFl9030tfZ/mOb+/wDz7ssCBYE/0vsy5Y+A37VtDzwHTDXDQ2g1+b
+        sPvpKb3niVvdCukt4RlcEPkjbL1NDhficbl78m8JtEXGni9MClabX/Hkj41wi52IqCa08tJabXY3
+        c1FdExLXhMTIEBEjQ0isIRGxhsQjV4QjV8Qj68KRdbGAQmJVTKwJ0dDEaGhCNDQxGmpVyEZVPLKQ
+        WBMTq0KcVTHOQvlyxFOETChiJoTEqphYaJ9i8xRRCgmFuhCrQmgQYntAQkUgsSJ0TTiwJgZMFQKm
+        itkQoovE6GpCV9LErqQLR9bFI+tCnnUxz6qQDVXMhhgMMRZClFEOykKzUHNcVDiyKh5ZF3qdLvY6
+        4cDicZHQOlFOuBIPnDOy0O2Q2O80oUa0HJUIsUBiLIRmIbYKofOJfQ8J+UVifjUhEpoYCSQMmVC7
+        +egnIKE84R9RSkquF74sSbBro9poaBC5ikaWrFuKKZuWqsrWUDeJTeyKrlcEycOO3V6RVPDPrXKJ
+        B2Y1GyvWGt4HDGRiparIul1VQSpDlYf6SJNtpFo1jWDd5qF8E4ydun0bGLWKKgaDNbwHGGwKgbBJ
+        9SuFWRPhXRhXLNXCBBsyUZShrA9HWK7hoSEr1rBSreiGNbIMgWA7dvs2LRpGjhZZw3uAgUY1pBt2
+        BWQxmaNqiox1Q5Mti+iGikamboj8e8durwWDf6Y4Ftx+gAZqraMioHgPeCy7RnANBNMqBsiJVEM2
+        MfsoIKlWVYRVBemmAJ4du31j+DNzop/5RlBcsw9ZhyT5yKNPpgA6X90HjGM3mg6sWxJ/uJldJB+E
+        RPFVSk7sVSo6nWGL1SbkyvrIX6+fnv4PLXH2LX5bAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -3295,12 +4247,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:56:29 GMT
+      - Thu, 21 Nov 2019 15:44:06 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -3310,9 +4262,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 4c1b828d649ed2bf6fff72f5f08f8811
+      - 96a773602876eed7e941befa17d706a9
     status:
       code: 200
       message: OK
@@ -3328,82 +4280,92 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VceXfiOBL/Kn7svn1hBhNfHOafWcIxyW6gGUjonunO8IQtiDbGYnyQpEO++5Zk
-        GwQYQjpHMzP9XhNZVZKrfnXosv2QIe6IZioPGXrrYi9TySDX9vDtv337Jk+9cSaXcdEEQ32A/WDg
-        W8gdjMhdEHqYkeggQN4YB5nKCDk+zmVG1LGxNyB2puKGjpPLWNQNPOpkKoEXAj30gTrF3oT4PqGu
-        n6moWjmX8a1rbIcOHoQhawo3m0wdFGAZDy1kIV2XNd3U5RLCRbmsjgpQUgu2ppVN1SqbumJYCBmF
-        cklBatEAwbBNggFyHHqL7YVsTHjQcRArdNmTag4NbakX1UOzKXWIdQ+0E+QTS2rj4JZ6N5wBqP41
-        8vBCMTr8H7YCrqmqKrlMgMYxGH7CgiwHyp8fMisKA2+MdcRlEx90vY/FiurE8hLL4H7KBLfxCIVO
-        kHnMrfXMoYz7Vtc73mrYjXp2Q21xN2axzONVLnNN/cCioRvwzmNDlQ3THGmKJZs2MmTDLJfkMthM
-        Lig2MrFtmkZBZ9AFKAhBQijQ6ZS47Dbcl+KbTP0MQzBGLy5p+Wk4ZMV8gF00dLCPrdAjwX3eohPg
-        R06QID4AKZeGnlpEhs7lcOpQtGr/AUjiMQ0KRV0vlcsKqBKQCfg2mkwX1aZmgL7IvxkmfgsXKASn
-        CjxEFs6cOFTcJzPSI7ASUNK754aPy5GXKGXNVPTERIMYZsvDKAD7DWzw91XBHAQhN6E2GRErhYdL
-        +Tw7iHCn2ySKQ4+76RaAE2eIfBv5Pg4SZVi1WE5yx172nHp07GGfiaQqigz/jzX4C/9jb0kYoJWH
-        uR8qyioloAFy4no3nIA21o0PKcgnkJWwHVM41xaaj2eYyRR7+kOGQC7iisY1xpLHgb9wN4UFYkxV
-        NqjqTqq2k6rvpBqPV4/Lykgyi0JiZqUorUMBciBvPIGcGE548ZqMr3nBgobgWk5Uy23n2viOqQQ2
-        noUO+CkaEge4sC+CAOadOuGYuHH+01RzURPbvA3mCH2p92tb8hcJdimssuAfoQlxWNLtUC9IeJmD
-        svsnAokoqqs315SCvn7zU9BFakI83ku/hMiBAMK2VKcTRFypDSzSUfOXejsrdbFPnZCF1lPC/YwZ
-        Fs6aWNpWsbSCpinrYl3UOsdnHekiSTgATzidgtrgft90f53ZCaJnmsRjfOkQ5Fo4uh4RJ2CAMvPF
-        cjDuPGH3hORjs1BMJKyyaJbO6hlh5H5I0gbEHOQ11mjMbp75rMgmkkdXD+VH+WhxYTzK2Qf9cXGt
-        ao9Hub1Zsz+IUiV3UlRNNwrFkoyGli3jkaLKrEIuQhZkVawGxsMMhfEQQcZl2mbwH2yQ478TFFjX
-        7CoqACpjj4bTRGvR0+/5uBoTIivkEeR9MgxhCpQfpsJ2Eo5hZPhjX+B+Zxpf/RjBcvVjus7ty9ZJ
-        o8uFv3OwOw4gZtXyuyiJ72DkhBnUyAMONgUaQFTOkJ+iea3a7ld7UiNqITWTFqk42B6d2jD6AdGB
-        kZHJz0ZSuOQDS+Zqq3YvUCYSfTBF1g0a4+0qdBYMewketYKKuhYrzzqA64/XMGQMOhBjEJUejLBv
-        otWdh0eVWqN7IddqaToBRaraM+LD9GNvt6xV5cgj5cRB12uyP/wzzVeB7Vf4J5/VpSOCKxJcw7Ct
-        y0o5+z5huYBjGxZ9sa9vjtN05TGMW/1LCUSAiQTk3QgDmE7oavZQ4pd6qa7/ods46Nidpkrdaexl
-        vnxqXr1ofLp4H6e0Zjjvods0Dfr7afD7EXDOIdVk5SPVNM25pnxW1CvujtkoJB+MHIyv+/Ftc+B+
-        A8JVLciwbCjm4qsiTMBhyH0vpHx/MEQ+HvjbPLXf60mwLMewGo849g/fL1/ycQD/lKp/KV/YUBPm
-        TMA65r+v4slMQ7atQWEWt1vLi5jrRZqmKmrktXdWdIYtuNHWKBC17XPWPQcqaKn9o1E5upx3PtTm
-        zfnpvF3PHnfPK0cfmvOL+cf5ZVRRA5ba/LI7r7FrHiff1DK7JXQaldOc1Kg0N2B95dh4Gsfnw1ft
-        V47O59V5O3tcBW1P5635ORTDylF73pu3ssc1VurMa9njs0WpmpQWWL6sm23AQq/tnAS/1TeGVt8j
-        78z0vPJnTz76ntmH6/rnT0H6c3LQqs7PjaQKtD6OMgrPJ5/idBJnk09RMoFcMu/CRRw3z2v0ndOP
-        vi+G3wQdSyBtSCDn806UQs7np9njTpfV8uIlzxvd7HGP4VXjGeUUSG2eUeJSNSmJAL9y1981WUVL
-        nI+NNAN83Hc6GYfmUyuaj4311Qws595kKbfcrRrY2Lc8Mo134zZ0ZPu1fPPutef+ryD6Aqw0wRds
-        UldgOwgVNr0sPlwaICva1tzUpx5xHP/XhdWgVI34/MNZM24ufm1tgB2H0DRtGpxwyGvghfRR2ydV
-        eIsQedNdCjRDxGEypOkWK1UVeA7ELjwfN+onMt9M2iZ4HQWITTBfd8vpoPaG45rrcLgdh1NOPBDL
-        xQLHvAMM5tkys2mscEoN4NxXjbipLyEPS6KLt6kUCyARH4bZP0Li8fMfINzwnIrTm74lFtgeDO8H
-        E+TcotSlQSNhk07updaC7bAMGinh8oPHp3RoJ1zfRQV+ABc/OrMp6Gl8cs7OCqu2zc/Evz2hq6aW
-        V4vlvJrXcmqJlfPwIy+LipJTFfYnX4Aps2bkuHT4DsG8BfOz+ffbwj+r9qspiLDqZ2ZQ+XNV/g3J
-        X6/k1Yy6Xr8lw/I7bsyBVVWuyopaUN/zWANEOUnH5OTdMTlJxeTkPTHxAzIeLM7KU3FpSb0lfR90
-        yOysf/XjFp2XvUUqn/Xf2fpph1qs+t2tf/H9I4K4g+AaUMC3aSn+zJUurjEk99sDWpBsH1UPdSAV
-        JncTHCCfV6bJvyAe8gJqqcK2FZSgx59m9cSTQ6vXTEsOLWJ51KejQDoJHQcHxN0vT7R6a8f/axVb
-        MkOrZ5qyaZrArihyqWy+IwIfev162ujI6/8yi64p62AwDYfOypOgm2p3GKPUWTKyBeiWBAOEEcGO
-        vQHEg/F4HBW0ZSEVEvbQx3GrdVyvb5icdS87LGvEJZwUx8GytKjkgPHSS7dLdu4idji/VF9hOqSt
-        uOiBv0HqU2ax8M3omcBd+XUwCZ2ALLPs4i5dWP2cokA6pxY73YkfwJX45iobMvkTlYJUpx358tNO
-        bk3gruMhQe5Odl1g71EHebAG3sVvCPxNbFMP7WQvCOy1n88kNAx9nBCLAvFnMDGlO/sqiaKGvcZO
-        5rLAXD3bDZkp8H4kLhjMlyrSZtJeGEQRG+AhdOvNomdko8dvRUFbFx1p6lFwm8mCQbRR08P4pFff
-        7QGilS6HoRuEu/lFK/UcZN2wac3uJqKlWuwdBHTzRAvRfF08oQGWRsTBErKsaIXMuUSr1cDIH3q7
-        exUN17zoJNUpNkocXlmR3IIbPBEh6kqIuAQ46YgbkfCjAM4k2qhFfCufEFYiJmoj2TjAVpy9OJOx
-        cgu+QS9duuRO3J+PHktODRBwv0+9XsKzEifskWmP0gCm/gxynng4lwh0t1NLqsupzn3pY0+aIBeN
-        8QTzYwXObK5GZPyEM88TIsrJJuoiiYiIdjD25Asqs79SkzlE7xrSipu8yqKLyNbOerUPCUFEtkk8
-        fIscZ3ELEdET8Gib0kXE6SKKvVq1Xk0IInT1doKoLmIFUDjgr5If2XLRpwhch7+IJC2PjhImc900
-        SPKvseOsW8dQVrwmgGwyXqTUFfTWHrrnDCJi7CWoaI3CSauYuWPAfCXHGiupoN1KAsoQIWufJcgY
-        xfU0QGa7M7whYtlv8UTT6O2OQEPE9sQLWeagHsQRzBuQwCai+5/QpbuHpsIKxhYBv2Zv6kjnxA3v
-        drcULdCiQ+a0dSx6Q0E0wQcPWcCxR7+idaoT9BXmf3u0Ek3WQQ6Vqk6we2gsiNY8DdEtJrv5RTM3
-        C8mbdU/gW9rAoN/a3UK085lrERtswl7ymFLXT1y4IFq5T7wgpF+/7la3KFr6t4vdM4Gi+vh6y9hd
-        88B9FzdHyvyzCpP4aCav5IqP2aMvX/wfZPZztE7K/nSU44RnttqyaPrE/uX4r8x/19ZPiqK8xZo/
-        fn1m8+W5rWi2BNa/x6Jpy2ZIjMeBboTQMJiGaXtRsdgfEvq3Ch7guyBHg2sY2FjxfbYyYnfdZ4Ef
-        qfl3XuHHYHEltwJ0EVH32oJ0WDbnXbE51KtsQsKsKs9+0gSMqvfdlXpQc4XHZeZd1iWJ+imuLYm5
-        rOTKkHzlslJWnpGTk+c0mbWfCYdHA2pRJw2SJWm/PWNrClehzX6JNZm+hsnEoSJFxC62kB9I/2IL
-        KjxNN2CKpBE3P96PeoDi2z2NwiYksLxMET+m/GU2RH2MB8jxaaqqGCawnHRog9eOU8udB5bbtvVg
-        jjtiep5T9vBKK3rDO5c5Ze935zK15O3uN3E44cXpDV2WpEPaWhWFv3fp1CdpR4i9JelAhQ9dP3lr
-        nD3vMsOuzZ+5XtfkcsnHnnjpJ3zf5VgugPXbDXHH+RHx/GAwoqGbtrRZfU2zyXhhmYXTXekvMb9Z
-        AMO/9rEfLufoLw/LptvPpl5+25srq/B0PEL5uryL2L6XdNTvdLPPGveSl1i+4zs7/DMPeywI1lT/
-        26wLFnHDvmPzNDC9YCsam8mvjdl42iR3fOJWtQIyw3wG54feCFmvM4cL0DivlwplFbHvWRWRIhsa
-        GsmmXRzKxlAtF3VT02zdTFFtz2bfcD7Iv/I1Q06IB7qqAgMvbxI2t7h8HMjX/BMRccmlwfPAUAy9
-        VDZQUdYUWwWthoqMRiqWFYSLuoJVS7OsFDD2bPYyMArldCyg/i2g4HeAMMZj9vWoIv9207reaTwv
-        VLKgbdESCG9icbVkl8yCKmNDM2QDY1VGZQPL6ggrI83UsGKP0iy+X7OXgVEqFNPBYIS3t3mpzO+/
-        2+gx08sUNVQ9XVFGeAtFizouIIywbBZLkL3K2lAul20kG5Y+MobWsGSrRorqezZ7GRjsw4HpaHDK
-        68Bxxb6cGOD4e00eZp/m4kO2z6R2w8nAmuHoS4HsIv62kxpdJeww+V/hIpMpslhtzK6s9/z56vHx
-        /0kUbRTvUQAA
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8s0eAbHIXGCoQZu5ms5SwBfhibNaPPDbku19L
+        tkGATEgmyWR3p2qILLWk7l8/rJYtPxQcb+wXjh4K/q1HgsJRAXt2QG7/GdrXZT+YFEoFD88I1Eck
+        jIahhb3h2LmL4oDQJn8Y4WBCosLRGLshKRXGvmuTYOjYhSMvdt1SwfK9KPDdwlEUxNAeh9A6J8HM
+        CUPH98LCEVJrpUJoTYkdu2QYx7QrTDabuzgiso5HBsKjkVyxkCEj1cQyIqot46pSsxS7MtaQboyr
+        tYqBqhXTUAxlXAXGiO1EQ+y6/i2xl7xR5kHGYSrQZU9quH5sS72kHrrNfdex7qHtGIeOJXVIdOsH
+        14wAWsMpDshSMH/0P2JFTFIVmaVChCcpGGFGgi0Xyl8fCmsCK6UM64TKdkKQ9T5lK6njyysso/s5
+        ZdwmYxy7UeGxtDEygzIdG20OnKvYrXom0nI2qrHC41WpMPXDyPJjL2KDp4oy9KqFq2ZNtglSZb1G
+        VHk01lRQV1XTVF1DSkWh0EU4ioFDKPjzuePRaZgtpZPMwwJFMEUvLanleTyixXJEPDxySUisOHCi
+        +7Llz4Aeu1GG+BC4XCl6bjkyDC7Hc9fH6/ofAicBlaBS1bWKUq1WYV5nBraNZ/NltVkD+ac4vB5l
+        dgsXOAajigLsLI05M6h0TKqkRyB1QMjgnik+LTMrQUgxNBNlKhqmMFsBwRHob2iDva8z5mJwuZlv
+        O2PHEtAwLp+nBx5usU4SPwyYmeYAnBlDYts4DEmUCUOrs3LKmWpXTa1qqrJhgN/qtSqRR6oylomG
+        rbGq6shWUSHpmUWavbQ/D/xJQEIqAFIUGf4fqvAX/qe2lRFAr4Awq1WU9ZbIj7Cb1nvxDGS3rkMI
+        WKEDMYyKy1oYVU5bSG4I5Sn1i4eCA5GLwZJ5CloRufAXplOo36bN6lYr4lq3+6pcq7LVqu1s1R+v
+        HleVMLpO0fADalAaTJXcCCjDEDYZazMIo/GM8TF1JlM2qAWdwRpddpGo27PJHRULzOImdsG08chx
+        gYqEPBIw3tyNJ46XOgMLmmlNqvgO6CQOpd5/OlK4jMkrhpUl/RjPHJfG6a4fRBkttWk6f8YQWseZ
+        m1xVTUPfnLxHghvHIlKTRBDXwdmemjvrYHMd+PnVdU3ywitIqW7Of9rvdyU6JgmkPripBHFZGoBY
+        e7DymYzSrpsgaLuYQFsgnDXaXamfxUPpgvwWQxH+zvwIoMH0xwkt1w+TBcBOrn4m1BbcDY70HRyp
+        xhYsvd5pHirSGVhsMMOvoazKLq5qW1z1A2yRwI8Bj2cwIQbEyJ1a1VVD2bITQCHok7tIAia8cAzA
+        dAM/8i3flQ6oERWfw1K+5VTz2aqo6hZb/Ub38IyzHXDjeD4H94RY+SJYarnzw90MIaH7tEk09e1Q
+        qicrP+kAoJJsJwCVw124+HIwzFxmqopRERpt3Z34MNN0FjKbPcfeJMYT8gxc2uBp5c2gpuzkpLbD
+        fRrHDant20RqOPMpiCi12G11nQ20Jxsonw2k6FuRnbLxmeBrqV1v8Mh8Cwv58dVUNCTUCWOBm16s
+        CnVPBjR6x4PFyDxbDKWXroM9iyTXY8eNqDnRG2HKCKUuO3RKWPnZVP6MxTpdSklnzQKXNj1kazZY
+        wsCiknaa0NkLXxUZkqHx1UPtUT5YXuiPcvFBe1xeA0oHpb1Jiz/wXGUzKUjV9IpRlfHIsmUyVpBM
+        K2SjWjNpFa2BZKTgg7dhcDQqbYH8RjMM9guRyJrSq6QAqEwgdM4zqfk1wz1LatKGRAllDItuZwSh
+        NiyPhLAdxxNYlv+2L3C/UomvfkxgufpRLHPnsn3cumDM37nEm0Sw+kG1dxGS3EHaAunrOAAKmn8O
+        YX1zg0OB5I16Z1DvSa2kh3SS9RDiYAf+3IbUAxpdSEso/zSNgUu2qi9c5Ur3DcIkrA/n2LqG4Jcv
+        QndJsBfjSS+oaKqp8HQAuP48hRX4sAs+Bl4ZQHrzJlLdBWR81Ghd9OVGQyQTtEh1+8YJ4a6zt1k2
+        6nJikXJmoJs1xR/+LrJVIPsP/JPPmtKBQ44kuIYsSJOVWvF93HIJRx4WA36sF/upWHgCGcDgUgIW
+        IC+DuJtgANmZhoofxX/9QGj6ny5aH9p350Kuu6291FcWxtV+60v/fYzSuiHlAN+KJBjsJ8GvB0C5
+        gFBTlA+QaZoLVfmqoCtmjsXEJR/0Etxf96PLM+BBC9wVVWSzVjVK6ZUhwyqqYrwXUmE4HOGQDMM8
+        Sx30etIxUEi9lGJ/9/3ll3LqwD8J5a+WK1tiwpoJSCfs91UsmUpI95R9yDN2S9lPqb5JUqGgell9
+        Z0FvWN6T6wW8tANGuueNCnqqf2sdHVwuup8ai5PF6aLTLB5enB8dfDpZ9BefF5dJRQNIGovLi0WD
+        XjM/eVHPYo7rtI5OS1Lr6GQL1lf2jadxfD589cHRwfmivugUD+sg7emivTiHYnx00Fn0Fu3iYYOW
+        uotG8fBsWapnpSWW3zZMHrAwaqckwW/9jaHV9og7N1pZ+aMHH23P6MNk/eOHIO05MWhd5ud60hH0
+        PkwiCosnX9JwkkaTL0kwgViyuICL1G+e1+k7hx9tXwxfBB0NIB0IIOeLbhJCzhenxcPuBa1lxUsW
+        Ny6Khz2KV4NFlFNo6rCIkpbqWYkH+JWH/q7BKklxPrdECvi873Iydc2nMprPrc1sBtK5N0nlVrtV
+        Q5uEVuDM0z3jLRnp4y+pQy9eee3/CqwvwRIxviSTLjiyDyHCtpWlT/aH2Er2NbflaSYUh//2IBuU
+        6gld+HFyxu3k11aHxHUdXyRNizV85Bx4yX3S90kR3sJF3nSXAt9gx6U8iGRLhapzNB9ELywet5rH
+        MttMymO8iSNMF5ivu+X0ofaG05ppPMrH4ZQ1fhDNpQyntEMC6slZ2bTWKKUWUO4rRto1lHBAJN7E
+        O76UMiA5Idxmf4udgD3+gYZrFlOJuOtbYkHs4eh+OMPuLRamBq2MTDq+l9pLso+l0EQIj73C8ZQM
+        nYzqu4jAHsCl7y1uM3qavohEn2bXbZu9YvTygI5MtYyMWhmV1RKq0nIZfuRVUVFKSKF/yhVYMqt6
+        iXFH7jCsWwh71en9tvDP6oO6ABFa/cwIKn+ty//F8u9X8npE3azPibBsxq01MEJyXVZQBb3nYw1g
+        5ViMyfG7Y3IsxOT4PTEJI2cyXD4qF+LSlnqr9n3QcW7OBlc/5si8Gi0R+WzwztoXPdSi1e+u/f73
+        9wjHG0ZTQIHcikL8mSf1pwSC++0HSkjy76of9UbKLe5mJMIhqxTxv2z8yAnUSoS8DIqT4w+TPbHg
+        0O6diIJD27ECP/THkXQcuy6JHG+/ONHubTz+36jIiQztnmnKpmkCuaLI1Zr5jgh86g2aorsjq//T
+        JF1zOsBwHo/ctdfwt8XuUkKpuyJkb8yKfREaxg5x7S0gHvTHw6SgrgpCSOhLH4ft9mGzuaVyOrzs
+        0qiRlkhWnESr0rKSAcZK37pdsnMXscvopeYa0Ufaikve9xsK3zJLmT9JXgncFV+Hs9iNnFWUXc5y
+        AdnPKY6kc9+iT3fS8wwS21ylt0z2ujHH1WlXvvyyk1rlqJtk5GBvJ7nGkfd8FweQA++i1zn6E2L7
+        Ad5JXuHIGz+fSXgUhyRrNLjGn0HFvr9zrCrPatxr7SSuccT1s92QmRztZ8cDhYXSkbQdtJcKUfgO
+        a28IJwcZeEbb/a40D3wwm9mSgNfRSUDIca+52wJ4LV2OYi+Kd9PzWuq52Lqmy5rdXXhNtekBMHz9
+        RA9efelxgLHjEglbVpIhMypeaw1Q8qfe7lF5xZ30u1m1QEeZwStrnFswwRMegtZcxHOA0h9L6XmA
+        jIjXUfauL2tY8xjBGYLkNf21KdgGvXTpOXf8/nzy4rzQQcD8vvR6Gc2an2CIOIHvR7D0p5CzwMOo
+        eKAvuo2suiY07suQBNIMe3hCZoQ9VmDE5rpHpu/gszjBo5xtoi6DCI9ol5BA7vsy/SudUIPoTSGs
+        eNk5Qo1HtnHWa3zKGnhkT5yA3GLXXU7BI3oMFm37/tLjNB7FXqPerGcNPHTNToaoxmMFULhgr1KY
+        6HI5Jg9cl50ClVaPjjIic1M1WAqnxHU3taMra1YTQTSZLEPqGnobx5cYAY8YPYGa5CjJwYc1zLwJ
+        YL4WY/W1UNBpZw6l85B1zjJkdGMzDDg3uyO8zmM5aLNA0+rt9kCdx/Y4oGdmxn4AfgTrBsyR8ej+
+        K/b83bemyhrGlgN2TY9JSueOF9/t7slroO2PqNE2CW8NFV4FnwJsAcUe4/Laqc/w77D+26MXr7Iu
+        dn2p7ka7b40VXpunMb4lzm56Xs0nlexY8xP4VrcwGLR39+D1fOZZjg06kS5IOPe9MDPhCq/lgRNE
+        sf/777vFNZQ1h7jt0dO2UuPn3vnubujx9RLaXSvCfdOcA2XxFcFyPlnTKyXjsXjwyy/hDzL9Odhs
+        Kv50UGINz+yVkz59of9K7FdmvxuZlKIob5H9p+dots8w56LZ5kj/GulTzrZIiscH3RLx42gei3al
+        UrY/Ze0vZTwid1HJj6Zwi6PF99nUSM11n1Q/EfOvnOunYDEhcwHqJ617bUa6NJqzoehq6lW2I2F9
+        VaY/IgaT6n33px5QqfK4iryruixQP0WVE5hrSqkGwVeuKTXlGTE5e2OTavuZcKSHhUWQrJr22z22
+        5nAV2/TXsWbz11AZf6sQsHhBLBxG0j9oakXmYgUKOE2o2YP+ZAQovt17KXRBAommgP205U+zNRoS
+        MsRu6AtFJbCUZU0f7ea14/nlzkeXeRt8BXrgHi7PffoaSzv5akapcEq/mVEqNLIvZryJwYW+G+f4
+        Sm/V9JE2WXnm7z1/Hjqih4m9VdMHZT72wuz4OH3z5YZ4Nnv7elOSyxUdffdlkNF9lwd0EWRy1443
+        KY+dIIyGYz/2RKnN+oHNE0oLaRYRm9KfYn2zBIZ9dGk/XM7xnx6WbbO/mQflvDMs6/B0A8dnefkF
+        pjtg0sGge1F81n0vO87yHU/vsC8+7JEQbIj+l8kLln5DPyf2NDC9KBeN7eDXIfR+euLcsYVb3Yqc
+        G8JWcGEcjLH1Omu4CE/Kvea/JdAWmfiBcFGw3vyCJ390hBvsxkQ1oZWVNmr53cxldU1IXBMSI0NE
+        jAwhsYZExBoSj1wRjlwRj6wLR9bFAgqJVTGxJkRDE6OhCdHQxGioVSEbVfHIQmJNTKwKcVbFOAvl
+        yxFPETKhiJkQEqtiYqF9is1TRCkkFOpCrAqhQYjtAQkVgcSK0DXhwJoYMFUImCpmQ4guEqOrCV1J
+        E7uSLhxZF4+sC3nWxTyrQjZUMRtiMMRYCFFGOSgLzULNcVHhyKp4ZF3odbrY64QDi8dFQutEOeFK
+        PHDOyEK3Q2K/04Qa0XJUIsQCibEQmoXYKoTOJ/Y9JOQXifnVhEhoYiSQMGRC7fajn5BE8pR9RCkt
+        eX70vEWCXRvXxiODyFU0tmTdUkzZtFRVtka6SWxiV3S9Ilg87NntBYsK9kVmJvHQrPKxYqPhbcBA
+        JlaqiqzbVRWkMlR5pI812UaqVdMI1m0WyrfB2Kvbt4FRq6hiMGjDW4BBpxAIm1a/UJgNEd6EccVS
+        LUywIRNFGcn6aIzlGh4ZsmKNKtWKblhjyxAItme3b9OiYeRokTa8BRhoXEO6YVdAFpM6qqbIWDc0
+        2bKIbqhobOqGyL/37PZSMNiXzBPB7XtocKxNVAQUbwGPZdcIroFgWsUAOZFqyCamHwUk1aqKsKog
+        3RTAs2e3bwx/Zk70M18Jiiv6rfuIpB95DAj9MjLL7kPKsRfPhtYNSb7tTi/SD0Ki5CojJ/Y6lTOb
+        Y4vWpuTK5shfrx4f/w/TS2PdoV8AAA==
     headers:
       Cache-Control:
       - no-cache
@@ -3414,12 +4376,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:56:39 GMT
+      - Thu, 21 Nov 2019 15:44:16 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -3429,9 +4391,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 2f2f0da4db75635733599ef0b0142a9e
+      - c2eba19b73caab9a2c9594da022c6100
     status:
       code: 200
       message: OK
@@ -3447,82 +4409,93 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VceXfiOBL/Kn7svn1hBhNfHOafWcIxyW4gTEjonunO8IQtiDbGon2QpEO++5Zk
-        GwQYQjpHMz39XhNZVZKqflUqnfZDhrhDmqk8ZOiti71MJYNc28O3//btmzz1RplcxkVjDPkB9oO+
-        byG3PyR3QehhRqL9AHkjHGQqQ+T4OJcZUsfGXp/YmYobOk4uY1E38KiTqQReCPTQB+oEe2Pi+4S6
-        fqaiauVcxreusR06uB+GrCg0Np44KMAyHljIQroua7qpyyWEi3JZHRYgpRZsTSubqlU2dcWwEDIK
-        5ZKC1KIBgmGbBH3kOPQW23PZmPCgYz9W6LIr1Rwa2lI3yodiE+oQ6x5oR8gnltTGwS31bjgDUP1r
-        5OG5YnTwP2wFXFNVVXKZAI1iMPyEBVkOpD89ZJYUBt4Y64jLJj7oeh+LFeWJ6QWWwf2ECW7jIQqd
-        IPOYW6mZQxnXra5WvNGwa/msQW3eGrNY5vEql7mmfmDR0A145bGhyoZpDjXFkk0bGbJhlktyGWwm
-        FxQbmdg2TaOgM+gCFIQgISToZEJc1gz3pbiRiZ9hCMboxSktPwkHLJkPsIsGDvaxFXokuM9bdAz8
-        yAkSxPsg5cLQE4vIULkcThyKlu3fB0k8pkGhqOulclkBVQIyBt9G48k829QM0Bf5N4PEb+EBheBU
-        gYfI3JkTh4rrZEZ6BFYCSnr33PBxOvISpayZip6YqB/DbHkYBWC/vg3+viyYg6DLjalNhsRK4eFS
-        Ps8OItzpNon6ocfddAPAiTNEvo18HweJMixbTCexYyd7Tjw68rDPRFIVRYb/hxr8hf+xtyQMUMrD
-        3A8VZZkS0AA5cb4bjkEb68aHEOQTiErYjimcawPNx1PMZIo9/SFDIBZxReOcwoLHgb/QmsI6YkxV
-        1qjqVqq2lapvpRqPV4+LzEgyi0JgZqkorEMCYiAvPIaYGI558pqMrnnCgoLgWk6Uy23n2viOqQQ2
-        noYO+CkaEAe4sC+CAOadOOGIuHH801RznhPbvA3mCH2p+3tb8ucBdiGsMucfojFxWNDtUC9IeJmD
-        svYTgUQU1eXGFVU1Vhs/qbU60kXSr6Vz/CWEJPwd0wBLdcR+iG851I8Gsq1y/YoZDM6KRNpmiTSl
-        oK9KdAzoSk2IEPfSbyFyoEtjW6rTMSKu1AYW6aD5W72dBRF96oSss3+bWPpGsbSCpimrYl3UOocn
-        AlRgsHAyAUNAh/im9g3mOdCfJ0mEiB8dglwLR89D4gTMxMyhYjkYd56wNiEc2iw4JBJWWXyRTuoZ
-        YS7xkAQyiAIQaVmhEWs880mRTSQPrx7Kj/LB/MF4lLMP+uP8WdUeD3I7s2Z/EqVKWlJUTTcKxZKM
-        BpYt46GiyixDLkJcZlksB0boDIURGsEYwLTN4C9s2OW/YxRY1+wpSgAqI4+Gk0Rrse/d85E+JkRW
-        yCMYicgghElZfpAK21E4grHqy67A/ck0vvo5guXq53Sd25eto8Y5F/7Owe4ogCiilt9FSXwHYznM
-        6YYecLBJWR/ixBT5KZrXqu1etSs1ohJSMymRioPt0YkN4zEQHRirmfxsbIdHPtRlrjZq9wJlItH7
-        E2TdoBHerEJnzrCT4FEpyKhrsfKsAnj+cA2DWL8DfQx6pQdj/ptodefhYaXWOL+Qa7U0nYAiVe0p
-        8WFCtLNb1qpy5JFy4qCrOdmf/pnmq8D2O/yTT+rSAcEVCZ5hIqHLSjn7Pt1yDscmLHpiXd/cT9OV
-        xzCS9i4lEAGmNhB3IwxggqOr2X3pv9RLdf2z88Ze991JqtSdxk7my6fG1YvGx4v3cUprivMeuk3T
-        oLebBn8eAOcMQk1WPlBN05xpyidFveLumI265IORg/F1N75NDtxrQHdVCzIsZIq5+KkISwIYct8L
-        Kd/vD5CP+/4mT+11u9IRcEjdmGP37vv5cz7uwL+k6l/KF9bUhDkTsI7476t4MtOQbbRQmMVt1/Ii
-        5nqRpqmKGnntnRWdYgsa2tgLRG17nHXHgQpKav9oVA4uZ52z2qw5O56169nD89PKwVlzdjH7MLuM
-        MmrAUptdns9q7Jn3k28qmd3QdRqV45zUqDTXYH3lvvE0js+Hr9qrHJzOqrN29rAK2h7PWrNTSIaV
-        g/asO2tlD2ss1ZnVsocn81Q1Sc2xfFk1m4CFWts5CX6rbwytvkPcmep55a8efPQdow/X9a8fgvTn
-        xKBlnZ/bkypQ+jCKKDyefIzDSRxNPkbBBGLJ7Bwe4n7zvELfOfzou2L4TdCxANKGAHI660Qh5HR2
-        nD3snLNcnrzkceM8e9hleNV4RDkGUptHlDhVTVIiwK9c9XcNVtES50MjzQAfdp1Oxl3zqRXNh8bq
-        agaWc2+ylFvsVvVt7FsemcS7cWs6sh1kvnn32nP/VxB9Dlaa4HM26Vxg2wsV1r0sPu7qIyva1lzX
-        px5xHP7XhdWgVI34/P1ZM64vfm2tjx2H0DRtGpywz2vgufRR2SdVeIsu8qa7FGiKiMNkSNMtVqoq
-        8OyJXXg8btSPZL6ZtEnwOgoQm2C+7pbTXu0NxznX4WAzDsecuCeWiwWOefsYzLNhZtNY4pQawLmr
-        GnFRX0IelkQXb1MpFkAiPgyzX0Li8fMfINzwmIrTi74lFtjuD+77Y+TcotSlQSNhk47updacbb8M
-        Ginh8qPQp3RoJ1zfRQV+ABdf5lkX9Dg+y2dnhVXb5qf03x7QVVPLq8VyXs1rObXE0nn4kRdJRcmp
-        CvuTL8CUWTNyXDp8h2Degvltgffbwj+p9qopiLDsZ0ZQ+VNV/gPJX6/k5Yi6mr8hwvIW1+bAqipX
-        ZUUtqO95rAGiHKVjcvTumBylYnL0npj4ARn152flqbi0pO6Cvgs6ZHrSu/p5g86L2iKVT3rvbP20
-        Qy2W/e7Wv/j+PYK4/eAaUMC3aSH+xJUurjEE99s9WpBsHlX3dSAVJndjHCCfZ6bJPyfu8wJqocKm
-        FZSgx19m9cSDQ6vbTAsOLWJ51KfDQDoKHQcHxN0tTrS6K8f/KxkbIkOra5qyaZrArihyqWy+IwJn
-        3V49bXTk+T/MomvCKuhPwoGzdDd1Xe0OY5Q6C0Z+/S69LwJhSLBjrwHxYDweRgltkUiFhF36OGy1
-        Duv1NZOz6mWHRY04hZPkKFik5pkcMJ566XbJ1l3EDueX6ktM+7QVF13466feMouFb0Z3ArfF1/44
-        dAKyiLLzVs5h9XOMAumUWux0J74SLPHNVTZk8huVglTHHfny41ZuTeCu4wFB7lZ2XWDvUgd5sAbe
-        xm8I/E1sUw9tZS8I7LVfTyQ0CH2cEIsC8VcwMaVb6yqJoobdxlbmssBcPdkOmSnwfiAuGMyXKtJ6
-        0J4bRBEL4AFU602jW7vRhWBR0NZFR5p4FNxmPGcQbdT0MD7q1rd7gGily0HoBuF2ftFKXQdZN2xa
-        s72IaKkWeysC3TxRQjRffLd4SBwsIcuKVsicS7RaDYx81t1eq2i45kUnyU6xUeLwypLkFjTwRA9R
-        l7qIS4CTDrkRCT8K4EyijVrEt/IJYanHRGUkGwfYiqMXZzKWmuAb9NKlS+7E/fnoWnJqBwH3+9jt
-        JjxL/YRdmfYoDWDqzyDngYdziUCfd2pJdjnVuS997Elj5KIRHmN+rMCZzeUeGd9w5nFCRDnZRJ0H
-        ERHRDsaefEFl9ldqMofoXkNYcZOXa3QR2dpJt3aWEERkm8TDt8hx5k2IiB6BR9uUznucLqLYrVXr
-        1YQgQldvJ4jqIlYAhQP+KvmRLed1isB1+KtR0uLoKGEyV02DJP8aO86qdQxlyWsCiCajeUhdQm/l
-        NQDOICLGXsuK1iictIyZOwLMl2KssRQK2q2kQxkiZO2TBBmjuBoGyHR7hDdELHstHmga3e090BCx
-        PfJCFjmoB/0I5g1IYBPR/U/o0u1DU2EJY4uAX7N3h6RT4oZ320uKFmjRAXPaOha9oSCa4MxDFnDs
-        UK9oneoYfYX53w6lRJN1kEOlqhNsHxoLojWPQ3SLyXZ+0czNQvKu3xP4ltYw6LW2lxDtfOJaxAab
-        sJc8JtT1ExcuiFbuES8I6dev29Utipb+42L7TKCoPr7eMnbbPHDXxc2BMvukwiQ+mskrueJj9uDz
-        Z/8nmf0crJKyvxzkOOGZpTYsmj6yfzn+K/PflfWToihvseaPX59Zf51vI5otgfXvsWjasBkS47Gn
-        GyE0DCZh2l5ULPZZQv9WwQN8F+RocA0DG0u+z1ZG7K67LPAjNf/OK/wYLK7kRoAuIupOW5AOi+a8
-        KjaHepVNSJhV5dlPmoBR9q67Ug9qrvC4iLyLvCRQP8W1ITCXlVwZgq9cVsrKM2Jyck+TWfuZcHg0
-        oBZ10iBZkHbbM7Ym8BTa7JdY48lrmEwcKlJEPMcW8gPpX2xBhSfpBkyRNOLmx/tRDZB8u9sobEIC
-        y8sU8WPKD7Mh6mPcR45PU1XFMIHlpH0bvLacWm49sNy0rQdz3CHT85Syyyut6J3zXOaYvXGey9SS
-        983fxOGEF6fXdFmQ9mlrVRT+3qUTn6QdIXYXpD0VPnT95K1xdt9lil2b37le1eRywcduvPQSvu9y
-        LBfA+u2GuKP8kHh+0B/S0E1b2iy/ptlkvLDMwumu9EPMb+bA8O+P7IbLKfrhYVl3++nEy296c2UZ
-        no5HKF+XnyO27yUd9Drn2WeNe8lLLN/xnR3+mYcdFgQrqv9t1gXzfsO+rPM0MN1gIxrrwa+N2Xja
-        JHd84la1AjLFfAbnh94QWa8zhwvQKK+XCmUVsS9sFZEiGxoayqZdHMjGQC0XdVPTbN1MUW3HYt9w
-        Psi/OzZFToj7uqoCA0+vE9a3uHwcyNf8ExFxyqXB88BQDL1UNlBR1hRbBa0GioyGKpYVhIu6glVL
-        s6wUMHYs9jIwCuV0LCD/LaDgLUA3xiP2Pasi/5rUqt5pPC9UsqBt0BIIb2JxtWSXzIIqY0MzZANj
-        VUZlA8vqECtDzdSwYg/TLL5bsZeBUSoU08FghLe3eanM299u9JjpZYoaqp6uKCO8haJFHRcQRlg2
-        iyWIXmVtIJfLNpINSx8aA2tQslUjRfUdi70MDPYpw3Q0OOV14Lhi33IMcPy9Jg+zj4XxIdtnUrvh
-        uG9NcfTtQvYQf9tJjZ4Sdpj8L3GR8QRZLDdmV1Zr/nT1+Ph/qEihe4FSAAA=
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8c0eAbHIbGC4QZu5mc5SwBfhibNaPPDbku19L
+        tkGATEgmyWR3p2qILLWk7l8/rJYtPxQcb+wXjh4K/q1HgsJRAXt2QG7/EdrXZT+YFEoFD88I1Eck
+        jIahhb3h2LmL4oDQJn8Y4WBCosLRGLshKRXGvmuTYOjYhSMvdt1SwfK9KPDdwlEUxNAeh9A6J8HM
+        CUPH98LCEVJrpUJoTYkdu2QYx7QrTDabuzgiso5HBsKjkVyxkCEj1cQyIqot46pSsxS7MtaQboyr
+        tYqBqhXTUAxlXAXGiO1EQ+y6/i2xl7xR5kHGYSrQZU9quH5sS72kHrrNfdex7qHtGIeOJXVIdOsH
+        14wAWsMpDshSMH/0P2JFTFIVmaVChCcpGGFGgi0Xyl8fCmsCK6UM64TKdkKQ9T5lK6njyysso/s5
+        ZdwmYxy7UeGxtDEygzIdG20OnKvYrXom0nI2qrHC41WpMPXDyPJjL2KDp4oy9KqFq2ZNtglSZb1G
+        VHk01lRQV1XTVF1DSkWh0EU4ioFDKPjzuePRaZgtpZPMwwJFMEUvLanleTyixXJEPDxySUisOHCi
+        +7Llz4Aeu1GG+BC4XCl6bjkyDC7Hc9fH6/ofAicBlaBS1bWKUq1WYV5nBraNZ/NltVkD+ac4vB5l
+        dgsXOAajigLsLI05M6h0TKqkRyB1QMjgnik+LTMrQUgxNBNlKhqmMFsBwRHob2iDva8z5mJwuZlv
+        O2PHEtAwLp+nBx5usU4SPwyYmeYAnBlDYts4DEmUCUOrs3LKmWpXTa1qqrJhgN/qtSqRR6oylomG
+        rbGq6shWUSHpmUWavbQ/D/xJQEIqAFIUGf4fqvAX/qe2lRFAr4Awq1WU9ZbIj7Cb1nvxDGS3rkMI
+        WKEDMYyKy1oYVU5bSG4I5Sn1i4eCA5GLwZJ5irYicuEvTKdQv02b1a1WxLWirVaVa1W2WrWdrfrj
+        1eOqEkY3KBp+QA1KAzaTGwFlGMImY20GYTSeMT6mzmTKBrWgM1ijyy4SdXs2uaNigVncxC6YNh45
+        LlCRkEcCxpu78cTxUmdgQTOtSRXfAZ3EodT7d0cKlzF5xbCypB/jmePSON31gyijpTZN588YQus4
+        c5Orqmnom5P3SHDjWERqkgjiOjjbU3NnHWyuAz+/uq5JXngFKdXN+U/7/a5ExySB1Ac3lSAuSwMQ
+        aw9WPpNR2nUTBG0XE2gLhLNGuyv1s3goXZBfYyjC35kfATSY/jih5fphsgDYydVPhNqCu8GRvoMj
+        1diCpdc7zUNFOgOLDWb4NZRV2cVVbYurfoAtEvgx4PEMJsSAGPlTq0pF27IT8DnpBG4199K/YuzC
+        vYHYUtOfYceTOkAiHZz8q9kpgs5C341fzlY1ly1VVw1liy1QTtAnd5EE2HjhGPTVDfzIt3xXOqC2
+        XXwOUvkGXctnq6KqW2z1G93DM86kIbrE8zlEDQjhL4LFzJ0fbrIICb26TaKpb4dSPVmQSgcAlWQ7
+        AVgiLA6KLwcDKbncVBWjInSmujvxYarpLGS+dI69SYwn5BnAtCEClDc5QTs5qe1w68ZxQ2r7NpEa
+        znwKMkotdrtfZwPtyUZ+0K0iRd+641A2PhN8LbXrDR6Zb2EhP+SaioaEOmEscNOLVaHuyYBO78Sw
+        SJpni7T00nWwZ5Hkeuy4EbUneoNOGaHUZYdOCStSm8qfsVinSzzprFng0rmHbC0JSytY7NJOEzp7
+        4asiQ5I2vnqoPcoHywv9US4+aI/La1DUQWlv0uIPPFfZTApSNb1iVGU8smyZjBUk0wrZqNZMWkVr
+        IEkq+OBuGDyNSlsgv9LMh/1CKLKm9CopACoTCOnzTGp+LXPPkq20IVFCGUMy4IzgFhCWR0LYjuMJ
+        pAu/7gvcf6nEVz8msFz9KJa5c9k+bl0w5u9c4k0iWJWh2rsISe4gnYK0ehwABc2Lh7DuusGhQPJG
+        vTOo96RW0kM6yXoIcbADf25DSgSNLqRLlH+aXsElyzYKV7nSfYMwCevDObauIfjli9BdEuzFeNIL
+        KppqKjwdAK4/TyEzGHbBx8ArA0i73kSqu4CMjxqti77caIhkghapbt84Idx29jbLRl1OLFLODHSz
+        pvjDX0W2CmT/hn/yWVM6cMiRBNeQnWmyUiu+j1su4cjDYsCP9WI/FQtPIDMZXErAAuSLEHcTDCBr
+        1FDxo/ivHwhN/9NF60P77lzIdbe1l/rKwrjab33pv49RWjekHOBbkQSD/ST47wFQLiDUFOUDZJrm
+        QlW+KuiKmWMxcckHvQT31/3o8gx40AJ3RRXZrFWNUnplyLCKqhjvhVQYDkc4JMMwz1IHvZ50DBRS
+        L6XY331/+aWcOvDfhfJXy5UtMWHNBKQT9vsqlkwlpHvdPiQau6Xsp1TfJKlQUL2svrOgNyzxyfUC
+        XtoBI93zRgU91b+0jg4uF91PjcXJ4nTRaRYPL86PDj6dLPqLz4vLpKIBJI3F5cWiQa+Zn7yoZzHH
+        dVpHpyWpdXSyBesr+8bTOD4fvvrg6OB8UV90iod1kPZ00V6cQzE+Ougseot28bBBS91Fo3h4tizV
+        s9ISy28bJg9YGLVTkuC3/sbQanvEnRutrPzeg4+2Z/Rhsv7+Q5D2nBi0LvNzPekIeh8mEYXFky9p
+        OEmjyZckmEAsWVzAReo3z+v0ncOPti+GL4KOBpAOBJDzRTcJIeeL0+Jh94LWsuIlixsXxcMexavB
+        IsopNHVYRElL9azEA/zKQ3/XYJWkOJ9bIgV83nc5mbrmUxnN59ZmNgPp3JukcqvdqqFNQitw5umm
+        8ZaM9LEc2/Z+7bX/K7C+BEvE+JJMuuDIPoQI21aWvnEwxFayr7ktTzOhOPzZg2xQqid04cfJGbeT
+        X1sdEtd1fJE0LdbwkXPgJfdJ3ydFeAsXedNdCnyDHZfyIJItFarO0XwQvbB43Goey2wzKY/xJo4w
+        XWC+7pbTh9obTmum8Sgfh1PW+EE0lzKc0g4JqCdnZdNao5RaQLmvGGnXUMIBkXgT7/hSyoDkhHCb
+        /TV2Avb4BxquWUwl4q5viQWxh6P74Qy7t1iYGrQyMun4XmovyT6WQhMhPPZqyVMydDKq7yICewCX
+        vk+5zehp+oIUfZxdt2326tPLAzoy1TIyamVUVkuoSstl+JFXRUUpIYX+KVdgyazqJcYducOwbiHs
+        Faz328I/qw/qAkRo9TMjqPy1Lv8Hy79dyesRdbM+J8KyGbfWwAjJdVlBFfSejzWAlWMxJsfvjsmx
+        EJPj98QkjJzJcPmoXIhLW+qt2vdBx7k5G1z9mCPzarRE5LPBO2tf9FCLVr+79vvf3yMcbxhNAQVy
+        KwrxZ57UnxII7rcfKCHJv6t+1Bspt7ibkQiHrFLE/7LxIydQKxHyMihOjt9N9sSCQ7t3IgoObccK
+        /NAfR9Jx7Lokcrz94kS7t/H4f6MiJzK0e6Ypm6YJ5IoiV2vmOyLwqTdoiu6OrP4Pk3TN6QDDeTxy
+        144HbIvdpYRSd0XI3uQV+yI0jB3i2ltAPOiPh0lBXRWEkNCXPg7b7cNmc0vldHjZpVEjLZGsOIlW
+        pWUlA4yVvnW7ZOcuYpfRS801oo+0FZe87zcUvmWWMn+SvBK4K74OZ7EbOasou5zlArKfUxxJ575F
+        n+6k5ywktrlKb5nsXWSOq9OufPllJ7XKUTfJyMHeTnKNI+/5Lg4gB95Fr3P0J8T2A7yTvMKRN346
+        k/AoDknWaHCNP4GKfX/nWFWe1bjX2klc44jrZ7shMznaz44HCgulI2k7aC8VovAd1l4RTg5Y8Iy2
+        +11pHvhgNrMlAa+jk4CQ415ztwXwWrocxV4U76bntdRzsXVNlzW7u/CaatODafj6iR68+tJjCmPH
+        JRK2rCRDZlS81hqg5E+93aPyijvpd7NqgY4yg1fWOLdggic8BK25iOcApT+W0nMKGRGvo+xdX9aw
+        5jGCsw3Je/prU7ANeunSc+74/fnkzXmhg4D5fen1Mpo1P6GHDQLfj2DpTyFngYdR8UBfdBtZdU1o
+        3JchCaQZ9vCEzAh7rMCIzXWPTF/CZ3GCRznbRF0GER7RLiGB3Pdl+lc6oQbRm0JY8bLzjRqPbOOs
+        1/iUNfDInjgBucWuu5yCR/QYLNr2/aXHaTyKvUa9Wc8aeOianQxRjccKoHDBXqUw0eVyTB64Ljud
+        Kq0eHWVE5qZqsBROietuakdX1qwmgmgyWYbUNfQ2jlUxAh4xejI2yVGSkw9rmHkTwHwtxuproaDT
+        zhxK5yHrnGXI6MZmGHBudkd4ncdy0GaBptXb7YE6j+1xQM/yjP0A/AjWDZgj49H9Z+z5u29NlTWM
+        LQfsmh7flM4dL77b3ZPXQNsfUaNtEt4aKrwKPgXYAoo9xuW1U5/h32D9t0cvXmVd7PpS3Y123xor
+        vDZPY3xLnN30vJpPKtlx6yfwrW5hMGjv7sHr+cyzHBt0Qo9HzX0vzEy4wmt54ARR7P/2225xDWXN
+        IW579BSw1Pipd767G3p8vYR214pw3zTnQFl8RbCcT9b0Ssl4LB788kv4g0x/Djabin8/KLGGZ/bK
+        SZ++0H8l9iuz341MSlGUt8j+03M022erc9Fsc6R/jvQpZ1skxeODbon4cTSPRbtSKdufsvaXMh6R
+        u6jkR1O4xdHi+2xqpOa6T6qfiPlnzvVTsJiQuQD1k9a9NiNdGs3ZUHQ19SrbkbC+KtMfEYNJ9b77
+        Uw+oVHlcRd5VXRaon6LKCcw1pVSD4CvXlJryjJicvbFJtf1MONLTwiJIVk377R5bc7iKbfrrWLP5
+        a6iMv1UIWLwgFg4j6W80tSJzsQIFnCbU7EF/MgIU3+69FLoggURTwH7a8ofZGg0JGWI39IWiEljK
+        sqaPdvPa8fxy56PLvA2+Aj1xD5fnPn2NpZ18zaNUOKXf8igVGtmXPN7E4LiPD2zJsmr6SJusPPP3
+        nj8PHdHDxN6q6YMyH3thdnycvvlyQzybvX29Kcnlio6++zLI6L7LA7oIMrlrx5uUx04QRsOxH3ui
+        1Gb9wOYJpYU0i4hN6Q+xvlkCwz4GtR8u5/gPD8u22d/Mg3LeGZZ1eLqB47O8/ALTHTDpYNC9KD7r
+        vpcdZ/mOp3fYFx/2SAg2RP/T5AVLv6GfOXsamF6Ui8Z28OsQej89ce7Ywq1uRc4NYSu4MA7G2Hqd
+        NVyEJ+Ve82cJtEUmfiBcFKw3v+DJHx3hBrsxUU1oZaWNWn43c1ldExLXhMTIEBEjQ0isIRGxhsQj
+        V4QjV8Qj68KRdbGAQmJVTKwJ0dDEaGhCNDQxGmpVyEZVPLKQWBMTq0KcVTHOQvlyxFOETChiJoTE
+        qphYaJ9i8xRRCgmFuhCrQmgQYntAQkUgsSJ0TTiwJgZMFQKmitkQoovE6GpCV9LErqQLR9bFI+tC
+        nnUxz6qQDVXMhhgMMRZClFEOykKzUHNcVDiyKh5ZF3qdLvY64cDicZHQOlFOuBIPnDOy0O2Q2O80
+        oUa0HJUIsUBiLIRmIbYKofOJfQ8J+UVifjUhEpoYCSQMmVC7/egnJJE8ZR9RSkueHz1vkWDXxrXx
+        yCByFY0tWbcUUzYtVZWtkW4Sm9gVXa8IFg97dnvBooJ9KZpJPDSrfKzYaHgbMJCJlaoi63ZVBakM
+        VR7pY022kWrVNIJ1m4XybTD26vZtYNQqqhgM2vAWYNApBMKm1S8UZkOEN2FcsVQLE2zIRFFGsj4a
+        Y7mGR4asWKNKtaIb1tgyBILt2e3btGgYOVqkDW8BBhrXkG7YFZDFpI6qKTLWDU22LKIbKhqbuiHy
+        7z27vRQM9oX1RHD7HhocaxMVAcVbwGPZNYJrIJhWMUBOpBqyielHAUm1qiKsKkg3BfDs2e0bw5+Z
+        E/3MV4Liin6DPyLpRx4DQr/YzLL7kHLsxbOhdUOSb87Ti/SDkCi5ysiJvU7lzObYorUpubI58ter
+        x8f/AwPl48w5YAAA
     headers:
       Cache-Control:
       - no-cache
@@ -3533,12 +4506,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:56:50 GMT
+      - Thu, 21 Nov 2019 15:44:27 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -3548,9 +4521,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - b360a50a5b8a6804987f5f6f80195d7e
+      - 6bf0fd84865c15a45dc1b8b0a739e5a8
     status:
       code: 200
       message: OK
@@ -3566,82 +4539,93 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VceXfiOBL/Kn7svn1hBhNfHOafWcIxyW4gTEjonunO8IQtiDbGon2QpEO++5Zk
-        GwQYQjpHMz39XhNZVZKqflUqnfZDhrhDmqk8ZOiti71MJYNc28O3//btmzz1RplcxkVjDPkB9oO+
-        byG3PyR3QehhRqL9AHkjHGQqQ+T4OJcZUsfGXp/YmYobOk4uY1E38KiTqQReCPTQB+oEe2Pi+4S6
-        fqaiauVcxreusR06uB+GrCg0Np44KMAyHljIQroua7qpyyWEi3JZHRYgpRZsTSubqlU2dcWwEDIK
-        5ZKC1KIBgmGbBH3kOPQW23PZmPCgYz9W6LIr1Rwa2lI3yodiE+oQ6x5oR8gnltTGwS31bjgDUP1r
-        5OG5YnTwP2wFXFNVVXKZAI1iMPyEBVkOpD89ZJYUBt4Y64jLJj7oeh+LFeWJ6QWWwf2ECW7jIQqd
-        IPOYW6mZQxnXra5WvNGwa/msQW3eGrNY5vEql7mmfmDR0A145bGhyoZpDjXFkk0bGbJhlktyGWwm
-        FxQbmdg2TaOgM+gCFIQgISToZEJc1gz3pbiRiZ9hCMboxSktPwkHLJkPsIsGDvaxFXokuM9bdAz8
-        yAkSxPsg5cLQE4vIULkcThyKlu3fB0k8pkGhqOulclkBVQIyBt9G48k829QM0Bf5N4PEb+EBheBU
-        gYfI3JkTh4rrZEZ6BFYCSnr33PBxOvISpayZip6YqB/DbHkYBWC/vg3+viyYg6DLjalNhsRK4eFS
-        Ps8OItzpNon6ocfddAPAiTNEvo18HweJMixbTCexYyd7Tjw68rDPRFIVRYb/hxr8hf+xtyQMUMrD
-        3A8VZZkS0AA5cb4bjkEb68aHEOQTiErYjimcawPNx1PMZIo9/SFDIBZxReOcwoLHgb/QmsI6YkxV
-        1qjqVqq2lapvpRqPV4+LzEgyi0JgZqkorEMCYiAvPIaYGI558pqMrnnCgoLgWk6Uy23n2viOqQQ2
-        noYO+CkaEAe4sC+CAOadOOGIuHH801RznhPbvA3mCH2p+3tb8ucBdiGsMucfojFxWNDtUC9IeJmD
-        svYTgUQU1eXGFVU1Vhs/qbU60kXSr6Vz/CWEJPwd0wBLdcR+iG851I8Gsq1y/YoZDM6KRNpmiTSl
-        oK9KdAzoSk2IEPfSbyFyoEtjW6rTMSKu1AYW6aD5W72dBRF96oSss3+bWPpGsbSCpimrYl3UOocn
-        AlRgsHAyAUNAh/im9g3mOdCfJ0mEiB8dglwLR89D4gTMxMyhYjkYd56wNiEc2iw4JBJWWXyRTuoZ
-        YS7xkAQyiAIQaVmhEWs880mRTSQPrx7Kj/LB/MF4lLMP+uP8WdUeD3I7s2Z/EqVKWlJUTTcKxZKM
-        BpYt46GiyixDLkJcZlksB0boDIURGsEYwLTN4C9s2OW/YxRY1+wpSgAqI4+Gk0Rrse/d85E+JkRW
-        yCMYicgghElZfpAK21E4grHqy67A/ck0vvo5guXq53Sd25eto8Y5F/7Owe4ogCiilt9FSXwHYznM
-        6YYecLBJWR/ixBT5KZrXqu1etSs1ohJSMymRioPt0YkN4zEQHRirmfxsbIdHPtRlrjZq9wJlItH7
-        E2TdoBHerEJnzrCT4FEpyKhrsfKsAnj+cA2DWL8DfQx6pQdj/ptodefhYaXWOL+Qa7U0nYAiVe0p
-        8WFCtLNb1qpy5JFy4qCrOdmf/pnmq8D2O/yTT+rSAcEVCZ5hIqHLSjn7Pt1yDscmLHpiXd/cT9OV
-        xzCS9i4lEAGmNhB3IwxggqOr2X3pv9RLdf2z88Ze991JqtSdxk7my6fG1YvGx4v3cUprivMeuk3T
-        oLebBn8eAOcMQk1WPlBN05xpyidFveLumI265IORg/F1N75NDtxrQHdVCzIsZIq5+KkISwIYct8L
-        Kd/vD5CP+/4mT+11u9IRcEjdmGP37vv5cz7uwL+k6l/KF9bUhDkTsI7476t4MtOQbbRQmMVt1/Ii
-        5nqRpqmKGnntnRWdYgsa2tgLRG17nHXHgQpKav9oVA4uZ52z2qw5O56169nD89PKwVlzdjH7MLuM
-        MmrAUptdns9q7Jn3k28qmd3QdRqV45zUqDTXYH3lvvE0js+Hr9qrHJzOqrN29rAK2h7PWrNTSIaV
-        g/asO2tlD2ss1ZnVsocn81Q1Sc2xfFk1m4CFWts5CX6rbwytvkPcmep55a8efPQdow/X9a8fgvTn
-        xKBlnZ/bkypQ+jCKKDyefIzDSRxNPkbBBGLJ7Bwe4n7zvELfOfzou2L4TdCxANKGAHI660Qh5HR2
-        nD3snLNcnrzkceM8e9hleNV4RDkGUptHlDhVTVIiwK9c9XcNVtES50MjzQAfdp1Oxl3zqRXNh8bq
-        agaWc2+ylFvsVvVt7FsemcS7cWs6sh1kvnn32nP/VxB9Dlaa4HM26Vxg2wsV1r0sPu7qIyva1lzX
-        px5xHP7XhdWgVI34/P1ZM64vfm2tjx2H0DRtGpywz2vgufRR2SdVeIsu8qa7FGiKiMNkSNMtVqoq
-        8OyJXXg8btSPZL6ZtEnwOgoQm2C+7pbTXu0NxznX4WAzDsecuCeWiwWOefsYzLNhZtNY4pQawLmr
-        GnFRX0IelkQXb1MpFkAiPgyzX0Li8fMfINzwmIrTi74lFtjuD+77Y+TcotSlQSNhk47updacbb8M
-        Ginh8qPQp3RoJ1zfRQV+ABdf5lkX9Dg+y2dnhVXb5qf03x7QVVPLq8VyXs1rObXE0nn4kRdJRcmp
-        CvuTL8CUWTNyXDp8h2Degvltgffbwj+p9qopiLDsZ0ZQ+VNV/gPJX6/k5Yi6mr8hwvIW1+bAqipX
-        ZUUtqO95rAGiHKVjcvTumBylYnL0npj4ARn152flqbi0pO6Cvgs6ZHrSu/p5g86L2iKVT3rvbP20
-        Qy2W/e7Wv/j+PYK4/eAaUMC3aSH+xJUurjEE99s9WpBsHlX3dSAVJndjHCCfZ6bJPyfu8wJqocKm
-        FZSgx19m9cSDQ6vbTAsOLWJ51KfDQDoKHQcHxN0tTrS6K8f/KxkbIkOra5qyaZrArihyqWy+IwJn
-        3V49bXTk+T/MomvCKuhPwoGzdDd1Xe0OY5Q6C0Z+/S69LwJhSLBjrwHxYDweRgltkUiFhF36OGy1
-        Duv1NZOz6mWHRY04hZPkKFik5pkcMJ566XbJ1l3EDueX6ktM+7QVF13466feMouFb0Z3ArfF1/44
-        dAKyiLLzVs5h9XOMAumUWux0J74SLPHNVTZk8huVglTHHfny41ZuTeCu4wFB7lZ2XWDvUgd5sAbe
-        xm8I/E1sUw9tZS8I7LVfTyQ0CH2cEIsC8VcwMaVb6yqJoobdxlbmssBcPdkOmSnwfiAuGMyXKtJ6
-        0J4bRBEL4AFU602jW7vRhWBR0NZFR5p4FNxmPGcQbdT0MD7q1rd7gGily0HoBuF2ftFKXQdZN2xa
-        s72IaKkWeysC3TxRQjRffLd4SBwsIcuKVsicS7RaDYx81t1eq2i45kUnyU6xUeLwypLkFjTwRA9R
-        l7qIS4CTDrkRCT8K4EyijVrEt/IJYanHRGUkGwfYiqMXZzKWmuAb9NKlS+7E/fnoWnJqBwH3+9jt
-        JjxL/YRdmfYoDWDqzyDngYdziUCfd2pJdjnVuS997Elj5KIRHmN+rMCZzeUeGd9w5nFCRDnZRJ0H
-        ERHRDsaefEFl9ldqMofoXkNYcZOXa3QR2dpJt3aWEERkm8TDt8hx5k2IiB6BR9uUznucLqLYrVXr
-        1YQgQldvJ4jqIlYAhQP+KvmRLed1isB1+KtR0uLoKGEyV02DJP8aO86qdQxlyWsCiCajeUhdQm/l
-        NQDOICLGXsuK1iictIyZOwLMl2KssRQK2q2kQxkiZO2TBBmjuBoGyHR7hDdELHstHmga3e090BCx
-        PfJCFjmoB/0I5g1IYBPR/U/o0u1DU2EJY4uAX7N3h6RT4oZ320uKFmjRAXPaOha9oSCa4MxDFnDs
-        UK9oneoYfYX53w6lRJN1kEOlqhNsHxoLojWPQ3SLyXZ+0czNQvKu3xP4ltYw6LW2lxDtfOJaxAab
-        sJc8JtT1ExcuiFbuES8I6dev29Utipb+42L7TKCoPr7eMnbbPHDXxc2BMvukwiQ+mskrueJj9uDz
-        Z/8nmf0crJKyvxzkOOGZpTYsmj6yfzn+K/PflfWToihvseaPX59Zf51vI5otgfXvsWjasBkS47Gn
-        GyE0DCZh2l5ULPZZQv9WwQN8F+RocA0DG0u+z1ZG7K67LPAjNf/OK/wYLK7kRoAuIupOW5AOi+a8
-        KjaHepVNSJhV5dlPmoBR9q67Ug9qrvC4iLyLvCRQP8W1ITCXlVwZgq9cVsrKM2Jyck+TWfuZcHg0
-        oBZ10iBZkHbbM7Ym8BTa7JdY48lrmEwcKlJEPMcW8gPpX2xBhSfpBkyRNOLmx/tRDZB8u9sobEIC
-        y8sU8WPKD7Mh6mPcR45PU1XFMIHlpH0bvLacWm49sNy0rQdz3CHT85Syyyut6J3zXOaYvXGey9SS
-        983fxOGEF6fXdFmQ9mlrVRT+3qUTn6QdIXYXpD0VPnT95K1xdt9lil2b37le1eRywcduvPQSvu9y
-        LBfA+u2GuKP8kHh+0B/S0E1b2iy/ptlkvLDMwumu9EPMb+bA8O+P7IbLKfrhYVl3++nEy296c2UZ
-        no5HKF+XnyO27yUd9Drn2WeNe8lLLN/xnR3+mYcdFgQrqv9t1gXzfsO+rPM0MN1gIxrrwa+N2Xja
-        JHd84la1AjLFfAbnh94QWa8zhwvQKK+XCmUVsS9sFZEiGxoayqZdHMjGQC0XdVPTbN1MUW3HYt9w
-        Psi/OzZFToj7uqoCA0+vE9a3uHwcyNf8ExFxyqXB88BQDL1UNlBR1hRbBa0GioyGKpYVhIu6glVL
-        s6wUMHYs9jIwCuV0LCD/LaDgLUA3xiP2Pasi/5rUqt5pPC9UsqBt0BIIb2JxtWSXzIIqY0MzZANj
-        VUZlA8vqECtDzdSwYg/TLL5bsZeBUSoU08FghLe3eanM299u9JjpZYoaqp6uKCO8haJFHRcQRlg2
-        iyWIXmVtIJfLNpINSx8aA2tQslUjRfUdi70MDPYpw3Q0OOV14Lhi33IMcPy9Jg+zj4XxIdtnUrvh
-        uG9NcfTtQvYQf9tJjZ4Sdpj8L3GR8QRZLDdmV1Zr/nT1+Ph/qEihe4FSAAA=
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8c0eAbHIbGC4QZu5mc5SwBfhibNaPPDbku19L
+        tkGATEgmyWR3p2qILLWk7l8/rJYtPxQcb+wXjh4K/q1HgsJRAXt2QG7/EdrXZT+YFEoFD88I1Eck
+        jIahhb3h2LmL4oDQJn8Y4WBCosLRGLshKRXGvmuTYOjYhSMvdt1SwfK9KPDdwlEUxNAeh9A6J8HM
+        CUPH98LCEVJrpUJoTYkdu2QYx7QrTDabuzgiso5HBsKjkVyxkCEj1cQyIqot46pSsxS7MtaQboyr
+        tYqBqhXTUAxlXAXGiO1EQ+y6/i2xl7xR5kHGYSrQZU9quH5sS72kHrrNfdex7qHtGIeOJXVIdOsH
+        14wAWsMpDshSMH/0P2JFTFIVmaVChCcpGGFGgi0Xyl8fCmsCK6UM64TKdkKQ9T5lK6njyysso/s5
+        ZdwmYxy7UeGxtDEygzIdG20OnKvYrXom0nI2qrHC41WpMPXDyPJjL2KDp4oy9KqFq2ZNtglSZb1G
+        VHk01lRQV1XTVF1DSkWh0EU4ioFDKPjzuePRaZgtpZPMwwJFMEUvLanleTyixXJEPDxySUisOHCi
+        +7Llz4Aeu1GG+BC4XCl6bjkyDC7Hc9fH6/ofAicBlaBS1bWKUq1WYV5nBraNZ/NltVkD+ac4vB5l
+        dgsXOAajigLsLI05M6h0TKqkRyB1QMjgnik+LTMrQUgxNBNlKhqmMFsBwRHob2iDva8z5mJwuZlv
+        O2PHEtAwLp+nBx5usU4SPwyYmeYAnBlDYts4DEmUCUOrs3LKmWpXTa1qqrJhgN/qtSqRR6oylomG
+        rbGq6shWUSHpmUWavbQ/D/xJQEIqAFIUGf4fqvAX/qe2lRFAr4Awq1WU9ZbIj7Cb1nvxDGS3rkMI
+        WKEDMYyKy1oYVU5bSG4I5Sn1i4eCA5GLwZJ5irYicuEvTKdQv02b1a1WxLWirVaVa1W2WrWdrfrj
+        1eOqEkY3KBp+QA1KAzaTGwFlGMImY20GYTSeMT6mzmTKBrWgM1ijyy4SdXs2uaNigVncxC6YNh45
+        LlCRkEcCxpu78cTxUmdgQTOtSRXfAZ3EodT7d0cKlzF5xbCypB/jmePSON31gyijpTZN588YQus4
+        c5Orqmnom5P3SHDjWERqkgjiOjjbU3NnHWyuAz+/uq5JXngFKdXN+U/7/a5ExySB1Ac3lSAuSwMQ
+        aw9WPpNR2nUTBG0XE2gLhLNGuyv1s3goXZBfYyjC35kfATSY/jih5fphsgDYydVPhNqCu8GRvoMj
+        1diCpdc7zUNFOgOLDWb4NZRV2cVVbYurfoAtEvgx4PEMJsSAGPlTq0pF27IT8DnpBG4199K/YuzC
+        vYHYUtOfYceTOkAiHZz8q9kpgs5C341fzlY1ly1VVw1liy1QTtAnd5EE2HjhGPTVDfzIt3xXOqC2
+        XXwOUvkGXctnq6KqW2z1G93DM86kIbrE8zlEDQjhL4LFzJ0fbrIICb26TaKpb4dSPVmQSgcAlWQ7
+        AVgiLA6KLwcDKbncVBWjInSmujvxYarpLGS+dI69SYwn5BnAtCEClDc5QTs5qe1w68ZxQ2r7NpEa
+        znwKMkotdrtfZwPtyUZ+0K0iRd+641A2PhN8LbXrDR6Zb2EhP+SaioaEOmEscNOLVaHuyYBO78Sw
+        SJpni7T00nWwZ5Hkeuy4EbUneoNOGaHUZYdOCStSm8qfsVinSzzprFng0rmHbC0JSytY7NJOEzp7
+        4asiQ5I2vnqoPcoHywv9US4+aI/La1DUQWlv0uIPPFfZTApSNb1iVGU8smyZjBUk0wrZqNZMWkVr
+        IEkq+OBuGDyNSlsgv9LMh/1CKLKm9CopACoTCOnzTGp+LXPPkq20IVFCGUMy4IzgFhCWR0LYjuMJ
+        pAu/7gvcf6nEVz8msFz9KJa5c9k+bl0w5u9c4k0iWJWh2rsISe4gnYK0ehwABc2Lh7DuusGhQPJG
+        vTOo96RW0kM6yXoIcbADf25DSgSNLqRLlH+aXsElyzYKV7nSfYMwCevDObauIfjli9BdEuzFeNIL
+        KppqKjwdAK4/TyEzGHbBx8ArA0i73kSqu4CMjxqti77caIhkghapbt84Idx29jbLRl1OLFLODHSz
+        pvjDX0W2CmT/hn/yWVM6cMiRBNeQnWmyUiu+j1su4cjDYsCP9WI/FQtPIDMZXErAAuSLEHcTDCBr
+        1FDxo/ivHwhN/9NF60P77lzIdbe1l/rKwrjab33pv49RWjekHOBbkQSD/ST47wFQLiDUFOUDZJrm
+        QlW+KuiKmWMxcckHvQT31/3o8gx40AJ3RRXZrFWNUnplyLCKqhjvhVQYDkc4JMMwz1IHvZ50DBRS
+        L6XY331/+aWcOvDfhfJXy5UtMWHNBKQT9vsqlkwlpHvdPiQau6Xsp1TfJKlQUL2svrOgNyzxyfUC
+        XtoBI93zRgU91b+0jg4uF91PjcXJ4nTRaRYPL86PDj6dLPqLz4vLpKIBJI3F5cWiQa+Zn7yoZzHH
+        dVpHpyWpdXSyBesr+8bTOD4fvvrg6OB8UV90iod1kPZ00V6cQzE+Ougseot28bBBS91Fo3h4tizV
+        s9ISy28bJg9YGLVTkuC3/sbQanvEnRutrPzeg4+2Z/Rhsv7+Q5D2nBi0LvNzPekIeh8mEYXFky9p
+        OEmjyZckmEAsWVzAReo3z+v0ncOPti+GL4KOBpAOBJDzRTcJIeeL0+Jh94LWsuIlixsXxcMexavB
+        IsopNHVYRElL9azEA/zKQ3/XYJWkOJ9bIgV83nc5mbrmUxnN59ZmNgPp3JukcqvdqqFNQitw5umm
+        8ZaM9LEc2/Z+7bX/K7C+BEvE+JJMuuDIPoQI21aWvnEwxFayr7ktTzOhOPzZg2xQqid04cfJGbeT
+        X1sdEtd1fJE0LdbwkXPgJfdJ3ydFeAsXedNdCnyDHZfyIJItFarO0XwQvbB43Goey2wzKY/xJo4w
+        XWC+7pbTh9obTmum8Sgfh1PW+EE0lzKc0g4JqCdnZdNao5RaQLmvGGnXUMIBkXgT7/hSyoDkhHCb
+        /TV2Avb4BxquWUwl4q5viQWxh6P74Qy7t1iYGrQyMun4XmovyT6WQhMhPPZqyVMydDKq7yICewCX
+        vk+5zehp+oIUfZxdt2326tPLAzoy1TIyamVUVkuoSstl+JFXRUUpIYX+KVdgyazqJcYducOwbiHs
+        Faz328I/qw/qAkRo9TMjqPy1Lv8Hy79dyesRdbM+J8KyGbfWwAjJdVlBFfSejzWAlWMxJsfvjsmx
+        EJPj98QkjJzJcPmoXIhLW+qt2vdBx7k5G1z9mCPzarRE5LPBO2tf9FCLVr+79vvf3yMcbxhNAQVy
+        KwrxZ57UnxII7rcfKCHJv6t+1Bspt7ibkQiHrFLE/7LxIydQKxHyMihOjt9N9sSCQ7t3IgoObccK
+        /NAfR9Jx7Lokcrz94kS7t/H4f6MiJzK0e6Ypm6YJ5IoiV2vmOyLwqTdoiu6OrP4Pk3TN6QDDeTxy
+        144HbIvdpYRSd0XI3uQV+yI0jB3i2ltAPOiPh0lBXRWEkNCXPg7b7cNmc0vldHjZpVEjLZGsOIlW
+        pWUlA4yVvnW7ZOcuYpfRS801oo+0FZe87zcUvmWWMn+SvBK4K74OZ7EbOasou5zlArKfUxxJ575F
+        n+6k5ywktrlKb5nsXWSOq9OufPllJ7XKUTfJyMHeTnKNI+/5Lg4gB95Fr3P0J8T2A7yTvMKRN346
+        k/AoDknWaHCNP4GKfX/nWFWe1bjX2klc44jrZ7shMznaz44HCgulI2k7aC8VovAd1l4RTg5Y8Iy2
+        +11pHvhgNrMlAa+jk4CQ415ztwXwWrocxV4U76bntdRzsXVNlzW7u/CaatODafj6iR68+tJjCmPH
+        JRK2rCRDZlS81hqg5E+93aPyijvpd7NqgY4yg1fWOLdggic8BK25iOcApT+W0nMKGRGvo+xdX9aw
+        5jGCsw3Je/prU7ANeunSc+74/fnkzXmhg4D5fen1Mpo1P6GHDQLfj2DpTyFngYdR8UBfdBtZdU1o
+        3JchCaQZ9vCEzAh7rMCIzXWPTF/CZ3GCRznbRF0GER7RLiGB3Pdl+lc6oQbRm0JY8bLzjRqPbOOs
+        1/iUNfDInjgBucWuu5yCR/QYLNr2/aXHaTyKvUa9Wc8aeOianQxRjccKoHDBXqUw0eVyTB64Ljud
+        Kq0eHWVE5qZqsBROietuakdX1qwmgmgyWYbUNfQ2jlUxAh4xejI2yVGSkw9rmHkTwHwtxuproaDT
+        zhxK5yHrnGXI6MZmGHBudkd4ncdy0GaBptXb7YE6j+1xQM/yjP0A/AjWDZgj49H9Z+z5u29NlTWM
+        LQfsmh7flM4dL77b3ZPXQNsfUaNtEt4aKrwKPgXYAoo9xuW1U5/h32D9t0cvXmVd7PpS3Y123xor
+        vDZPY3xLnN30vJpPKtlx6yfwrW5hMGjv7sHr+cyzHBt0Qo9HzX0vzEy4wmt54ARR7P/2225xDWXN
+        IW579BSw1Pipd767G3p8vYR214pw3zTnQFl8RbCcT9b0Ssl4LB788kv4g0x/Djabin8/KLGGZ/bK
+        SZ++0H8l9iuz341MSlGUt8j+03M022erc9Fsc6R/jvQpZ1skxeODbon4cTSPRbtSKdufsvaXMh6R
+        u6jkR1O4xdHi+2xqpOa6T6qfiPlnzvVTsJiQuQD1k9a9NiNdGs3ZUHQ19SrbkbC+KtMfEYNJ9b77
+        Uw+oVHlcRd5VXRaon6LKCcw1pVSD4CvXlJryjJicvbFJtf1MONLTwiJIVk377R5bc7iKbfrrWLP5
+        a6iMv1UIWLwgFg4j6W80tSJzsQIFnCbU7EF/MgIU3+69FLoggURTwH7a8ofZGg0JGWI39IWiEljK
+        sqaPdvPa8fxy56PLvA2+Aj1xD5fnPn2NpZ18zaNUOKXf8igVGtmXPN7E4LiPD2zJsmr6SJusPPP3
+        nj8PHdHDxN6q6YMyH3thdnycvvlyQzybvX29Kcnlio6++zLI6L7LA7oIMrlrx5uUx04QRsOxH3ui
+        1Gb9wOYJpYU0i4hN6Q+xvlkCwz4GtR8u5/gPD8u22d/Mg3LeGZZ1eLqB47O8/ALTHTDpYNC9KD7r
+        vpcdZ/mOp3fYFx/2SAg2RP/T5AVLv6GfOXsamF6Ui8Z28OsQej89ce7Ywq1uRc4NYSu4MA7G2Hqd
+        NVyEJ+Ve82cJtEUmfiBcFKw3v+DJHx3hBrsxUU1oZaWNWn43c1ldExLXhMTIEBEjQ0isIRGxhsQj
+        V4QjV8Qj68KRdbGAQmJVTKwJ0dDEaGhCNDQxGmpVyEZVPLKQWBMTq0KcVTHOQvlyxFOETChiJoTE
+        qphYaJ9i8xRRCgmFuhCrQmgQYntAQkUgsSJ0TTiwJgZMFQKmitkQoovE6GpCV9LErqQLR9bFI+tC
+        nnUxz6qQDVXMhhgMMRZClFEOykKzUHNcVDiyKh5ZF3qdLvY64cDicZHQOlFOuBIPnDOy0O2Q2O80
+        oUa0HJUIsUBiLIRmIbYKofOJfQ8J+UVifjUhEpoYCSQMmVC7/egnJJE8ZR9RSkueHz1vkWDXxrXx
+        yCByFY0tWbcUUzYtVZWtkW4Sm9gVXa8IFg97dnvBooJ9KZpJPDSrfKzYaHgbMJCJlaoi63ZVBakM
+        VR7pY022kWrVNIJ1m4XybTD26vZtYNQqqhgM2vAWYNApBMKm1S8UZkOEN2FcsVQLE2zIRFFGsj4a
+        Y7mGR4asWKNKtaIb1tgyBILt2e3btGgYOVqkDW8BBhrXkG7YFZDFpI6qKTLWDU22LKIbKhqbuiHy
+        7z27vRQM9oX1RHD7HhocaxMVAcVbwGPZNYJrIJhWMUBOpBqyielHAUm1qiKsKkg3BfDs2e0bw5+Z
+        E/3MV4Liin6DPyLpRx4DQr/YzLL7kHLsxbOhdUOSb87Ti/SDkCi5ysiJvU7lzObYorUpubI58ter
+        x8f/AwPl48w5YAAA
     headers:
       Cache-Control:
       - no-cache
@@ -3652,12 +4636,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:57:01 GMT
+      - Thu, 21 Nov 2019 15:44:37 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -3667,9 +4651,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 86916d6cd359bad47c94f99bce3ef657
+      - cfc03be98e3038f974415e228f3594fe
     status:
       code: 200
       message: OK
@@ -3685,82 +4669,93 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VceXfiOBL/Kn7svn1hBhNfHOafWcIxyW4gTEjonunO8IQtiDbGon2QpEO++5Zk
-        GwQYQjpHMz39XhNZVZKqflUqnfZDhrhDmqk8ZOiti71MJYNc28O3//btmzz1RplcxkVjDPkB9oO+
-        byG3PyR3QehhRqL9AHkjHGQqQ+T4OJcZUsfGXp/YmYobOk4uY1E38KiTqQReCPTQB+oEe2Pi+4S6
-        fqaiauVcxreusR06uB+GrCg0Np44KMAyHljIQroua7qpyyWEi3JZHRYgpRZsTSubqlU2dcWwEDIK
-        5ZKC1KIBgmGbBH3kOPQW23PZmPCgYz9W6LIr1Rwa2lI3yodiE+oQ6x5oR8gnltTGwS31bjgDUP1r
-        5OG5YnTwP2wFXFNVVXKZAI1iMPyEBVkOpD89ZJYUBt4Y64jLJj7oeh+LFeWJ6QWWwf2ECW7jIQqd
-        IPOYW6mZQxnXra5WvNGwa/msQW3eGrNY5vEql7mmfmDR0A145bGhyoZpDjXFkk0bGbJhlktyGWwm
-        FxQbmdg2TaOgM+gCFIQgISToZEJc1gz3pbiRiZ9hCMboxSktPwkHLJkPsIsGDvaxFXokuM9bdAz8
-        yAkSxPsg5cLQE4vIULkcThyKlu3fB0k8pkGhqOulclkBVQIyBt9G48k829QM0Bf5N4PEb+EBheBU
-        gYfI3JkTh4rrZEZ6BFYCSnr33PBxOvISpayZip6YqB/DbHkYBWC/vg3+viyYg6DLjalNhsRK4eFS
-        Ps8OItzpNon6ocfddAPAiTNEvo18HweJMixbTCexYyd7Tjw68rDPRFIVRYb/hxr8hf+xtyQMUMrD
-        3A8VZZkS0AA5cb4bjkEb68aHEOQTiErYjimcawPNx1PMZIo9/SFDIBZxReOcwoLHgb/QmsI6YkxV
-        1qjqVqq2lapvpRqPV4+LzEgyi0JgZqkorEMCYiAvPIaYGI558pqMrnnCgoLgWk6Uy23n2viOqQQ2
-        noYO+CkaEAe4sC+CAOadOOGIuHH801RznhPbvA3mCH2p+3tb8ucBdiGsMucfojFxWNDtUC9IeJmD
-        svYTgUQU1eXGFVU1Vhs/qbU60kXSr6Vz/CWEJPwd0wBLdcR+iG851I8Gsq1y/YoZDM6KRNpmiTSl
-        oK9KdAzoSk2IEPfSbyFyoEtjW6rTMSKu1AYW6aD5W72dBRF96oSss3+bWPpGsbSCpimrYl3UOocn
-        AlRgsHAyAUNAh/im9g3mOdCfJ0mEiB8dglwLR89D4gTMxMyhYjkYd56wNiEc2iw4JBJWWXyRTuoZ
-        YS7xkAQyiAIQaVmhEWs880mRTSQPrx7Kj/LB/MF4lLMP+uP8WdUeD3I7s2Z/EqVKWlJUTTcKxZKM
-        BpYt46GiyixDLkJcZlksB0boDIURGsEYwLTN4C9s2OW/YxRY1+wpSgAqI4+Gk0Rrse/d85E+JkRW
-        yCMYicgghElZfpAK21E4grHqy67A/ck0vvo5guXq53Sd25eto8Y5F/7Owe4ogCiilt9FSXwHYznM
-        6YYecLBJWR/ixBT5KZrXqu1etSs1ohJSMymRioPt0YkN4zEQHRirmfxsbIdHPtRlrjZq9wJlItH7
-        E2TdoBHerEJnzrCT4FEpyKhrsfKsAnj+cA2DWL8DfQx6pQdj/ptodefhYaXWOL+Qa7U0nYAiVe0p
-        8WFCtLNb1qpy5JFy4qCrOdmf/pnmq8D2O/yTT+rSAcEVCZ5hIqHLSjn7Pt1yDscmLHpiXd/cT9OV
-        xzCS9i4lEAGmNhB3IwxggqOr2X3pv9RLdf2z88Ze991JqtSdxk7my6fG1YvGx4v3cUprivMeuk3T
-        oLebBn8eAOcMQk1WPlBN05xpyidFveLumI265IORg/F1N75NDtxrQHdVCzIsZIq5+KkISwIYct8L
-        Kd/vD5CP+/4mT+11u9IRcEjdmGP37vv5cz7uwL+k6l/KF9bUhDkTsI7476t4MtOQbbRQmMVt1/Ii
-        5nqRpqmKGnntnRWdYgsa2tgLRG17nHXHgQpKav9oVA4uZ52z2qw5O56169nD89PKwVlzdjH7MLuM
-        MmrAUptdns9q7Jn3k28qmd3QdRqV45zUqDTXYH3lvvE0js+Hr9qrHJzOqrN29rAK2h7PWrNTSIaV
-        g/asO2tlD2ss1ZnVsocn81Q1Sc2xfFk1m4CFWts5CX6rbwytvkPcmep55a8efPQdow/X9a8fgvTn
-        xKBlnZ/bkypQ+jCKKDyefIzDSRxNPkbBBGLJ7Bwe4n7zvELfOfzou2L4TdCxANKGAHI660Qh5HR2
-        nD3snLNcnrzkceM8e9hleNV4RDkGUptHlDhVTVIiwK9c9XcNVtES50MjzQAfdp1Oxl3zqRXNh8bq
-        agaWc2+ylFvsVvVt7FsemcS7cWs6sh1kvnn32nP/VxB9Dlaa4HM26Vxg2wsV1r0sPu7qIyva1lzX
-        px5xHP7XhdWgVI34/P1ZM64vfm2tjx2H0DRtGpywz2vgufRR2SdVeIsu8qa7FGiKiMNkSNMtVqoq
-        8OyJXXg8btSPZL6ZtEnwOgoQm2C+7pbTXu0NxznX4WAzDsecuCeWiwWOefsYzLNhZtNY4pQawLmr
-        GnFRX0IelkQXb1MpFkAiPgyzX0Li8fMfINzwmIrTi74lFtjuD+77Y+TcotSlQSNhk47updacbb8M
-        Ginh8qPQp3RoJ1zfRQV+ABdf5lkX9Dg+y2dnhVXb5qf03x7QVVPLq8VyXs1rObXE0nn4kRdJRcmp
-        CvuTL8CUWTNyXDp8h2Degvltgffbwj+p9qopiLDsZ0ZQ+VNV/gPJX6/k5Yi6mr8hwvIW1+bAqipX
-        ZUUtqO95rAGiHKVjcvTumBylYnL0npj4ARn152flqbi0pO6Cvgs6ZHrSu/p5g86L2iKVT3rvbP20
-        Qy2W/e7Wv/j+PYK4/eAaUMC3aSH+xJUurjEE99s9WpBsHlX3dSAVJndjHCCfZ6bJPyfu8wJqocKm
-        FZSgx19m9cSDQ6vbTAsOLWJ51KfDQDoKHQcHxN0tTrS6K8f/KxkbIkOra5qyaZrArihyqWy+IwJn
-        3V49bXTk+T/MomvCKuhPwoGzdDd1Xe0OY5Q6C0Z+/S69LwJhSLBjrwHxYDweRgltkUiFhF36OGy1
-        Duv1NZOz6mWHRY04hZPkKFik5pkcMJ566XbJ1l3EDueX6ktM+7QVF13466feMouFb0Z3ArfF1/44
-        dAKyiLLzVs5h9XOMAumUWux0J74SLPHNVTZk8huVglTHHfny41ZuTeCu4wFB7lZ2XWDvUgd5sAbe
-        xm8I/E1sUw9tZS8I7LVfTyQ0CH2cEIsC8VcwMaVb6yqJoobdxlbmssBcPdkOmSnwfiAuGMyXKtJ6
-        0J4bRBEL4AFU602jW7vRhWBR0NZFR5p4FNxmPGcQbdT0MD7q1rd7gGily0HoBuF2ftFKXQdZN2xa
-        s72IaKkWeysC3TxRQjRffLd4SBwsIcuKVsicS7RaDYx81t1eq2i45kUnyU6xUeLwypLkFjTwRA9R
-        l7qIS4CTDrkRCT8K4EyijVrEt/IJYanHRGUkGwfYiqMXZzKWmuAb9NKlS+7E/fnoWnJqBwH3+9jt
-        JjxL/YRdmfYoDWDqzyDngYdziUCfd2pJdjnVuS997Elj5KIRHmN+rMCZzeUeGd9w5nFCRDnZRJ0H
-        ERHRDsaefEFl9ldqMofoXkNYcZOXa3QR2dpJt3aWEERkm8TDt8hx5k2IiB6BR9uUznucLqLYrVXr
-        1YQgQldvJ4jqIlYAhQP+KvmRLed1isB1+KtR0uLoKGEyV02DJP8aO86qdQxlyWsCiCajeUhdQm/l
-        NQDOICLGXsuK1iictIyZOwLMl2KssRQK2q2kQxkiZO2TBBmjuBoGyHR7hDdELHstHmga3e090BCx
-        PfJCFjmoB/0I5g1IYBPR/U/o0u1DU2EJY4uAX7N3h6RT4oZ320uKFmjRAXPaOha9oSCa4MxDFnDs
-        UK9oneoYfYX53w6lRJN1kEOlqhNsHxoLojWPQ3SLyXZ+0czNQvKu3xP4ltYw6LW2lxDtfOJaxAab
-        sJc8JtT1ExcuiFbuES8I6dev29Utipb+42L7TKCoPr7eMnbbPHDXxc2BMvukwiQ+mskrueJj9uDz
-        Z/8nmf0crJKyvxzkOOGZpTYsmj6yfzn+K/PflfWToihvseaPX59Zf51vI5otgfXvsWjasBkS47Gn
-        GyE0DCZh2l5ULPZZQv9WwQN8F+RocA0DG0u+z1ZG7K67LPAjNf/OK/wYLK7kRoAuIupOW5AOi+a8
-        KjaHepVNSJhV5dlPmoBR9q67Ug9qrvC4iLyLvCRQP8W1ITCXlVwZgq9cVsrKM2Jyck+TWfuZcHg0
-        oBZ10iBZkHbbM7Ym8BTa7JdY48lrmEwcKlJEPMcW8gPpX2xBhSfpBkyRNOLmx/tRDZB8u9sobEIC
-        y8sU8WPKD7Mh6mPcR45PU1XFMIHlpH0bvLacWm49sNy0rQdz3CHT85Syyyut6J3zXOaYvXGey9SS
-        983fxOGEF6fXdFmQ9mlrVRT+3qUTn6QdIXYXpD0VPnT95K1xdt9lil2b37le1eRywcduvPQSvu9y
-        LBfA+u2GuKP8kHh+0B/S0E1b2iy/ptlkvLDMwumu9EPMb+bA8O+P7IbLKfrhYVl3++nEy296c2UZ
-        no5HKF+XnyO27yUd9Drn2WeNe8lLLN/xnR3+mYcdFgQrqv9t1gXzfsO+rPM0MN1gIxrrwa+N2Xja
-        JHd84la1AjLFfAbnh94QWa8zhwvQKK+XCmUVsS9sFZEiGxoayqZdHMjGQC0XdVPTbN1MUW3HYt9w
-        Psi/OzZFToj7uqoCA0+vE9a3uHwcyNf8ExFxyqXB88BQDL1UNlBR1hRbBa0GioyGKpYVhIu6glVL
-        s6wUMHYs9jIwCuV0LCD/LaDgLUA3xiP2Pasi/5rUqt5pPC9UsqBt0BIIb2JxtWSXzIIqY0MzZANj
-        VUZlA8vqECtDzdSwYg/TLL5bsZeBUSoU08FghLe3eanM299u9JjpZYoaqp6uKCO8haJFHRcQRlg2
-        iyWIXmVtIJfLNpINSx8aA2tQslUjRfUdi70MDPYpw3Q0OOV14Lhi33IMcPy9Jg+zj4XxIdtnUrvh
-        uG9NcfTtQvYQf9tJjZ4Sdpj8L3GR8QRZLDdmV1Zr/nT1+Ph/qEihe4FSAAA=
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8c0eAbHIbGC4QZu5mc5SwBfhibNaPPDbku19L
+        tkGATEgmyWR3p2qILLWk7l8/rJYtPxQcb+wXjh4K/q1HgsJRAXt2QG7/EdrXZT+YFEoFD88I1Eck
+        jIahhb3h2LmL4oDQJn8Y4WBCosLRGLshKRXGvmuTYOjYhSMvdt1SwfK9KPDdwlEUxNAeh9A6J8HM
+        CUPH98LCEVJrpUJoTYkdu2QYx7QrTDabuzgiso5HBsKjkVyxkCEj1cQyIqot46pSsxS7MtaQboyr
+        tYqBqhXTUAxlXAXGiO1EQ+y6/i2xl7xR5kHGYSrQZU9quH5sS72kHrrNfdex7qHtGIeOJXVIdOsH
+        14wAWsMpDshSMH/0P2JFTFIVmaVChCcpGGFGgi0Xyl8fCmsCK6UM64TKdkKQ9T5lK6njyysso/s5
+        ZdwmYxy7UeGxtDEygzIdG20OnKvYrXom0nI2qrHC41WpMPXDyPJjL2KDp4oy9KqFq2ZNtglSZb1G
+        VHk01lRQV1XTVF1DSkWh0EU4ioFDKPjzuePRaZgtpZPMwwJFMEUvLanleTyixXJEPDxySUisOHCi
+        +7Llz4Aeu1GG+BC4XCl6bjkyDC7Hc9fH6/ofAicBlaBS1bWKUq1WYV5nBraNZ/NltVkD+ac4vB5l
+        dgsXOAajigLsLI05M6h0TKqkRyB1QMjgnik+LTMrQUgxNBNlKhqmMFsBwRHob2iDva8z5mJwuZlv
+        O2PHEtAwLp+nBx5usU4SPwyYmeYAnBlDYts4DEmUCUOrs3LKmWpXTa1qqrJhgN/qtSqRR6oylomG
+        rbGq6shWUSHpmUWavbQ/D/xJQEIqAFIUGf4fqvAX/qe2lRFAr4Awq1WU9ZbIj7Cb1nvxDGS3rkMI
+        WKEDMYyKy1oYVU5bSG4I5Sn1i4eCA5GLwZJ5irYicuEvTKdQv02b1a1WxLWirVaVa1W2WrWdrfrj
+        1eOqEkY3KBp+QA1KAzaTGwFlGMImY20GYTSeMT6mzmTKBrWgM1ijyy4SdXs2uaNigVncxC6YNh45
+        LlCRkEcCxpu78cTxUmdgQTOtSRXfAZ3EodT7d0cKlzF5xbCypB/jmePSON31gyijpTZN588YQus4
+        c5Orqmnom5P3SHDjWERqkgjiOjjbU3NnHWyuAz+/uq5JXngFKdXN+U/7/a5ExySB1Ac3lSAuSwMQ
+        aw9WPpNR2nUTBG0XE2gLhLNGuyv1s3goXZBfYyjC35kfATSY/jih5fphsgDYydVPhNqCu8GRvoMj
+        1diCpdc7zUNFOgOLDWb4NZRV2cVVbYurfoAtEvgx4PEMJsSAGPlTq0pF27IT8DnpBG4199K/YuzC
+        vYHYUtOfYceTOkAiHZz8q9kpgs5C341fzlY1ly1VVw1liy1QTtAnd5EE2HjhGPTVDfzIt3xXOqC2
+        XXwOUvkGXctnq6KqW2z1G93DM86kIbrE8zlEDQjhL4LFzJ0fbrIICb26TaKpb4dSPVmQSgcAlWQ7
+        AVgiLA6KLwcDKbncVBWjInSmujvxYarpLGS+dI69SYwn5BnAtCEClDc5QTs5qe1w68ZxQ2r7NpEa
+        znwKMkotdrtfZwPtyUZ+0K0iRd+641A2PhN8LbXrDR6Zb2EhP+SaioaEOmEscNOLVaHuyYBO78Sw
+        SJpni7T00nWwZ5Hkeuy4EbUneoNOGaHUZYdOCStSm8qfsVinSzzprFng0rmHbC0JSytY7NJOEzp7
+        4asiQ5I2vnqoPcoHywv9US4+aI/La1DUQWlv0uIPPFfZTApSNb1iVGU8smyZjBUk0wrZqNZMWkVr
+        IEkq+OBuGDyNSlsgv9LMh/1CKLKm9CopACoTCOnzTGp+LXPPkq20IVFCGUMy4IzgFhCWR0LYjuMJ
+        pAu/7gvcf6nEVz8msFz9KJa5c9k+bl0w5u9c4k0iWJWh2rsISe4gnYK0ehwABc2Lh7DuusGhQPJG
+        vTOo96RW0kM6yXoIcbADf25DSgSNLqRLlH+aXsElyzYKV7nSfYMwCevDObauIfjli9BdEuzFeNIL
+        KppqKjwdAK4/TyEzGHbBx8ArA0i73kSqu4CMjxqti77caIhkghapbt84Idx29jbLRl1OLFLODHSz
+        pvjDX0W2CmT/hn/yWVM6cMiRBNeQnWmyUiu+j1su4cjDYsCP9WI/FQtPIDMZXErAAuSLEHcTDCBr
+        1FDxo/ivHwhN/9NF60P77lzIdbe1l/rKwrjab33pv49RWjekHOBbkQSD/ST47wFQLiDUFOUDZJrm
+        QlW+KuiKmWMxcckHvQT31/3o8gx40AJ3RRXZrFWNUnplyLCKqhjvhVQYDkc4JMMwz1IHvZ50DBRS
+        L6XY331/+aWcOvDfhfJXy5UtMWHNBKQT9vsqlkwlpHvdPiQau6Xsp1TfJKlQUL2svrOgNyzxyfUC
+        XtoBI93zRgU91b+0jg4uF91PjcXJ4nTRaRYPL86PDj6dLPqLz4vLpKIBJI3F5cWiQa+Zn7yoZzHH
+        dVpHpyWpdXSyBesr+8bTOD4fvvrg6OB8UV90iod1kPZ00V6cQzE+Ougseot28bBBS91Fo3h4tizV
+        s9ISy28bJg9YGLVTkuC3/sbQanvEnRutrPzeg4+2Z/Rhsv7+Q5D2nBi0LvNzPekIeh8mEYXFky9p
+        OEmjyZckmEAsWVzAReo3z+v0ncOPti+GL4KOBpAOBJDzRTcJIeeL0+Jh94LWsuIlixsXxcMexavB
+        IsopNHVYRElL9azEA/zKQ3/XYJWkOJ9bIgV83nc5mbrmUxnN59ZmNgPp3JukcqvdqqFNQitw5umm
+        8ZaM9LEc2/Z+7bX/K7C+BEvE+JJMuuDIPoQI21aWvnEwxFayr7ktTzOhOPzZg2xQqid04cfJGbeT
+        X1sdEtd1fJE0LdbwkXPgJfdJ3ydFeAsXedNdCnyDHZfyIJItFarO0XwQvbB43Goey2wzKY/xJo4w
+        XWC+7pbTh9obTmum8Sgfh1PW+EE0lzKc0g4JqCdnZdNao5RaQLmvGGnXUMIBkXgT7/hSyoDkhHCb
+        /TV2Avb4BxquWUwl4q5viQWxh6P74Qy7t1iYGrQyMun4XmovyT6WQhMhPPZqyVMydDKq7yICewCX
+        vk+5zehp+oIUfZxdt2326tPLAzoy1TIyamVUVkuoSstl+JFXRUUpIYX+KVdgyazqJcYducOwbiHs
+        Faz328I/qw/qAkRo9TMjqPy1Lv8Hy79dyesRdbM+J8KyGbfWwAjJdVlBFfSejzWAlWMxJsfvjsmx
+        EJPj98QkjJzJcPmoXIhLW+qt2vdBx7k5G1z9mCPzarRE5LPBO2tf9FCLVr+79vvf3yMcbxhNAQVy
+        KwrxZ57UnxII7rcfKCHJv6t+1Bspt7ibkQiHrFLE/7LxIydQKxHyMihOjt9N9sSCQ7t3IgoObccK
+        /NAfR9Jx7Lokcrz94kS7t/H4f6MiJzK0e6Ypm6YJ5IoiV2vmOyLwqTdoiu6OrP4Pk3TN6QDDeTxy
+        144HbIvdpYRSd0XI3uQV+yI0jB3i2ltAPOiPh0lBXRWEkNCXPg7b7cNmc0vldHjZpVEjLZGsOIlW
+        pWUlA4yVvnW7ZOcuYpfRS801oo+0FZe87zcUvmWWMn+SvBK4K74OZ7EbOasou5zlArKfUxxJ575F
+        n+6k5ywktrlKb5nsXWSOq9OufPllJ7XKUTfJyMHeTnKNI+/5Lg4gB95Fr3P0J8T2A7yTvMKRN346
+        k/AoDknWaHCNP4GKfX/nWFWe1bjX2klc44jrZ7shMznaz44HCgulI2k7aC8VovAd1l4RTg5Y8Iy2
+        +11pHvhgNrMlAa+jk4CQ415ztwXwWrocxV4U76bntdRzsXVNlzW7u/CaatODafj6iR68+tJjCmPH
+        JRK2rCRDZlS81hqg5E+93aPyijvpd7NqgY4yg1fWOLdggic8BK25iOcApT+W0nMKGRGvo+xdX9aw
+        5jGCsw3Je/prU7ANeunSc+74/fnkzXmhg4D5fen1Mpo1P6GHDQLfj2DpTyFngYdR8UBfdBtZdU1o
+        3JchCaQZ9vCEzAh7rMCIzXWPTF/CZ3GCRznbRF0GER7RLiGB3Pdl+lc6oQbRm0JY8bLzjRqPbOOs
+        1/iUNfDInjgBucWuu5yCR/QYLNr2/aXHaTyKvUa9Wc8aeOianQxRjccKoHDBXqUw0eVyTB64Ljud
+        Kq0eHWVE5qZqsBROietuakdX1qwmgmgyWYbUNfQ2jlUxAh4xejI2yVGSkw9rmHkTwHwtxuproaDT
+        zhxK5yHrnGXI6MZmGHBudkd4ncdy0GaBptXb7YE6j+1xQM/yjP0A/AjWDZgj49H9Z+z5u29NlTWM
+        LQfsmh7flM4dL77b3ZPXQNsfUaNtEt4aKrwKPgXYAoo9xuW1U5/h32D9t0cvXmVd7PpS3Y123xor
+        vDZPY3xLnN30vJpPKtlx6yfwrW5hMGjv7sHr+cyzHBt0Qo9HzX0vzEy4wmt54ARR7P/2225xDWXN
+        IW579BSw1Pipd767G3p8vYR214pw3zTnQFl8RbCcT9b0Ssl4LB788kv4g0x/Djabin8/KLGGZ/bK
+        SZ++0H8l9iuz341MSlGUt8j+03M022erc9Fsc6R/jvQpZ1skxeODbon4cTSPRbtSKdufsvaXMh6R
+        u6jkR1O4xdHi+2xqpOa6T6qfiPlnzvVTsJiQuQD1k9a9NiNdGs3ZUHQ19SrbkbC+KtMfEYNJ9b77
+        Uw+oVHlcRd5VXRaon6LKCcw1pVSD4CvXlJryjJicvbFJtf1MONLTwiJIVk377R5bc7iKbfrrWLP5
+        a6iMv1UIWLwgFg4j6W80tSJzsQIFnCbU7EF/MgIU3+69FLoggURTwH7a8ofZGg0JGWI39IWiEljK
+        sqaPdvPa8fxy56PLvA2+Aj1xD5fnPn2NpZ18zaNUOKXf8igVGtmXPN7E4LiPD2zJsmr6SJusPPP3
+        nj8PHdHDxN6q6YMyH3thdnycvvlyQzybvX29Kcnlio6++zLI6L7LA7oIMrlrx5uUx04QRsOxH3ui
+        1Gb9wOYJpYU0i4hN6Q+xvlkCwz4GtR8u5/gPD8u22d/Mg3LeGZZ1eLqB47O8/ALTHTDpYNC9KD7r
+        vpcdZ/mOp3fYFx/2SAg2RP/T5AVLv6GfOXsamF6Ui8Z28OsQej89ce7Ywq1uRc4NYSu4MA7G2Hqd
+        NVyEJ+Ve82cJtEUmfiBcFKw3v+DJHx3hBrsxUU1oZaWNWn43c1ldExLXhMTIEBEjQ0isIRGxhsQj
+        V4QjV8Qj68KRdbGAQmJVTKwJ0dDEaGhCNDQxGmpVyEZVPLKQWBMTq0KcVTHOQvlyxFOETChiJoTE
+        qphYaJ9i8xRRCgmFuhCrQmgQYntAQkUgsSJ0TTiwJgZMFQKmitkQoovE6GpCV9LErqQLR9bFI+tC
+        nnUxz6qQDVXMhhgMMRZClFEOykKzUHNcVDiyKh5ZF3qdLvY64cDicZHQOlFOuBIPnDOy0O2Q2O80
+        oUa0HJUIsUBiLIRmIbYKofOJfQ8J+UVifjUhEpoYCSQMmVC7/egnJJE8ZR9RSkueHz1vkWDXxrXx
+        yCByFY0tWbcUUzYtVZWtkW4Sm9gVXa8IFg97dnvBooJ9KZpJPDSrfKzYaHgbMJCJlaoi63ZVBakM
+        VR7pY022kWrVNIJ1m4XybTD26vZtYNQqqhgM2vAWYNApBMKm1S8UZkOEN2FcsVQLE2zIRFFGsj4a
+        Y7mGR4asWKNKtaIb1tgyBILt2e3btGgYOVqkDW8BBhrXkG7YFZDFpI6qKTLWDU22LKIbKhqbuiHy
+        7z27vRQM9oX1RHD7HhocaxMVAcVbwGPZNYJrIJhWMUBOpBqyielHAUm1qiKsKkg3BfDs2e0bw5+Z
+        E/3MV4Liin6DPyLpRx4DQr/YzLL7kHLsxbOhdUOSb87Ti/SDkCi5ysiJvU7lzObYorUpubI58ter
+        x8f/AwPl48w5YAAA
     headers:
       Cache-Control:
       - no-cache
@@ -3771,12 +4766,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:57:11 GMT
+      - Thu, 21 Nov 2019 15:44:48 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -3786,9 +4781,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 4f2af5707cf663a11e39f837b9063db3
+      - e4f155c5a5ba5d8213a597ab19a505bc
     status:
       code: 200
       message: OK
@@ -3804,82 +4799,93 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYuIXYPPPHuGxyV0gbEiY2Z3JuoQtiC/GYvwgyYR892vJ
-        NggwhEwew85O1RBZ3ZK6f91qPe2HnOMNSa76kCO3HvZz1RzybB/f/juwb4rEH+UKOQ+NMeSHOAjN
-        wEKeOXTuwsjHlETMEPkjHOaqQ+QGuJAbEtfGvunYuaoXuW4hZxEv9Imbq4Z+BPQoAOoE+2MnCBzi
-        BbmqrOiFXGBdYztysRlFtCg0Np64KMQiHljIQqoqKqqhihWEy6IuD0uQkku2ouiGbOmGKmkWQlpJ
-        r0hILmsgGLad0ESuS26xPZeNCg86molClz2h7pLIFnpxPhSbENex7oF2hALHEjo4vCX+DWMAanCN
-        fDxXjAz+h62QaSrLUiEXolECRpCyIMuF9KeH3JLCwJtgHXPZTgC63idixXl8eoFleD+hgtt4iCI3
-        zD0WVmpmUCZ1y6sVbzTsWj5tUJm3Ri2We7wq5K5JEFok8kJWeWIoXTOMoSJZomEjTdQMvSLqYDOx
-        JNnIwLZhaCWVQheiMAIJc4CkhV1AMTaHmTQyCXIUwQS9JKUUJ9GAJosh9tDAxQG2It8J74sWGQM/
-        csMUcROkXBh6YjkiVC5GE5egZfubIIlPNSiVVbWi6xKoEjpj8G00nqTZhqSWEnbs2cu51yi4GaTe
-        DA8oAlcLfeTMXTx1s6Sl2HRpJquPZj1CaScIiX/PPCRJx+4k6Qo0ltrSTOxh+RiFYGjTho6xrIGL
-        oG+Oie0MHWudJxb8eQbj7ZJtvLjD+syfN1gi9Zq4E6AgwGGqDM3m02mQ2cnwE5+MfBxQkWRJEuH/
-        oQJ/4X/iVikDlPIxc1hJWqaEJERuku9FY9DGugkgVgUOhC9sJxTGtYEW4CmmMiVd4iHnQNBiiiY5
-        pQWPC3+hNYn22IQqrVHlrVRlK1XdStUerx4XmbFkFoEITlNx/IcEBEtWeAzBMxqz5LUzumYJCwqC
-        a7lxLrOdZ+M7qhLYeBq54Kdo4LjAhQMeBDDvxI1GjpcESkU25jmJzTtgjigQer93hGAeiRfCSnP+
-        IRo7Lo3OXeKHKS91UNp+KhCPorzcuCTL2mrjJ/V2V7hIA4Bwjr9EkIS/YxJioYHojxNYLgniEW+r
-        XL9iCoO7IpGyWSJFKqmrEh0DukILIsS98FuEXOjS2BYaZIwcT+gAi3DQ+q3RyYOIAXEj2tm/TSx1
-        o1hKSVGkVbEu6t3DEw4qMFg0mYAh4nDw/PY16jnQnydphEgeXYdGmfh56LghNTF1qEQOyl10aJsQ
-        Dm0aHFIJazS+CCeNHDfpeEgDGUQBiLS00Ig2nvskiQYSh1cP+qN4MH/QHsX8g/o4f5aVx4PCzqz5
-        n3ip0pYkWVG1UrkiooFli3goySLNEMsV3aBZNAeG8hyBoRzBGEC1zeEvdHxmv2MUWtf0KU4AKiOf
-        RJNUa77v3bMpQUKIrVBEMDg5gwhmb8VBJmxH0QiGry+7Avcn1fjq5xiWq5+zde5cto+a50z4Oxd7
-        oxCiiKy/i5L4DgZ9mPwNfeCgszcT4sQUBRma12udfq0nNOMSQistkYmD7ZOJDeMxEF0Yq6n8dLiH
-        RzbU5a42avcCZWLRzQmybtAIb1ahO2fYSfC4FGQ0lER5WgE8f7iGQczsQh+DXunDmP8mWt35eFit
-        N88vxHo9SyegCDV76gQwIdrZLes1MfZIMXXQ1Zz8T//M8lVg+x3+iScN4cDBVQGeYSKhipKef59u
-        OYdjExZ9vq5v7qfZymMYSfuXAogAUxuIuzEGMMFR5fy+9F/iZ7r+2Xlzr/vuJFPqbnMn8xUz4+pF
-        8+PF+zilNcVFH91madDfTYM/D4BzBqEmLx7IhmHMFOmTJF8xd8zHXfJBK8D4uhvfJgfuN6G7yiUR
-        FjLlQvJUhiUBDLnvhVQQmAMUYDPY5Kn9Xk84Ag6hl3Ds3n0/fy4mHfiXTP0rxdKamjBnAtYR+30V
-        T6Ya0h0ZArO47VpeJFwv0jRTUa2ovLOiU2xBQxt7Aa9tn7HuOFBBSeUfzerB5ax7Vp+1ZsezTiN/
-        eH5aPThrzS5mH2aXcUYdWOqzy/NZnT6zfvJNJfMbuk6zelwQmtXWGqyv3DeexvH58NX61YPTWW3W
-        yR/WQNvjWXt2CsmoetCZ9Wbt/GGdprqzev7wZJ6qpak5li+rZhOwUGunIMBv7Y2hVXeIO1O1KP3V
-        g4+6Y/Rhuv71Q5D6nBi0rPNze1IVSh/GEYXFk49JOEmiycc4mEAsmZ3DQ9JvnlfoO4cfdVcMvwk6
-        GkA6EEBOZ904hJzOjvOH3XOay5KXLG6c5w97FK86iyjHQOqwiJKkammKB/iVq/6uwSpe4nxoZhng
-        w67TyaRrPrWi+dBcXc3Acu5NlnKL3SrTxoHlO5NkN25NR7qDzDbvXnvu/wqiz8HKEnzOJpxzbHuh
-        wrqXJediJrLibc11fRoxx+F/PVgNCrWYL9ifNeP64tdWTOy6DsnSpskI+7wGnksfl31ShbfoIm+6
-        S4GmyHGpDFm6JUrVOJ49sQuLx83Gkcg2kzYJ3kAhohPM191y2qu94STnOhpsxuGYEffEconACa+J
-        wTwbZjbNJU6hCZy7qpEUDQTkY4F38Q4REgEEJ4Bh9kvk+Oz8Bwg3LKbi7KJviQW2zcG9OUbuLcpc
-        GjRTNuHoXmjP2fbLoLESHjsKfUqHTsr1XVRgB3DJrZ91QY+Ts3x6VlizbXZK/+0BXTaUolzWi3JR
-        KcgVmi7Cj7hISlJBluifYgmmzIpWYNLhOwTzFsxuC7zfFv5JrV/LQIRmPzOCip9q4h9I/HolLkfU
-        1fwNEZa1uDYHlmWxJkpySX7PYw0Q5Sgbk6N3x+QoE5Oj98QkCJ2ROT8rz8SlLfQW9F3QcaYn/auf
-        N+i8qC1W+aT/ztbPOtSi2e9u/Yvv3yMczwyvAQV8mxXiTzzh4hpDcL/dowXJ5lF1XwdSbnI3xiEK
-        WGaW/HPiPi+gFipsWkFxevxlVk8sOLR7razg0HYsnwRkGApHkevi0PF2ixPt3srx/0rGhsjQ7hmG
-        aBgGsEuSWNGNd0TgrNdvZI2OLP+HWXRNaAXmJBq4S3dT19XuUkahu2Bk1++y+yIQhg527TUgHrTH
-        wzihLBKZkNBLH4ft9mGjsWZyWr3o0qiRpHCaHIWL1DyTAcZSL90u2bqL2GX8QmOJaZ+24uILf2bm
-        LbNE+FZ8J3BbfDXHkRs6iyg7b+UcVj/HKBROiUVPd5IrwQLbXKVDJrtRyUl13BUvP27lVjjuBh44
-        yNvKrnLsPeIiH9bA2/g1jr+FbeKjrewljr3+64mABlGAU2KZI/4KJiZka10VXtSo19zKrHPMtZPt
-        kBkc7wfHA4MFQlVYD9pzg0h8ATyAav1pfGs3vhDMC9q+6AoTn4DbjOcMvI1aPsZHvcZ2D+CtdDmI
-        vDDazs9bqeci64ZOa7YX4S3Vpq9PoJsnSvDmS+4WDx0XC8iy4hUy4+KtVgcjn/W218obrnXRTbMz
-        bJQ6vLQkuQUNPNFD5KUu4jnASYbMiA47CmBMvI3aTmAVU8JSj4nLCDYOsZVEL8akLTXBNuiFS8+5
-        4/fn42vJmR0E3O9jr5fyLPUTemXaJySEqT+FnAUexsUDfd6tp9l6pnNfBtgXxshDIzzG7FiBMRvL
-        PTK54cziBI9yuok6DyI8ol2MffGCiPSv0KIO0buGsOKlb+GoPLL1k179LCXwyLYcH98i1503wSN6
-        BB5tEzLvcSqPYq9ea9RSAg9do5MiqvJYARQu+KsQxLac18kD12XvUAmLo6OUyVg1DRKCa+y6q9bR
-        pCWvCSGajOYhdQm9ldcAGAOPGH1/K16jMNIyZt4IMF+KsdpSKOi00w6l8ZB1TlJktPJqGHCm2yO8
-        xmPZb7NA0+xt74Eaj+2RH9HIQXzoRzBvQBwbj+5/Io9sH5pKSxhbDvg1fXdIOHW86G57Sd4CbTKg
-        TtvAvDeUeBOc+cgCjh3q5a1TG6OvMP/boRRvsi5yiVBzw+1DY4m35nGEbrGznZ83c6uUvhT4BL6V
-        NQz67e0leDufeJZjg03oSx4T4gWpC5d4K/cdP4zI16/b1S3zlv7jYvtMoCw/vt4ydts8cNfFzYE0
-        +yTDJD6eyUuF8mP+4PPn4CeR/hyskvK/HBQY4ZmlNiyaPtJ/BfYrst+V9ZMkSW+x5k9en1l/nW8j
-        mm2O9e+xaNqwGZLgsacbISQKJ1HWXlQi9llK/1bBQ3wXFkh4DQMbTb7PVkbirrss8GM1/84r/AQs
-        puRGgC5i6k5bkC6N5qwqOod6lU1ImFUV6U+WgHH2rrtSD3Kh9LiIvIu8NFA/xbUhMOtSQYfgK+qS
-        Lj0jJqf3NKm1nwmHT0JiETcLkgVptz1jawJPkU1/HWs8eQ2T8UNFhojn2EJBKPyLLqjwJNuAGZLG
-        3Ox4P64Bkm93G4VOSGB5mSF+QvlhNkQDjE3kBiRTVQwTWEbat8Fry6nl1gPLTdt6MMcdUj1PCb28
-        0o7fOS/kjukb54VcPX3f/E0cjntxek2XBWmftlZ54e89MgmcrCPE3oK0p8JHXpC+NU7vu0yxZ7M7
-        16uaXC746I2Xfsr3XY7lQli/3TjeqDh0/CA0hyTyspY2y69ptigvLLNwtiv9EPObOTDs+yO74XKK
-        fnhY1t1+OvGLm95cWYan6zuErcvPEd33Eg763fP8s8a99CWW7/jODvvMww4LghXV/zbrgnm/oV/W
-        eRqYXrgRjfXg18F0PG05d2ziVrNCZ4rZDC6I/CGyXmcOF6JRUa2UdBnRT3GVkSRqChqKhl0eiNpA
-        1suqoSi2amSotmOxbzgfZB8omyI3wqYqy8DA0uuE9S2uAIfiNftERJLySPg8MCRNregaKouKZMug
-        1UAS0VDGooRwWZWwbCmWlQHGjsVeBkZJz8YC8t8CCtYCdGM8ot+zKrOvSa3qncXzQiVLygYtgfAm
-        FpcrdsUoySLWFE3UMJZFpGtYlIdYGiqGgiV7mGXx3Yq9DIxKqZwNBiW8vc0rOmt/u9ETppcpqslq
-        tqKU8BaKllVcQhhh0ShXIHrpykDUdRuJmqUOtYE1qNiylqH6jsVeBgb95mE2GozyOnBc0Y8+hjj5
-        XpOP6cfC2JAdUKm9aGxaUxx/5JA+JN92kuOnlB0m/0tczniCLJqbsEurNX+6enz8P02hOy2qUgAA
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8c0eAbHIbGC4QZu5mc5SwBfhibNaPPDbku19L
+        tkGATEgmyWR3p2qILLWk7l8/rJYtPxQcb+wXjh4K/q1HgsJRAXt2QG7/EdrXZT+YFEoFD88I1Eck
+        jIahhb3h2LmL4oDQJn8Y4WBCosLRGLshKRXGvmuTYOjYhSMvdt1SwfK9KPDdwlEUxNAeh9A6J8HM
+        CUPH98LCEVJrpUJoTYkdu2QYx7QrTDabuzgiso5HBsKjkVyxkCEj1cQyIqot46pSsxS7MtaQboyr
+        tYqBqhXTUAxlXAXGiO1EQ+y6/i2xl7xR5kHGYSrQZU9quH5sS72kHrrNfdex7qHtGIeOJXVIdOsH
+        14wAWsMpDshSMH/0P2JFTFIVmaVChCcpGGFGgi0Xyl8fCmsCK6UM64TKdkKQ9T5lK6njyysso/s5
+        ZdwmYxy7UeGxtDEygzIdG20OnKvYrXom0nI2qrHC41WpMPXDyPJjL2KDp4oy9KqFq2ZNtglSZb1G
+        VHk01lRQV1XTVF1DSkWh0EU4ioFDKPjzuePRaZgtpZPMwwJFMEUvLanleTyixXJEPDxySUisOHCi
+        +7Llz4Aeu1GG+BC4XCl6bjkyDC7Hc9fH6/ofAicBlaBS1bWKUq1WYV5nBraNZ/NltVkD+ac4vB5l
+        dgsXOAajigLsLI05M6h0TKqkRyB1QMjgnik+LTMrQUgxNBNlKhqmMFsBwRHob2iDva8z5mJwuZlv
+        O2PHEtAwLp+nBx5usU4SPwyYmeYAnBlDYts4DEmUCUOrs3LKmWpXTa1qqrJhgN/qtSqRR6oylomG
+        rbGq6shWUSHpmUWavbQ/D/xJQEIqAFIUGf4fqvAX/qe2lRFAr4Awq1WU9ZbIj7Cb1nvxDGS3rkMI
+        WKEDMYyKy1oYVU5bSG4I5Sn1i4eCA5GLwZJ5irYicuEvTKdQv02b1a1WxLWirVaVa1W2WrWdrfrj
+        1eOqEkY3KBp+QA1KAzaTGwFlGMImY20GYTSeMT6mzmTKBrWgM1ijyy4SdXs2uaNigVncxC6YNh45
+        LlCRkEcCxpu78cTxUmdgQTOtSRXfAZ3EodT7d0cKlzF5xbCypB/jmePSON31gyijpTZN588YQus4
+        c5Orqmnom5P3SHDjWERqkgjiOjjbU3NnHWyuAz+/uq5JXngFKdXN+U/7/a5ExySB1Ac3lSAuSwMQ
+        aw9WPpNR2nUTBG0XE2gLhLNGuyv1s3goXZBfYyjC35kfATSY/jih5fphsgDYydVPhNqCu8GRvoMj
+        1diCpdc7zUNFOgOLDWb4NZRV2cVVbYurfoAtEvgx4PEMJsSAGPlTq0pF27IT8DnpBG4199K/YuzC
+        vYHYUtOfYceTOkAiHZz8q9kpgs5C341fzlY1ly1VVw1liy1QTtAnd5EE2HjhGPTVDfzIt3xXOqC2
+        XXwOUvkGXctnq6KqW2z1G93DM86kIbrE8zlEDQjhL4LFzJ0fbrIICb26TaKpb4dSPVmQSgcAlWQ7
+        AVgiLA6KLwcDKbncVBWjInSmujvxYarpLGS+dI69SYwn5BnAtCEClDc5QTs5qe1w68ZxQ2r7NpEa
+        znwKMkotdrtfZwPtyUZ+0K0iRd+641A2PhN8LbXrDR6Zb2EhP+SaioaEOmEscNOLVaHuyYBO78Sw
+        SJpni7T00nWwZ5Hkeuy4EbUneoNOGaHUZYdOCStSm8qfsVinSzzprFng0rmHbC0JSytY7NJOEzp7
+        4asiQ5I2vnqoPcoHywv9US4+aI/La1DUQWlv0uIPPFfZTApSNb1iVGU8smyZjBUk0wrZqNZMWkVr
+        IEkq+OBuGDyNSlsgv9LMh/1CKLKm9CopACoTCOnzTGp+LXPPkq20IVFCGUMy4IzgFhCWR0LYjuMJ
+        pAu/7gvcf6nEVz8msFz9KJa5c9k+bl0w5u9c4k0iWJWh2rsISe4gnYK0ehwABc2Lh7DuusGhQPJG
+        vTOo96RW0kM6yXoIcbADf25DSgSNLqRLlH+aXsElyzYKV7nSfYMwCevDObauIfjli9BdEuzFeNIL
+        KppqKjwdAK4/TyEzGHbBx8ArA0i73kSqu4CMjxqti77caIhkghapbt84Idx29jbLRl1OLFLODHSz
+        pvjDX0W2CmT/hn/yWVM6cMiRBNeQnWmyUiu+j1su4cjDYsCP9WI/FQtPIDMZXErAAuSLEHcTDCBr
+        1FDxo/ivHwhN/9NF60P77lzIdbe1l/rKwrjab33pv49RWjekHOBbkQSD/ST47wFQLiDUFOUDZJrm
+        QlW+KuiKmWMxcckHvQT31/3o8gx40AJ3RRXZrFWNUnplyLCKqhjvhVQYDkc4JMMwz1IHvZ50DBRS
+        L6XY331/+aWcOvDfhfJXy5UtMWHNBKQT9vsqlkwlpHvdPiQau6Xsp1TfJKlQUL2svrOgNyzxyfUC
+        XtoBI93zRgU91b+0jg4uF91PjcXJ4nTRaRYPL86PDj6dLPqLz4vLpKIBJI3F5cWiQa+Zn7yoZzHH
+        dVpHpyWpdXSyBesr+8bTOD4fvvrg6OB8UV90iod1kPZ00V6cQzE+Ougseot28bBBS91Fo3h4tizV
+        s9ISy28bJg9YGLVTkuC3/sbQanvEnRutrPzeg4+2Z/Rhsv7+Q5D2nBi0LvNzPekIeh8mEYXFky9p
+        OEmjyZckmEAsWVzAReo3z+v0ncOPti+GL4KOBpAOBJDzRTcJIeeL0+Jh94LWsuIlixsXxcMexavB
+        IsopNHVYRElL9azEA/zKQ3/XYJWkOJ9bIgV83nc5mbrmUxnN59ZmNgPp3JukcqvdqqFNQitw5umm
+        8ZaM9LEc2/Z+7bX/K7C+BEvE+JJMuuDIPoQI21aWvnEwxFayr7ktTzOhOPzZg2xQqid04cfJGbeT
+        X1sdEtd1fJE0LdbwkXPgJfdJ3ydFeAsXedNdCnyDHZfyIJItFarO0XwQvbB43Goey2wzKY/xJo4w
+        XWC+7pbTh9obTmum8Sgfh1PW+EE0lzKc0g4JqCdnZdNao5RaQLmvGGnXUMIBkXgT7/hSyoDkhHCb
+        /TV2Avb4BxquWUwl4q5viQWxh6P74Qy7t1iYGrQyMun4XmovyT6WQhMhPPZqyVMydDKq7yICewCX
+        vk+5zehp+oIUfZxdt2326tPLAzoy1TIyamVUVkuoSstl+JFXRUUpIYX+KVdgyazqJcYducOwbiHs
+        Faz328I/qw/qAkRo9TMjqPy1Lv8Hy79dyesRdbM+J8KyGbfWwAjJdVlBFfSejzWAlWMxJsfvjsmx
+        EJPj98QkjJzJcPmoXIhLW+qt2vdBx7k5G1z9mCPzarRE5LPBO2tf9FCLVr+79vvf3yMcbxhNAQVy
+        KwrxZ57UnxII7rcfKCHJv6t+1Bspt7ibkQiHrFLE/7LxIydQKxHyMihOjt9N9sSCQ7t3IgoObccK
+        /NAfR9Jx7Lokcrz94kS7t/H4f6MiJzK0e6Ypm6YJ5IoiV2vmOyLwqTdoiu6OrP4Pk3TN6QDDeTxy
+        144HbIvdpYRSd0XI3uQV+yI0jB3i2ltAPOiPh0lBXRWEkNCXPg7b7cNmc0vldHjZpVEjLZGsOIlW
+        pWUlA4yVvnW7ZOcuYpfRS801oo+0FZe87zcUvmWWMn+SvBK4K74OZ7EbOasou5zlArKfUxxJ575F
+        n+6k5ywktrlKb5nsXWSOq9OufPllJ7XKUTfJyMHeTnKNI+/5Lg4gB95Fr3P0J8T2A7yTvMKRN346
+        k/AoDknWaHCNP4GKfX/nWFWe1bjX2klc44jrZ7shMznaz44HCgulI2k7aC8VovAd1l4RTg5Y8Iy2
+        +11pHvhgNrMlAa+jk4CQ415ztwXwWrocxV4U76bntdRzsXVNlzW7u/CaatODafj6iR68+tJjCmPH
+        JRK2rCRDZlS81hqg5E+93aPyijvpd7NqgY4yg1fWOLdggic8BK25iOcApT+W0nMKGRGvo+xdX9aw
+        5jGCsw3Je/prU7ANeunSc+74/fnkzXmhg4D5fen1Mpo1P6GHDQLfj2DpTyFngYdR8UBfdBtZdU1o
+        3JchCaQZ9vCEzAh7rMCIzXWPTF/CZ3GCRznbRF0GER7RLiGB3Pdl+lc6oQbRm0JY8bLzjRqPbOOs
+        1/iUNfDInjgBucWuu5yCR/QYLNr2/aXHaTyKvUa9Wc8aeOianQxRjccKoHDBXqUw0eVyTB64Ljud
+        Kq0eHWVE5qZqsBROietuakdX1qwmgmgyWYbUNfQ2jlUxAh4xejI2yVGSkw9rmHkTwHwtxuproaDT
+        zhxK5yHrnGXI6MZmGHBudkd4ncdy0GaBptXb7YE6j+1xQM/yjP0A/AjWDZgj49H9Z+z5u29NlTWM
+        LQfsmh7flM4dL77b3ZPXQNsfUaNtEt4aKrwKPgXYAoo9xuW1U5/h32D9t0cvXmVd7PpS3Y123xor
+        vDZPY3xLnN30vJpPKtlx6yfwrW5hMGjv7sHr+cyzHBt0Qo9HzX0vzEy4wmt54ARR7P/2225xDWXN
+        IW579BSw1Pipd767G3p8vYR214pw3zTnQFl8RbCcT9b0Ssl4LB788kv4g0x/Djabin8/KLGGZ/bK
+        SZ++0H8l9iuz341MSlGUt8j+03M022erc9Fsc6R/jvQpZ1skxeODbon4cTSPRbtSKdufsvaXMh6R
+        u6jkR1O4xdHi+2xqpOa6T6qfiPlnzvVTsJiQuQD1k9a9NiNdGs3ZUHQ19SrbkbC+KtMfEYNJ9b77
+        Uw+oVHlcRd5VXRaon6LKCcw1pVSD4CvXlJryjJicvbFJtf1MONLTwiJIVk377R5bc7iKbfrrWLP5
+        a6iMv1UIWLwgFg4j6W80tSJzsQIFnCbU7EF/MgIU3+69FLoggURTwH7a8ofZGg0JGWI39IWiEljK
+        sqaPdvPa8fxy56PLvA2+Aj1xD5fnPn2NpZ18zaNUOKXf8igVGtmXPN7E4LiPD2zJsmr6SJusPPP3
+        nj8PHdHDxN6q6YMyH3thdnycvvlyQzybvX29Kcnlio6++zLI6L7LA7oIMrlrx5uUx04QRsOxH3ui
+        1Gb9wOYJpYU0i4hN6Q+xvlkCwz4GtR8u5/gPD8u22d/Mg3LeGZZ1eLqB47O8/ALTHTDpYNC9KD7r
+        vpcdZ/mOp3fYFx/2SAg2RP/T5AVLv6GfOXsamF6Ui8Z28OsQej89ce7Ywq1uRc4NYSu4MA7G2Hqd
+        NVyEJ+Ve82cJtEUmfiBcFKw3v+DJHx3hBrsxUU1oZaWNWn43c1ldExLXhMTIEBEjQ0isIRGxhsQj
+        V4QjV8Qj68KRdbGAQmJVTKwJ0dDEaGhCNDQxGmpVyEZVPLKQWBMTq0KcVTHOQvlyxFOETChiJoTE
+        qphYaJ9i8xRRCgmFuhCrQmgQYntAQkUgsSJ0TTiwJgZMFQKmitkQoovE6GpCV9LErqQLR9bFI+tC
+        nnUxz6qQDVXMhhgMMRZClFEOykKzUHNcVDiyKh5ZF3qdLvY64cDicZHQOlFOuBIPnDOy0O2Q2O80
+        oUa0HJUIsUBiLIRmIbYKofOJfQ8J+UVifjUhEpoYCSQMmVC7/egnJJE8ZR9RSkueHz1vkWDXxrXx
+        yCByFY0tWbcUUzYtVZWtkW4Sm9gVXa8IFg97dnvBooJ9KZpJPDSrfKzYaHgbMJCJlaoi63ZVBakM
+        VR7pY022kWrVNIJ1m4XybTD26vZtYNQqqhgM2vAWYNApBMKm1S8UZkOEN2FcsVQLE2zIRFFGsj4a
+        Y7mGR4asWKNKtaIb1tgyBILt2e3btGgYOVqkDW8BBhrXkG7YFZDFpI6qKTLWDU22LKIbKhqbuiHy
+        7z27vRQM9oX1RHD7HhocaxMVAcVbwGPZNYJrIJhWMUBOpBqyielHAUm1qiKsKkg3BfDs2e0bw5+Z
+        E/3MV4Liin6DPyLpRx4DQr/YzLL7kHLsxbOhdUOSb87Ti/SDkCi5ysiJvU7lzObYorUpubI58ter
+        x8f/AwPl48w5YAAA
     headers:
       Cache-Control:
       - no-cache
@@ -3890,12 +4896,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:57:22 GMT
+      - Thu, 21 Nov 2019 15:44:58 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -3905,9 +4911,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 27ab6f14582bb6ba631daf425e975617
+      - 655ce4e825c80b8a57debb47388d6f0c
     status:
       code: 200
       message: OK
@@ -3923,19 +4929,93 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110/history/10829038
+    uri: https://cloud.tenable.com/scans/219
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAzVQy27DMAz7F5/rwM9E7ql/Eiiy2nVL0yCx0RXD/n1Kl94IUqIo/qj7Y+Klv2Z1
-        dAe10gfnOnJf68aowrd5xMKaB0JC77XzyesOudVgz1GQjdk5SJYgeRMIMUToDNo2KPErWOoqRoQT
-        8ch54wT3IixFHW1sve8AjD3sQfbD3EXKBKwHB6gD+k5DIqdbii2DjykaVPuOjOOUF36c1vzV3JeL
-        CGJ/4bJd/keumeuwwabwhMPIK1NdruXZ0P22GQ2fTOVVgzXgkvFwUHsWCCmdnSGdMgYdEkgW6UNH
-        kzFxTilE//6Lp/z+SjzizpbnzGI0rzI24Y1fza6lf4nn63epC6vfP9arnKWMAQAA
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8c0eAbHIbGC4QZu5mc5SwBfhibNaPPDbku19L
+        tkGATEgmyWR3p2qILLXk7l8/pJYtPxQcb+wXjh4K/q1HgsJRAXt2QG7/EdrXZT+YFEoFD88I1Eck
+        jIahhb3h2LmL4oDQJn8Y4WBCosLRGLshKRXGvmuTYOjYhSMvdt1SwfK9KPDdwlEUxNAeh9A6J8HM
+        CUPH98LCEVJrpUJoTYkdu2QYx7Qr3Gw2d3FEZB2PDIRHI7liIUNGqollRFRbxlWlZil2Zawh3RhX
+        axUDVSumoRjKuAqMEduJhth1/VtiL3mjzIOMw1Sgy57UcP3YlnpJPXSb+65j3UPbMQ4dS+qQ6NYP
+        rhkBtIZTHJClYP7of8SKmKQqMkuFCE9SMMKMBFsulL8+FNYEVkoZ1gmV7YQg633KVlLHl1dYRvdz
+        yrhNxjh2o8JjaWNkBmU6NtocOFexW/VMpOXdqMYKj1elwtQPI8uPvYgNnirK0KsWrpo12SZIlfUa
+        UeXRWFNBXVVNU3UNKRWFQhfhKAYOC4CkRVxAMVHHML3JPCxQBFP00pJanscjWixHxMMjl4TEigMn
+        ui9b/gzosRtliA+By5Wi55Yjw+ByPHd9vK7/IXASUAkqVV2rKNVqFe7rzMC28WyeVSOkmCk58ez1
+        2ikOr0eZNcMFjsHUogA7SxPPzCy9U6K6rJKNR6seobcTRn5wzywkLTNzghsZmokyXQ5TfVgBwREo
+        emiDY6xL4GLwzZlvO2PH2qZJGH+ewni9iJWXOGzA7DlHE5nVJE6Aw5BEmTC0OiunnKl21dSqpiob
+        Bji4XqsSeaQqY5lo2Bqrqo5sFRWSnllI2stM5oE/CUhIBUCKIsP/QxX+wv/UCDMC6BUQZt6Kst4S
+        +RF203ovnoHs1nUIkS10INhRcVkLo8ppC8kNoTylDvRQcCDEMVgyl9JWRC78hdsp1MHTZnWrFXGt
+        aKtV5VqVrVZtZ6v+ePW4qoTRDYqGH1CD0oDNZMagDEN8ZazNIN7GM8bH1JlM2aAWdAZrdNlFom7P
+        JndULDCLm9gF08YjxwUqEvJIwHhzN544XuoMLLqmNaniO6CTOJR6/+5I4TJ4rxhWlvRjPHNcGtC7
+        fhBltNSm6f0zhtA6ztzNVdU09M2b90hw41hEapIIJgBwtqfunXWwuQ78/dV1TfLCK0ipbt7/tN/v
+        SnRMEkh9cFMJArg0ALH2YOUzGaVdN0HQdjGBtkA4a7S7Uj8LnNIF+TWGIvyd+RFAg+mPE1quHyYr
+        hZ1c/USoLbgbHOk7OFKNLVh6vdM8VKQzsNhghl9DWZVdXNW2uOoH2CKBHwMez2BCDIiRf2tVqWhb
+        dgI+J53AVHMv/SvGLswNxJaa/gw7ntQBEung5F/NThF0Fvpu/HK2qrlsqbpqKFtsgXKCPrmLJMDG
+        C8egr27gR77lu9IBte3ic5DKN+haPlsVVd1iq9/oHp5xJg3RJZ7PIWok093zYTFz7w+TLEJCr26T
+        aOrboVRPVq7SAUAl2U4AlgiLg+LLwUBKLjdVxagInanuTny41XQWMl86x94kxhPyDGDaEAHKm5yg
+        nZzUdrh147ghtX2bSA1nPgUZpRab7tfZQHuykR90q0jRt2YcysZngq+ldr3BI/MtLOSHXFPRkFAn
+        jAXu9mJVqHsyoNOZGBZJ82yRll66Dl3oJddjx42oPdEJOmWEUpcdektYkdpU/ozFOl3iSWfNApf3
+        PWRrSVhawWKXdprQuxe+KjJkc+Orh9qjfLC80B/l4oP2uLwGRR2U9iYt/sBzld1JQaqmV4yqjEeW
+        LZOxgmRaIRvVmkmraA1kUwUf3A2Dp1FpC+RXmiKxXwhF1pReJQVAZQIhfZ5Jza9l7llWljYkSihj
+        yA+cEUwBYXkkhO04nkAG8eu+wP2XSnz1YwLL1Y9imTuX7ePWBWP+ziXeJIJVGaq9i5DkDvIuyL/H
+        AVDQBHoI664bHAokb9Q7g3pPaiU9pJOshxAHO/DnNqRE0OhCukT5pxkXXLJso3CVK903CJOwPpxj
+        6xqCX74I3SXBXownvaCiqabC0wHg+vMUMoNhF3wMvDKAtOtNpLoLyPio0broy42GSCZoker2jRPC
+        tLO3WTbqcmKRcmagmzXFH/4qslUg+zf8k8+a0oFDjiS4huxMk5Va8X3ccglHHhYDfqwX+6lYeAKZ
+        yeBSAhYgX4S4m2AAWaOGih/Ff/1AaPqfLlof2nfnQq67rb3UVxbG1X7rS/99jNK6IeUA34okGOwn
+        wX8PgHIBoaYoHyDTNBeq8lVBV8wci4lLPuglmF/3o8sz4EEL3BVVZLNWNUrplSHDKqpivBdSYTgc
+        4ZAMwzxLHfR60jFQSL2UYn/3/eWXcurAfxfKXy1XtsSENROQTtjvq1gylZBuivuQaOyWsp9SfZOk
+        QkH1svrOgt6wxCfXC3hpB4x0z4kKeqp/aR0dXC66nxqLk8XpotMsHl6cHx18Oln0F58Xl0lFA0ga
+        i8uLRYNeMz95Uc9ijuu0jk5LUuvoZAvWV/aNp3F8Pnz1wdHB+aK+6BQP6yDt6aK9OIdifHTQWfQW
+        7eJhg5a6i0bx8GxZqmelJZbfNkwesDBqpyTBb/2NodX2iDs3Wln5vQcfbc/ow2T9/Ycg7TkxaF3m
+        53rSEfQ+TCIKiydf0nCSRpMvSTCBWLK4gIvUb57X6TuHH21fDF8EHQ0gHQgg54tuEkLOF6fFw+4F
+        rWXFSxY3LoqHPYpXg0WUU2jqsIiSlupZiQf4lYf+rsEqSXE+t0QK+LzvcjJ1zacyms+tzWwG0rk3
+        SeVWu1VDm4RW4MzTTeMtGeljObbt/dpr/1dgfQmWiPElmXTBkX0IEbatLH01YYitZF9zW55mQnH4
+        swfZoFRP6MKPkzNuJ7+2OiSu6/giaVqs4SPnwEvuk75PivAWLvKmuxT4Bjsu5UEkWypUnaP5IHph
+        8bjVPJbZZlIe400cYbrAfN0tpw+1N5zWTONRPg6nrPGDaC5lOKUdElBPzsqmtUYptYByXzHSrqGE
+        AyLxJt7xpZQByQlhmv01dgL2+AcarllMJeKub4kFsYej++EMu7dYmBq0MjLp+F5qL8k+lkITITz2
+        aslTMnQyqu8iAnsAl754uc3oafqCFH2cXbdt9urTywM6MtUyMmplVFZLqErLZfiRV0VFKSGF/ilX
+        YMms6iXGHbnDsG4h7BWs99vCP6sP6gJEaPUzI6j8tS7/B8u/XcnrEXWzPifCsjturYERkuuygiro
+        PR9rACvHYkyO3x2TYyEmx++JSRg5k+HyUbkQl7bUW7Xvg45zcza4+jFH5tVoichng3fWvuihFq1+
+        d+33v79HON4wmgIK5FYU4s88qT8lENxvP1BCkj+rftSJlFvczUiEQ1Yp4n/Z+JETqJUIeRkUJ8fv
+        JntiwaHdOxEFh7ZjBX7ojyPpOHZdEjnefnGi3dt4/L9RkRMZ2j3TlE3TBHJFkas18x0R+NQbNEWz
+        I6v/wyRdczrAcB6P3LXjAdtidymh1F0Rsjd5xb4IDWOHuPYWEA/642FSUFcFIST0pY/Ddvuw2dxS
+        OR1edmnUSEskK06iVWlZyQBjpW/dLtm5i9hl9FJzjegjbcUl7/sNhW+ZpcyfJK8E7oqvw1nsRs4q
+        yi7vcgHZzymOpHPfok930nMWEttcpVMmexeZ4+q0K19+2UmtctRNMnKwt5Nc48h7vosDyIF30esc
+        /Qmx/QDvJK9w5I2fziQ8ikOSNRpc40+gYt/fOVaVZzXutXYS1zji+tluyEyO9rPjgcJC6UjaDtpL
+        hSh8h7VXhJMDFjyj7X5Xmgc+mM1sScDr6CQg5LjX3G0BvJYuR7EXxbvpeS31XGxd02XN7i68ptr0
+        BBu+fqIHr770mMLYcYmELSvJkBkVr7UGKPlTb/eovOJO+t2sWqCjzOCVNc4tuMETHoLWXMRzgNIf
+        S+k5hYyI11H2ri9rWPMYwdmG5D39tVuwDXrp0nPu+P355M15oYOA+X3p9TKaNT+hhw0C349g6U8h
+        Z4GHUfFAX3QbWXVNaNyXIQmkGfbwhMwIe6zAiM11j0xfwmdxgkc520RdBhEe0S4hgdz3ZfpXOqEG
+        0ZtCWPGyg5Aaj2zjrNf4lDXwyJ44AbnFrru8BY/oMVi07ftLj9N4FHuNerOeNfDQNTsZohqPFUDh
+        gr1KYaLL5Zg8cF12jFVaPTrKiMxN1WApnBLX3dSOrqxZTQTRZLIMqWvobRyrYgQ8YvQIbZKjJCcf
+        1jDzJoD5WozV10JBp505lM5D1jnLkNGNzTDg3OyO8DqP5aDNAk2rt9sDdR7b44Ce5Rn7AfgRrBsw
+        R8aj+8/Y83dPTZU1jC0H7Joe35TOHS++292T10DbH1GjbRLeGiq8Cj4F2AKKPcbltVOf4d9g/bdH
+        L15lXez6Ut2Ndk+NFV6bpzG+Jc5uel7NJ5XsXPYT+Fa3MBi0d/fg9XzmWY4NOqHHo+a+F2YmXOG1
+        PHCCKPZ/+223uIay5hC3PXowWGr81Dvf3Q09vl5Cu2tFuG+ac6AsviJYzidreqVkPBYPfvkl/EGm
+        PwebTcW/H5RYwzN75aRPX+i/EvuV2e9GJqUoyltk/+k5mu2z1blotjnSP0f6lLMtkuLxQbdE/Dia
+        x6JdqZTtT1n7SxmPyF1U8qMpTHG0+D6bGqm57pPqJ2L+mXP9FCwmZC5A/aR1r81Il0ZzNhRdTb3K
+        diSsr8r0R8RgUr3v/tQDKlUeV5F3VZcF6qeocgJzTSnVIPjKNaWmPCMmZ29sUm0/E470tLAIklXT
+        frvH1hyuYpv+OtZs/hoq46cKAYsXxMJhJP2NplZkLlaggNOEmj3oT0aA4tu9l0IXJJBoCthPW/4w
+        W6MhIUPshr5QVAJLWdb00SavHc8vdz66zNvgK9AT93B57tPXWNrJ1zxKhVP6LY9SoZF9yeNNDI77
+        +MCWLKumj7TJyjN/7/nz0BE9TOytmj4o87EXZsfH6ZsvN8Sz2dvXm5Jcrujouy+DjO67PKCLIJO7
+        drxJeewEYTQc+7EnSm3WD2yeUFpIs4jYlP4Q65slMOxjUPvhco7/8LBsm/3NPCjnnWFZh6cbOD7L
+        yy8w3QGTDgbdi+Kz5r3sOMt3PL3DvviwR0KwIfqfJi9Y+g39zNnTwPSiXDS2g1+H0Pn0xLljC7e6
+        FTk3hK3gwjgYY+t11nARnpR7zZ8l0BaZ+IFwUbDe/IInf3SEG+zGRDWhlZU2avndzGV1TUhcExIj
+        Q0SMDCGxhkTEGhKPXBGOXBGPrAtH1sUCColVMbEmREMTo6EJ0dDEaKhVIRtV8chCYk1MrApxVsU4
+        C+XLEU8RMqGImRASq2JioX2KzVNEKSQU6kKsCqFBiO0BCRWBxIrQNeHAmhgwVQiYKmZDiC4So6sJ
+        XUkTu5IuHFkXj6wLedbFPKtCNlQxG2IwxFgIUUY5KAvNQs1xUeHIqnhkXeh1utjrhAOLx0VC60Q5
+        4Uo8cM7IQrdDYr/ThBrRclQixAKJsRCahdgqhM4n9j0k5BeJ+dWESGhiJJAwZELt9qOfkETylH1E
+        KS15fvS8RYJdG9fGI4PIVTS2ZN1STNm0VFW2RrpJbGJXdL0iWDzs2e0Fiwr2SWkm8dCs8rFio+Ft
+        wEAmVqqKrNtVFaQyVHmkjzXZRqpV0wjWbRbKt8HYq9u3gVGrqGIwaMNbgEFvIRA2rX6hMBsivAnj
+        iqVamGBDJooykvXRGMs1PDJkxRpVqhXdsMaWIRBsz27fpkXDyNEibXgLMNC4hnTDroAsJnVUTZGx
+        bmiyZRHdUNHY1A2Rf+/Z7aVgsE+xJ4Lb99DgWJuoCCjeAh7LrhFcA8G0igFyItWQTUw/CkiqVRVh
+        VUG6KYBnz27fGP7MnOhnvhIUV/Rj/RFJP/IYEPrFZpbdh5RjL54NrRuSfJyeXqQfhETJVUZO7HUq
+        ZzbHFq1NyZXNkb9ePT7+HzDzuQFiYAAA
     headers:
       Cache-Control:
       - no-cache
@@ -3946,7 +5026,63 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:57:22 GMT
+      - Thu, 21 Nov 2019 15:45:09 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-c-ca-central-1-prod
+      X-Request-Uuid:
+      - 9e9b0d99584b75be14bcc974f44f53b7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/219/history/11063918
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzVQy27DMAz7F5/rwI/YsnfanwSyrHTd0jRIbHTFsH+f06U3gpRIiT/idp95HS5Z
+        vJmT2OiDc514qHVnROHrMmFh2WPyGlOSjrSX2kSUmk2WCCqQym60uvcjBOc1uOiVVyOI5lew1K0Z
+        Ec7EE+eda3howlrEm3bQW6cA4HQccgQzOMoUWCYTsKVbkCGSkZ6c52BddArFsdPGcc4r39+3/NXd
+        1nMTmv2Zy578j0y31LTDrvCMaeKNqa6X8ujodt2N0idTedagtfI26nASxy2+B0KIQWbWRvaBjUyj
+        Na0KsNb0ViunXn/xnF9fNZ94sOWxcDNatjY245WfzW5leIrj5bvUlcXvHwkLeYyMAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:45:09 GMT
       Expires:
       - '0'
       Pragma:
@@ -3954,8 +5090,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -3967,9 +5103,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - a89166c0a937ffa70f2dd6b286def722
+      - 0bf316909950d5ae5af367fc347860af
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -3987,22 +5123,26 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/110/hosts/2
+    uri: https://cloud.tenable.com/scans/219/hosts/2
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA82S22oCMRCGXyXkqgXdbqJLcW+VnqBiD1CKFIm7ox3IYd0kUhHfvbOt1WJvWuiF
-        N8lMMv/8fMmsOdqZ4/maG1W0VVnW4D3PbdS6xV+dD+3ZorQ850HVcwgyqeK0CZMAVk01eChijWGV
-        FM7wrQIrqs9k0jlPhOwlstuhG1dBrQLaeduvfADz3WMCtiTJE5TsJmomzpnI8izLu5LJVPS2fSee
-        jMPPuk4uxWfdpsWXUVsymqLGgEAk4zUvXLSkk9s2WO5iqwz8mq3ScY52MlMG9YpUI1cH5gtlydDv
-        75v2QkjR251sXYb0stGzh+fhl4pEHpbQePA83ScTtCW8fRw1PLt009rBiH+GuYTm2fQBRipE9xDj
-        un87Yo9ogL7DVOweFpFC2o0LwAaqWdAX2vlYw9ETyjTrHBJekRW7oOlcsbuoNM6QBm7gjELLhlTC
-        Ti7uBsNTQvZOx4DOHjumzKRMDzEf+6Oz629fSaMZq4qGGso/87y0iMdUGpUtqPf4ZfMOUoY3RVkE
-        AAA=
+        H4sIAAAAAAAAA9WWa0/bMBSG/4qVTyCVLnYvkHxjZQyktSprNDQhVLnJaWvNsYMvhQrx33fSFSik
+        3dC0SeFL4iTn0ifvyeveB0JNdRDfBzlPD3iWGbA2iJWXshHMtXUH05tMBXHguJmBY83CT8pl04Hi
+        EwkWUm+EWzZTnQfrDFFgfKvTpF3WZBTP7Qgf6QIMd0LNDuzSOsg3m4xBZZiTzD0Z6AVhlNBO3G7F
+        LCIspNG68NhiZ1eJa0Vx6/BX3EMjWHipsNFESOEEIMrVfZBqrzCPrcuI7GmteA5vhiuknwk1nvJc
+        yCVmDbVxxKZcYUP7/LwsTymj0dOddZcBvlpvyej74DELkywsoOwRxOHzxVioDO5Wt0qep8uHxn+D
+        GYFZiBRIBg5SJ7R6CcRY1G2/BnrMOdnI+Vse+o95LmFCyt9XlSak4eFrkrMkGa7DSbIsgHCVkW+Y
+        Wy+oz1DOtqwA0Yo0573+kCQiB/xm8oJ8hRuPSzzn2qFgvDwIm0ptvYEaEf5hDGnIuhXxRqOzXdqR
+        c3Q3k/OaDecOHdlRhS0xPAWjPer1nlBY2GlVvjFsRU7R85fkwnMppgIycqJzLhQZYAjZO704Gezj
+        jFotfc0wd9oJa7NuWEHFMTQJ3DmC+ik7xckcGu10qiXZK71m/z2pyTqMVRCT3vDD+YbF4L7miwJ3
+        RMhqxLNTtnaLUrp1F+iDm+vMkmMp9S1O6B5KSTJh0I60We7XCK6PBt58iXUYdjtb/fFYzjSWmud2
+        ZY9fuJp5PoN6qrYD7Og3xt/72CN9nQHpiWKOapNPq0YvqWjtqGjYrvxNLKkugf8g/ePepm7vgigK
+        W3TrAK6INmi2zx17A891A3nyQgquUqx+df3wEzLUU7jFDAAA
     headers:
       Cache-Control:
       - no-cache
@@ -4013,12 +5153,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 15:57:23 GMT
+      - Thu, 21 Nov 2019 15:45:10 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -4028,9 +5168,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 49f39a9dc82598186ad4154c88b7d75f
+      - 05867184eee327e319639b0137aa8c8f
     status:
       code: 200
       message: OK

--- a/tests/integration/api/cassettes/test_scans_control_endpoints_using_schedule_uuid.yaml
+++ b/tests/integration/api/cassettes/test_scans_control_endpoints_using_schedule_uuid.yaml
@@ -1,0 +1,4806 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/editor/scan/templates
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2683'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:45:32 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - ''
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 913b984354032e03a98116dbd33c3552
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"uuid": "731a8e52-3ea6-a291-ec0a-d2ff0619c19d7bd788d6be818b65", "settings":
+      {"name": "test_scan_fixture", "enabled": false, "text_targets": "fakehost.tenable.com",
+      "acls": [], "asset_lists": []}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '211'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scans
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3VS246jMAz9lzw3FQFCoE/zJ8gkphNtICgXdbuj+fdxaOlopJ08oBDbx+cc+4NF
+        DSu7fDDt1wR2xTBawy6slWKatOr5MNWat3pu+FSB5E1n0AyNmnpp2In5W6nIea9BJbXRPfKp7oG3
+        0CjeD7rmnZYd9o0cZAVU88xOuGwOEnLTV7IyILiBWnA1CMmFGlreNs2gWtkZjRV0w6zErLDqFBhd
+        Wq+w4A4T01hEjLP9m3JAChmMOtgtWU/S1uzciW3eWX3ftdV1ddplH2IfGcfLk171PPw/n9+OoN64
+        gHXxBbrQlZXnFSaHBDyDi0gUIb5PHoIh2g6PdLtqlw2OcL0GvJI57JJCxge5MdkFx5tdjb8dBTrH
+        5JcxQbhiKq0et/q85alcz+nROKLOwab7WfuF2ESKpQJ34ISQKen4K5F/fn1FV5/sbDUUQwvfhOFb
+        4TuEoos8zZHs2zAsNkbKpBRR92UaM2SXfkaq5+4QZVhNwNtbNH/OPlxfS7WP6sQc0HwXb74JmN0X
+        IVXbSCGahlwI+Fso3beyJWQHzZ+wHwsgPj+/ALTmfPz6AgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:45:33 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - ''
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 51d634f9a58abddbe472d35308265595
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3VRS2+DMAz+K5XPMAF9UDhN232XaqeqQl5i2qwpQYkjhqr+9wVKu5d2s/zZ/h4+
+        g2pqA+UZTNeQhRKwkZa6RyePD8buIYIGTxT6TI4rJ7CpavXB3tIAmYrR7omhrFE7iqA2WpKtlISy
+        8VpHIEzD1mgo2fqAexfQluxJOadM46BMs3UEThxIek2V98NqIDu1GpliuU6WicQ0lpilcV6kyzjN
+        i0W8mM+LfLFcSUEJroo6T+ucklWOUsggjKTiCrU2Hckb9aA9WKwmP6+b2bM2Xs42137Yao1Wog/Y
+        EzolZi/EnbHHcSCg7oCW7r7M2zsJHo1mWRoB437Kwt1GUOhQb8/ww28S3aK+TknlgtV+knXtfa+/
+        ouS+HYRLqtFrhkv06/KY5HQ7/X3437/+6Y+W7mzDw+CyC/YZ2QcWCK/hPrDDQTk2NuS13V0+AYb7
+        iCFIAgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:45:33 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - fb5aa155e04ac4b6fe27ac270c5f9810
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd/launch
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSSjMyMjUzMUvUTTI2MNI1MTJK1rW0MLcEco0MzS0MDQ3S
+        DJKVagHfbfPKNAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:45:34 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - ''
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 5f1f3a960038951e62a73be5c9e14f16
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGE4G0sZMRhX5jLLyX8KbnQNChwFhMGk5JWnkZDXiyH1CVDhwbU
+        inwWPpYtbwJ44oQp6wOQdGHsqcVkGFyOpo5Hln1gANL4oIVaqRl6RVV1A67LJuDfZDJdrr4hwe1w
+        3hnOSASeFfqEOWtulYzKTfUMWBaEnv8ozJ+Uha8AJVXd1KqJoQYJ2ZZPSQhWHNjg9csyOAQCb+LZ
+        bMSsPMzLrJElfG6ZKXXt1ChxMPrC0DkMpx7BHRyKd5ED2pAhc8C+NKkEE00zGH7qMOJaND4fMSek
+        fhwhiS9ydJnxCAY+bG7v1HsbQUBD6aRVyKSUp1QTChWPotOYPsD5J0U2iTy6fqo/y3vzE+NZLj7p
+        z/NzVXveK20NLf6UlSq9kqJqOqShmkyGli3TkaLKvEKu1uomr+I1EKgFDwKVgBNwbQv0dx594jgh
+        oXXDz+ICsDL2vWiaap2l9VEEfNIwdaIxc8sEfJENI8jN5SFK22E0Bm/9fVvi/ss1vv45puX6Z1zn
+        s6vOYftCCP/gUHcc3oAz1t9FSfoA4QypfeQDgufmAQTfHQkQzZuNs36jJ7XjHtJR2gPlwfa9qQ0B
+        CY0OBCuXn9+v4FQ4e+E6V7vvUCYWfTAl1i0Z03wVunPAVoLHvaCipSXK8wHg/MMNC+mgCzEGUelD
+        0L+JVg8+HR002xeXcrOJ6QQtUsO+YwFkxK3dstmQY4+UUwddrSn+9HfMVwH2b/iTT1rSHqMHEpxr
+        iqLLSr34PmE5pyOPi352rG+OU1x56odS/0oCEahPIe/GHKhAgFrclfj1fNT1zy/aOx27U1Tqbnsr
+        85XRvHrZ/nj5Pk5p3dGyT+4xDfrbafDfPUDOINUU5T3VNM2ZpnxS1GvhjsU4JJ+MEtxft8PlOXC/
+        DeEKc36YxVRLyVlVVhW45b4XU0EwGJKAwtInx1P7vZ4E6wUKy4QYsX34fv5cTgL4F1T/WrmypibM
+        mQA6FsdX8WSuIV9veT5xNmt5maC+S1NUUaOsvbOid7B48/zcKMhq2xfQLW9U0FP7W/tg72rWPW/O
+        jmbHs7NWcf/i9GDv/Gh2Ofswu4ormgBpzq4uZk1+LuLkm3oWc0KnfXBcktoHR2u0vnJsfJ3Hl9PX
+        6B/snc4as7PifgO0PZ51ZqdQjA72zma9Wae43+Sl7qxZ3D+Zlxppac7l9w2TRyyMelaS4Nh4Y2r1
+        LfLOnV5W/ujJR98y+whd//gpSH9JDlrW+aWRdAC99+OMIvLJxySdJNnkY5xMIJfMLuAkiZuXdfrB
+        6UfflsNvoo4nkDNIIKezbpxCTmfHxf3uBa8VxSuRNy6K+z3OV1NklGNoOhMZJSk10lKW4Fce+ocm
+        q3iJ86GNGeDDttPJJDS/tqL50F5dzcBy7k2WcovdqoFNA8tnU773hul4Q61b6YyfvPLc/xVEn5OF
+        CT6HSRcZ2E6osO5lya73gFjxJvS6Pq0Ysf+bC6tBqRHjgt1ZM64vfm1tQB2HeZg2bdGwy2vgufRx
+        36+q8BYh8qa7FOSOMIfLgOmWKNXIYHbELiIft1uHsthMyhO8RULCJ5ivu+W0U3vDSc1NNMzn4Vg0
+        7ojlEoET7ICCeXJmNu0lpNQG5LZqJF0DifhUyrr4mSclAkgsgNvs7xHjzztFw63IqRTv+pZcUHsw
+        fBxMiHNP0KVBO4VJh49SZw7bLYPGSrg0CCLsUcWSDmcp6oeoIB7AJc/01wU9hlZe3D/pSg3b9kHU
+        70joqqmV1Wq9rJa1klrj5TIc5EVRUUqqwv+VKzBl1oySkI4+EJi3UPEA+P228E8a/QbCCK9+YQaV
+        PzXk/xD5y7W8nFFX63MyrLji2hxYVeWGrKgV9T0fa4Aohzgnh+/OySHKyeF7chKEbDwI6B3l7yfg
+        vHSk3qJ9G3bY3Un/+uccnRejxSqf9N/Z+thDLV797ta//PERwdxBeAMs0HssxZ+40uUNheR+v0ML
+        kvy76q7eSDOTuwkNSSAqMfnnjbu8gFqokLeCyujxh1k9ieTQ6R1hyaHDLN8LvFEoHUaOQ0Pmbpcn
+        Or2Vx/8rFTmZodMzTdk0TYArilyrm+/IwHmv38LujqL+T7PomvIBBtNo6Cy9nLaudpcDpe4CyBeg
+        OQkGGkaMOvYaEU/G835c0BYFlBL+0sd+p7Pfaq2ZnA8vOzxrJCWaFsfhojSvFISJ0vdul2zcRewK
+        vNRaAu3SVtyITJgj3mHMFf5IQDbm18EkckK2yLLzq1zA6ueYhNKpZ/GnO8lbnpLYXOW3TPHuZEaq
+        46589XEjWsugW3TIiLsRrmfgPc8hPqyBN+GNDP6I2p5PNsIrGXjz1xOJDKOApo3VTOOvYGLP2zhW
+        LStq1GtvBNcz4MbJZsrMDPYDc8FggXQgrSftuUGUbAc6hGH9O/5KZ9KcNVivc9mVpr4HbjOZA7I2
+        OvIpPey1NntA1kpXw8gNo834rJV6DrFu+bRmc5espTr85Why+5UeWfNd0IkXUmnEHCoRy4pXyAKV
+        tVoTjHze2zxq1nBHl920GrFR6vDKkuQWXOArEaIuhYjLAOmNhBGZeBQQv9yeHZUFVjltWIqYuI9k
+        05BaSfYSIGPpEmKDXrpy2UN2f14A8QAB9/vY66WYpTghkHF8zwth6s8pF4lHoLJEX3SbaXUdde6r
+        gPrShLhkTCdUPFYQYHM5IiExOmmeyLKcbqLOk0iW0S6lvnzpyfy/dMQdoncDacVN37HXs8w2T3rN
+        87Qhy+wR8+k9cZz5JbKMHoJH2543jzg9y2Kv2Wg10oYsda2zlFE9yxVQ4YC/SkFsy/mYWeK64gsJ
+        afHoKAWZq6YhUnBDHWfVOoay5DUhZJPxPKUusef5oZS8Wz8HZBnjX2fEaxTRtMyZOwbOl3KssZQK
+        zjppQBlZys5OUmaM6moaYHebM7yR5bLfEYmm3dscgUaW20M/4pnD8yGOYN5AMrAsu/+KXG/zramy
+        xLHFwK/5xwPSKXOjh809sxboeEPutC2a9YZK1gTnPrEAscW4Wes0JuQLzP+26JU1WZc4ntRwws23
+        xkrWmscRuadsMz5r5qNK+snPV/itrXHQ72zukbXziWsxG2wiXdBg6rlB6sKVrJX7zA8j78uXzepW
+        laWAuO/xb1Ck5q+9083d1OfXW9BumhFuu8zZU2afVJjOx3N6pVR9Lu59/hz8JPPD3mpT8Ze9kmh4
+        Ya+c5dNH/lcSR1kcV1ZSiqK8xeo/rkG+7Mlls5OB/jWWTznbIgkfO7ol4kXhNMJ2pRKxz9P2bxU8
+        pA9hyQtv4BbHi++zqZG46zZL/VjNv/JaPyFLKJlL0GXcutVmpMOzuRiKz6ZeZTsS5ldlfsAEjKu3
+        3Z96UkuV50XmXdSlifprqJzEXFdKdUi+cl2pKy/Iyekbm9zaL6TD90LP8hyMkkXTdrvH1hTOIpsf
+        mTWZvobJsrcKRMQLapEglP7Bl1Z0ihsQkTRGiwf98QhQfLv3UviEBBaaiPhJy59mazSgdECcwENV
+        pTCVFU27dvPa8Pxy46PLvA0+mO2OuJ6nHn+NpUNtFvHvto/ZmEvXhPEYz2xv4nCB50Q5sdJbNO3S
+        JmtW+EfXmwYMe5jYWzTtqPCRG0RTnlLjN1/uqGuLt69XNbla4Pi7L/0U90Me0IWwkrtl7rg8Yn4Q
+        DkZe5GJLm+UPNo84FpZZFHelP8X8Zk6M+CmC7Xg5JX96Wtbd/m7ql/O+YVmmp+szT6zLLwjfAZP2
+        +t2L4ovue+nnLD/w6x0O3WZBsKL6X2ZdMI8b/iMbXyemF+aysZ78zii/nx6xBzFxa1ghu6NiBhdE
+        /ohYrzOHC8m43Gv9JoG16Njz0UnBcvM3PPnjI9wRJ6KaCa2itFKb3c2cV9dRcB0Fq1UMrFZRsK5i
+        YF3FR66gI1fwkQ10ZANXEAVrOFhH2dBxNnSUDR1nQ6uhYtTwkVGwjoM1lGcN5xnVL0c9BRVCwYVA
+        wRoORv0Td08MiQJRW+CmQB0C9wcVNYSKG8LQ0YF1nDANJUzDxUDZVXF2dTSUdDyUDHRkAx/ZQGU2
+        cJk1VAwNFwMnA+cCZVnNYRl1Cy0nRNGRNXxkA406A486dGB8XBX1TjUnXeED54yMhp2Kx52OWkTP
+        MQnKhYpzgboF7hVo8OGxp6Lyqri8OsqEjjOhoikTatcf/QQ0lG/EjyglJdcLXzZJsOuj+mhYpXJN
+        HVmyYSmmbFqaJltDw6Q2tSuGUUEmD1t2+4ZJhfi1QqHxwKxlc8VKw9uQoZpEqSmyYdc00KqqyUNj
+        pMu2qll1nRLDFql8nYytun0fGfWKhpPBG96CDH4JRNmk+huVWVHhTQRXLM0ilFRlqihD2RiOiFwn
+        w6qsWMNKrWJUrZFVRRTbstv3WbFazbEib3gLMtRRXTWqdgV0MXmg6opMjKouWxY1qpo6Mo0qFt9b
+        dvtWMsSvfMaK24/QwKxVVhDEW9Bj2XVK6qCYXqmCnqpWlU3CfxSQ1mqaSjRFNUyEni27fWf6M3Oy
+        n/lKVFzz34EN09989OkESBere6h5en7+P4Fm7GpiVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:45:41 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 7e0486e1ec6a55d38774ee87af6d41aa
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEIK9rM5dfRbhSco1pUOAEJuQlJa08jYa8WA6pS4YODagV+Sx8
+        LFveBPDECVPCByDkws5Ti8kwuBxNHY8sm38AgviggFqpGXpFVXUDrssm4NpkMl2uviHB7XDeGc5I
+        BE4V+oQ5ax6VjMqt9AxYFoSe/ygsn5SFmwAbVd3UqomNBgnPlk9JCAYc2ODwyzI4BGJu4tlsxKw8
+        zMsMkSUcNUoch76wcQ7DqTNw34biXeSANmTIHBYymlSCiaYZDD91GHEtGp+PmBNSPw6OxA05usx4
+        8AIfNrd36riNIKChdNIqZLLJU6oJhYpH0WlMH+D8kyKbRB5dP9Wf5b35ifEsF5/05/m5qj3vlbaG
+        Fn/KSpVeSVE1HTJQTSZDy5bpSFFlXiFXa3WTV/EaiNGCBzFKwAm4tgX6Ow88cZyQ0LrhZ3EBWBn7
+        XjRNtc7S+ihiPWmYOtGYuWUCvsiGEaTl8hCl7TAag7f+vi1x/+UaX/8c03L9M67z2VXnsH0hhH9w
+        qDsOb8AZ6++iJH2AcIasPvIBwdPyAILvjgSI5s3GWb/Rk9pxD+ko7YHyYPve1IaAhEYHgpXLz29V
+        cCqcvXCdq913KBOLPpgS65aMab4K3TlgK8HjXlDR0hLl+QBw/uGGhXTQhRiDqPQh6N9Eqwefjg6a
+        7YtLudnEdIIWqWHfsQAy4tZu2WzIsUfKqYOu1hR/+jvmqwD7N/zJJy1pj9EDCc41RdFlpV58n7Cc
+        05HHRT871jfHKa489UOpfyWBCNSnkHdjDlQgQC3uSvx6Pur65xftnY7dKSp1t72V+cpoXr1sf7x8
+        H6e07mjZJ/eYBv3tNPjvHiBnkGqK8p5qmuZMUz4p6rVwx2Ickk9GCe6v2+HyHLjfhnCF6T7MYqql
+        5Kwqqwrcct+LqSAYDElAYdWT46n9Xk+CpQKFFUKM2D58P38uJwH8C6p/rVxZUxPmTAAdi+OreDLX
+        kC+1PJ84m7W8TFDfpSmqqFHW3lnRO1i3eX5uFGS17Qvoljcq6Kn9rX2wdzXrnjdnR7Pj2VmruH9x
+        erB3fjS7nH2YXcUVTYA0Z1cXsyY/F3HyTT2LOaHTPjguSe2DozVaXzk2vs7jy+lr9A/2TmeN2Vlx
+        vwHaHs86s1MoRgd7Z7PerFPcb/JSd9Ys7p/MS420NOfy+4bJIxZGPStJcGy8MbX6FnnnTi8rf/Tk
+        o2+ZfYSuf/wUpL8kBy3r/NJIOoDe+3FGEfnkY5JOkmzyMU4mkEtmF3CSxM3LOv3g9KNvy+E3UccT
+        yBkkkNNZN04hp7Pj4n73gteK4pXIGxfF/R7nqykyyjE0nYmMkpQaaSlL8CsP/UOTVbzE+dDGDPBh
+        2+lkEppfW9F8aK+uZmA59yZLucVu1cCmgeWzKd97w3S8odatdMZPXnnu/wqiz8nCBJ/DpIsMbCdU
+        WPeyZMN7QKx4/3ldn1aM2P/NhdWg1Ihxwe6sGdcXv7Y2oI7DPEybtmjY5TXwXPq471dVeIsQedNd
+        CnJHmMNlwHRLlGpkMDtiF5GP261DWWwm5QneIiHhE8zX3XLaqb3hpOYmGubzcCwad8RyicAJdkDB
+        PDkzm/YSUmoDcls1kq6BRHwqZV38zJMSASQWwG3294jxR52i4VbkVIp3fUsuqD0YPg4mxLkn6NKg
+        ncKkw0epM4ftlkFjJVwaBBH2qGJJh7MU9UNUEA/gksf564IeQysv7p90pYZt+yDqdyR01dTKarVe
+        VstaSa3xchkO8qKoKCVV4f/KFZgya0ZJSEcfCMxbqHgA/H5b+CeNfgNhhFe/MIPKnxryf4j85Vpe
+        zqir9TkZVlxxbQ6sqnJDVtSK+p6PNUCUQ5yTw3fn5BDl5PA9OQlCNh4E9I7y9xNwXjpSb9G+DTvs
+        7qR//XOOzovRYpVP+u9sfeyhFq9+d+tf/viIYO4gvAEW6D2W4k9c6fKGQnK/36EFSf5ddVdvpJnJ
+        3YSGJBCVmPzzxl1eQC1UyFtBZfT4w6yeRHLo9I6w5NBhlu8F3iiUDiPHoSFzt8sTnd7K4/+VipzM
+        0OmZpmyaJsAVRa7VzXdk4LzXb2F3R1H/p1l0TfkAg2k0dJZeTltXu8uBUncB5AvQnAQDDSNGHXuN
+        iCfjeT8uaIsCSgl/6WO/09lvtdZMzoeXHZ41khJNi+NwUZpXCsJE6Xu3SzbuInYFXmotgXZpK25E
+        JswR7zDmCn8kIBvz62ASOSFbZNn5VS5g9XNMQunUs/jTneQtT0lsrvJbpnh3MiPVcVe++rgRrWXQ
+        LTpkxN0I1zPwnucQH9bAm/BGBn9Ebc8nG+GVDLz564lEhlFA08ZqpvFXMLHnbRyrlhU16rU3gusZ
+        cONkM2VmBvuBuWCwQDqQ1pP23CBKtgMdwrD+HX+lM2nOGqzXuexKU98Dt5nMAVkbHfmUHvZamz0g
+        a6WrYeSG0WZ81ko9h1i3fFqzuUvWUh3+XjS5/UqPrPku6MQLqTRiDpWIZcUrZIHKWq0JRj7vbR41
+        a7ijy25ajdgodXhlSXILLvCVCFGXQsRlgPRGwohMPAqI32vPjsoCq5w2LEVM3EeyaUitJHsJkLF0
+        CbFBL1257CG7Py+AeICA+33s9VLMUpwQyDi+54Uw9eeUi8QjUFmiL7rNtLqOOvdVQH1pQlwyphMq
+        HisIsLkckZAYnTRPZFlON1HnSSTLaJdSX770ZP5fOuIO0buBtOKmr9frWWabJ73medqQZfaI+fSe
+        OM78EllGD8Gjbc+bR5yeZbHXbLQaaUOWutZZyqie5QqocMBfpSC25XzMLHFd8XGEtHh0lILMVdMQ
+        KbihjrNqHUNZ8poQssl4nlKX2PP8UErerZ8DsozxDzPiNYpoWubMHQPnSznWWEoFZ500oIwsZWcn
+        KTNGdTUNsLvNGd7IctnviETT7m2OQCPL7aEf8czh+RBHMG8gGViW3X9Frrf51lRZ4thi4Nf84wHp
+        lLnRw+aeWQt0vCF32hbNekMla4Jzn1iA2GLcrHUaE/IF5n9b9MqarEscT2o44eZbYyVrzeOI3FO2
+        GZ8181El/drnK/zW1jjodzb3yNr5xLWYDTaRLmgw9dwgdeFK1sp95oeR9+XLZnWrylJA3Pf4NyhS
+        89fe6eZu6vPrLWg3zQi3XebsKbNPKkzn4zm9Uqo+F/c+fw5+kvlhb7Wp+MteSTS8sFfO8ukj/yuJ
+        oyyOKyspRVHeYvUf1yBf9uSy2clA/xrLp5xtkYSPHd0S8aJwGmG7UonY52n7twoe0oew5IU3cIvj
+        xffZ1EjcdZulfqzmX3mtn5AllMwl6DJu3Woz0uHZXAzFZ1Ovsh0J86syP2ACxtXb7k89qaXK8yLz
+        LurSRP01VE5iriulOiRfua7UlRfk5PSNTW7tF9Lhe6FneQ5GyaJpu91jawpnkc2PzJpMX8Nk2VsF
+        IuIFtUgQSv/gSys6xQ2ISBqjxYP+eAQovt17KXxCAgtNRPyk5U+zNRpQOiBO4KGqUpjKiqZdu3lt
+        eH658dFl3gYfzHZHXM9Tj7/G0qE2i/h328dszKVrwniMZ7Y3cbjAc6KcWOktmnZpkzUr/KPrTQOG
+        PUzsLZp2VPjIDaIpT6nxmy931LXF29ermlwtcPzdl36K+yEP6EJYyd0yd1weMT8IByMvcrGlzfIH
+        m0ccC8ssirvSn2J+MydG/BTBdryckj89Letufzf1y3nfsCzT0/WZJ9blF4TvgEl7/e5F8UX3vfRz
+        lh/49Q6HbrMgWFH9L7MumMcN/5GNrxPTC3PZWE9+Z5TfT4/Yg5i4NayQ3VExgwsif0Ss15nDhWRc
+        7rV+k8BadOz56KRgufkbnvzxEe6IE1HNhFZRWqnN7mbOq+souI6C1SoGVqsoWFcxsK7iI1fQkSv4
+        yAY6soEriII1HKyjbOg4GzrKho6zodVQMWr4yChYx8EayrOG84zql6Oeggqh4EKgYA0Ho/6JuyeG
+        RIGoLXBToA6B+4OKGkLFDWHo6MA6TpiGEqbhYqDsqji7OhpKOh5KBjqygY9soDIbuMwaKoaGi4GT
+        gXOBsqzmsIy6hZYToujIGj6ygUadgUcdOjA+rop6p5qTrvCBc0ZGw07F405HLaLnmATlQsW5QN0C
+        9wo0+PDYU1F5VVxeHWVCx5lQ0ZQJteuPfgIayjfiR5SSkuuFL5sk2PVRfTSsUrmmjizZsBRTNi1N
+        k62hYVKb2hXDqCCThy27fcOkQvxQodB4YNayuWKl4W3IUE2i1BTZsGsaaFXV5KEx0mVb1ay6Tolh
+        i1S+TsZW3b6PjHpFw8ngDW9BBr8EomxS/Y3KrKjwJoIrlmYRSqoyVZShbAxHRK6TYVVWrGGlVjGq
+        1siqIopt2e37rFit5liRN7wFGeqorhpVuwK6mDxQdUUmRlWXLYsaVU0dmUYVi+8tu30rGeIHPmPF
+        7UdoYNYqKwjiLeix7DoldVBMr1RBT1WryibhPwpIazVNJZqiGiZCz5bdvjP9mTnZz3wlKq75T8CG
+        6W8++nQCpIvVPdQ8PT//H4ugN2xdVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:45:45 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 1812a9f0be30fda08f21dd7e90b2e16d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEIK9rM5dfRbhSco1pUOAEJuQlJa08jYa8WA6pS4YODagV+Sx8
+        LFveBPDECVPCByDkws5Ti8kwuBxNHY8sm38AgviggFqpGXpFVXUDrssm4NpkMl2uviHB7XDeGc5I
+        BE4V+oQ5ax6VjMqt9AxYFoSe/ygsn5SFmwAbVd3UqomNBgnPlk9JCAYc2ODwyzI4BGJu4tlsxKw8
+        zMsMkSUcNUoch76wcQ7DqTNw34biXeSANmTIHBYymlSCiaYZDD91GHEtGp+PmBNSPw6OxA05usx4
+        8AIfNrd36riNIKChdNIqZLLJU6oJhYpH0WlMH+D8kyKbRB5dP9Wf5b35ifEsF5/05/m5qj3vlbaG
+        Fn/KSpVeSVE1HTJQTSZDy5bpSFFlXiFXa3WTV/EaiNGCBzFKwAm4tgX6Ow88cZyQ0LrhZ3EBWBn7
+        XjRNtc7S+ihiPWmYOtGYuWUCvsiGEaTl8hCl7TAag7f+vi1x/+UaX/8c03L9M67z2VXnsH0hhH9w
+        qDsOb8AZ6++iJH2AcIasPvIBwdPyAILvjgSI5s3GWb/Rk9pxD+ko7YHyYPve1IaAhEYHgpXLz29V
+        cCqcvXCdq913KBOLPpgS65aMab4K3TlgK8HjXlDR0hLl+QBw/uGGhXTQhRiDqPQh6N9Eqwefjg6a
+        7YtLudnEdIIWqWHfsQAy4tZu2WzIsUfKqYOu1hR/+jvmqwD7N/zJJy1pj9EDCc41RdFlpV58n7Cc
+        05HHRT871jfHKa489UOpfyWBCNSnkHdjDlQgQC3uSvx6Pur65xftnY7dKSp1t72V+cpoXr1sf7x8
+        H6e07mjZJ/eYBv3tNPjvHiBnkGqK8p5qmuZMUz4p6rVwx2Ickk9GCe6v2+HyHLjfhnCF6T7MYqql
+        5Kwqqwrcct+LqSAYDElAYdWT46n9Xk+CpQKFFUKM2D58P38uJwH8C6p/rVxZUxPmTAAdi+OreDLX
+        kC+1PJ84m7W8TFDfpSmqqFHW3lnRO1i3eX5uFGS17Qvoljcq6Kn9rX2wdzXrnjdnR7Pj2VmruH9x
+        erB3fjS7nH2YXcUVTYA0Z1cXsyY/F3HyTT2LOaHTPjguSe2DozVaXzk2vs7jy+lr9A/2TmeN2Vlx
+        vwHaHs86s1MoRgd7Z7PerFPcb/JSd9Ys7p/MS420NOfy+4bJIxZGPStJcGy8MbX6FnnnTi8rf/Tk
+        o2+ZfYSuf/wUpL8kBy3r/NJIOoDe+3FGEfnkY5JOkmzyMU4mkEtmF3CSxM3LOv3g9KNvy+E3UccT
+        yBkkkNNZN04hp7Pj4n73gteK4pXIGxfF/R7nqykyyjE0nYmMkpQaaSlL8CsP/UOTVbzE+dDGDPBh
+        2+lkEppfW9F8aK+uZmA59yZLucVu1cCmgeWzKd97w3S8odatdMZPXnnu/wqiz8nCBJ/DpIsMbCdU
+        WPeyZMN7QKx4/3ldn1aM2P/NhdWg1Ihxwe6sGdcXv7Y2oI7DPEybtmjY5TXwXPq471dVeIsQedNd
+        CnJHmMNlwHRLlGpkMDtiF5GP261DWWwm5QneIiHhE8zX3XLaqb3hpOYmGubzcCwad8RyicAJdkDB
+        PDkzm/YSUmoDcls1kq6BRHwqZV38zJMSASQWwG3294jxR52i4VbkVIp3fUsuqD0YPg4mxLkn6NKg
+        ncKkw0epM4ftlkFjJVwaBBH2qGJJh7MU9UNUEA/gksf564IeQysv7p90pYZt+yDqdyR01dTKarVe
+        VstaSa3xchkO8qKoKCVV4f/KFZgya0ZJSEcfCMxbqHgA/H5b+CeNfgNhhFe/MIPKnxryf4j85Vpe
+        zqir9TkZVlxxbQ6sqnJDVtSK+p6PNUCUQ5yTw3fn5BDl5PA9OQlCNh4E9I7y9xNwXjpSb9G+DTvs
+        7qR//XOOzovRYpVP+u9sfeyhFq9+d+tf/viIYO4gvAEW6D2W4k9c6fKGQnK/36EFSf5ddVdvpJnJ
+        3YSGJBCVmPzzxl1eQC1UyFtBZfT4w6yeRHLo9I6w5NBhlu8F3iiUDiPHoSFzt8sTnd7K4/+VipzM
+        0OmZpmyaJsAVRa7VzXdk4LzXb2F3R1H/p1l0TfkAg2k0dJZeTltXu8uBUncB5AvQnAQDDSNGHXuN
+        iCfjeT8uaIsCSgl/6WO/09lvtdZMzoeXHZ41khJNi+NwUZpXCsJE6Xu3SzbuInYFXmotgXZpK25E
+        JswR7zDmCn8kIBvz62ASOSFbZNn5VS5g9XNMQunUs/jTneQtT0lsrvJbpnh3MiPVcVe++rgRrWXQ
+        LTpkxN0I1zPwnucQH9bAm/BGBn9Ebc8nG+GVDLz564lEhlFA08ZqpvFXMLHnbRyrlhU16rU3gusZ
+        cONkM2VmBvuBuWCwQDqQ1pP23CBKtgMdwrD+HX+lM2nOGqzXuexKU98Dt5nMAVkbHfmUHvZamz0g
+        a6WrYeSG0WZ81ko9h1i3fFqzuUvWUh3+XjS5/UqPrPku6MQLqTRiDpWIZcUrZIHKWq0JRj7vbR41
+        a7ijy25ajdgodXhlSXILLvCVCFGXQsRlgPRGwohMPAqI32vPjsoCq5w2LEVM3EeyaUitJHsJkLF0
+        CbFBL1257CG7Py+AeICA+33s9VLMUpwQyDi+54Uw9eeUi8QjUFmiL7rNtLqOOvdVQH1pQlwyphMq
+        HisIsLkckZAYnTRPZFlON1HnSSTLaJdSX770ZP5fOuIO0buBtOKmr9frWWabJ73medqQZfaI+fSe
+        OM78EllGD8Gjbc+bR5yeZbHXbLQaaUOWutZZyqie5QqocMBfpSC25XzMLHFd8XGEtHh0lILMVdMQ
+        KbihjrNqHUNZ8poQssl4nlKX2PP8UErerZ8DsozxDzPiNYpoWubMHQPnSznWWEoFZ500oIwsZWcn
+        KTNGdTUNsLvNGd7IctnviETT7m2OQCPL7aEf8czh+RBHMG8gGViW3X9Frrf51lRZ4thi4Nf84wHp
+        lLnRw+aeWQt0vCF32hbNekMla4Jzn1iA2GLcrHUaE/IF5n9b9MqarEscT2o44eZbYyVrzeOI3FO2
+        GZ8181El/drnK/zW1jjodzb3yNr5xLWYDTaRLmgw9dwgdeFK1sp95oeR9+XLZnWrylJA3Pf4NyhS
+        89fe6eZu6vPrLWg3zQi3XebsKbNPKkzn4zm9Uqo+F/c+fw5+kvlhb7Wp+MteSTS8sFfO8ukj/yuJ
+        oyyOKyspRVHeYvUf1yBf9uSy2clA/xrLp5xtkYSPHd0S8aJwGmG7UonY52n7twoe0oew5IU3cIvj
+        xffZ1EjcdZulfqzmX3mtn5AllMwl6DJu3Woz0uHZXAzFZ1Ovsh0J86syP2ACxtXb7k89qaXK8yLz
+        LurSRP01VE5iriulOiRfua7UlRfk5PSNTW7tF9Lhe6FneQ5GyaJpu91jawpnkc2PzJpMX8Nk2VsF
+        IuIFtUgQSv/gSys6xQ2ISBqjxYP+eAQovt17KXxCAgtNRPyk5U+zNRpQOiBO4KGqUpjKiqZdu3lt
+        eH658dFl3gYfzHZHXM9Tj7/G0qE2i/h328dszKVrwniMZ7Y3cbjAc6KcWOktmnZpkzUr/KPrTQOG
+        PUzsLZp2VPjIDaIpT6nxmy931LXF29ermlwtcPzdl36K+yEP6EJYyd0yd1weMT8IByMvcrGlzfIH
+        m0ccC8ssirvSn2J+MydG/BTBdryckj89Letufzf1y3nfsCzT0/WZJ9blF4TvgEl7/e5F8UX3vfRz
+        lh/49Q6HbrMgWFH9L7MumMcN/5GNrxPTC3PZWE9+Z5TfT4/Yg5i4NayQ3VExgwsif0Ss15nDhWRc
+        7rV+k8BadOz56KRgufkbnvzxEe6IE1HNhFZRWqnN7mbOq+souI6C1SoGVqsoWFcxsK7iI1fQkSv4
+        yAY6soEriII1HKyjbOg4GzrKho6zodVQMWr4yChYx8EayrOG84zql6Oeggqh4EKgYA0Ho/6JuyeG
+        RIGoLXBToA6B+4OKGkLFDWHo6MA6TpiGEqbhYqDsqji7OhpKOh5KBjqygY9soDIbuMwaKoaGi4GT
+        gXOBsqzmsIy6hZYToujIGj6ygUadgUcdOjA+rop6p5qTrvCBc0ZGw07F405HLaLnmATlQsW5QN0C
+        9wo0+PDYU1F5VVxeHWVCx5lQ0ZQJteuPfgIayjfiR5SSkuuFL5sk2PVRfTSsUrmmjizZsBRTNi1N
+        k62hYVKb2hXDqCCThy27fcOkQvxQodB4YNayuWKl4W3IUE2i1BTZsGsaaFXV5KEx0mVb1ay6Tolh
+        i1S+TsZW3b6PjHpFw8ngDW9BBr8EomxS/Y3KrKjwJoIrlmYRSqoyVZShbAxHRK6TYVVWrGGlVjGq
+        1siqIopt2e37rFit5liRN7wFGeqorhpVuwK6mDxQdUUmRlWXLYsaVU0dmUYVi+8tu30rGeIHPmPF
+        7UdoYNYqKwjiLeix7DoldVBMr1RBT1WryibhPwpIazVNJZqiGiZCz5bdvjP9mTnZz3wlKq75T8CG
+        6W8++nQCpIvVPdQ8PT//H4ugN2xdVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:45:59 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 6328c4a98f3d7c7da56966d4142f4ffe
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEIK9rM5dfRbhSco1pUOAEJuQlJa08jYa8WA6pS4YODagV+Sx8
+        LFveBPDECVPCByDkws5Ti8kwuBxNHY8sm38AgviggFqpGXpFVXUDrssm4NpkMl2uviHB7XDeGc5I
+        BE4V+oQ5ax6VjMqt9AxYFoSe/ygsn5SFmwAbVd3UqomNBgnPlk9JCAYc2ODwyzI4BGJu4tlsxKw8
+        zMsMkSUcNUoch76wcQ7DqTNw34biXeSANmTIHBYymlSCiaYZDD91GHEtGp+PmBNSPw6OxA05usx4
+        8AIfNrd36riNIKChdNIqZLLJU6oJhYpH0WlMH+D8kyKbRB5dP9Wf5b35ifEsF5/05/m5qj3vlbaG
+        Fn/KSpVeSVE1HTJQTSZDy5bpSFFlXiFXa3WTV/EaiNGCBzFKwAm4tgX6Ow88cZyQ0LrhZ3EBWBn7
+        XjRNtc7S+ihiPWmYOtGYuWUCvsiGEaTl8hCl7TAag7f+vi1x/+UaX/8c03L9M67z2VXnsH0hhH9w
+        qDsOb8AZ6++iJH2AcIasPvIBwdPyAILvjgSI5s3GWb/Rk9pxD+ko7YHyYPve1IaAhEYHgpXLz29V
+        cCqcvXCdq913KBOLPpgS65aMab4K3TlgK8HjXlDR0hLl+QBw/uGGhXTQhRiDqPQh6N9Eqwefjg6a
+        7YtLudnEdIIWqWHfsQAy4tZu2WzIsUfKqYOu1hR/+jvmqwD7N/zJJy1pj9EDCc41RdFlpV58n7Cc
+        05HHRT871jfHKa489UOpfyWBCNSnkHdjDlQgQC3uSvx6Pur65xftnY7dKSp1t72V+cpoXr1sf7x8
+        H6e07mjZJ/eYBv3tNPjvHiBnkGqK8p5qmuZMUz4p6rVwx2Ickk9GCe6v2+HyHLjfhnCF6T7MYqql
+        5Kwqqwrcct+LqSAYDElAYdWT46n9Xk+CpQKFFUKM2D58P38uJwH8C6p/rVxZUxPmTAAdi+OreDLX
+        kC+1PJ84m7W8TFDfpSmqqFHW3lnRO1i3eX5uFGS17Qvoljcq6Kn9rX2wdzXrnjdnR7Pj2VmruH9x
+        erB3fjS7nH2YXcUVTYA0Z1cXsyY/F3HyTT2LOaHTPjguSe2DozVaXzk2vs7jy+lr9A/2TmeN2Vlx
+        vwHaHs86s1MoRgd7Z7PerFPcb/JSd9Ys7p/MS420NOfy+4bJIxZGPStJcGy8MbX6FnnnTi8rf/Tk
+        o2+ZfYSuf/wUpL8kBy3r/NJIOoDe+3FGEfnkY5JOkmzyMU4mkEtmF3CSxM3LOv3g9KNvy+E3UccT
+        yBkkkNNZN04hp7Pj4n73gteK4pXIGxfF/R7nqykyyjE0nYmMkpQaaSlL8CsP/UOTVbzE+dDGDPBh
+        2+lkEppfW9F8aK+uZmA59yZLucVu1cCmgeWzKd97w3S8odatdMZPXnnu/wqiz8nCBJ/DpIsMbCdU
+        WPeyZMN7QKx4/3ldn1aM2P/NhdWg1Ihxwe6sGdcXv7Y2oI7DPEybtmjY5TXwXPq471dVeIsQedNd
+        CnJHmMNlwHRLlGpkMDtiF5GP261DWWwm5QneIiHhE8zX3XLaqb3hpOYmGubzcCwad8RyicAJdkDB
+        PDkzm/YSUmoDcls1kq6BRHwqZV38zJMSASQWwG3294jxR52i4VbkVIp3fUsuqD0YPg4mxLkn6NKg
+        ncKkw0epM4ftlkFjJVwaBBH2qGJJh7MU9UNUEA/gksf564IeQysv7p90pYZt+yDqdyR01dTKarVe
+        VstaSa3xchkO8qKoKCVV4f/KFZgya0ZJSEcfCMxbqHgA/H5b+CeNfgNhhFe/MIPKnxryf4j85Vpe
+        zqir9TkZVlxxbQ6sqnJDVtSK+p6PNUCUQ5yTw3fn5BDl5PA9OQlCNh4E9I7y9xNwXjpSb9G+DTvs
+        7qR//XOOzovRYpVP+u9sfeyhFq9+d+tf/viIYO4gvAEW6D2W4k9c6fKGQnK/36EFSf5ddVdvpJnJ
+        3YSGJBCVmPzzxl1eQC1UyFtBZfT4w6yeRHLo9I6w5NBhlu8F3iiUDiPHoSFzt8sTnd7K4/+VipzM
+        0OmZpmyaJsAVRa7VzXdk4LzXb2F3R1H/p1l0TfkAg2k0dJZeTltXu8uBUncB5AvQnAQDDSNGHXuN
+        iCfjeT8uaIsCSgl/6WO/09lvtdZMzoeXHZ41khJNi+NwUZpXCsJE6Xu3SzbuInYFXmotgXZpK25E
+        JswR7zDmCn8kIBvz62ASOSFbZNn5VS5g9XNMQunUs/jTneQtT0lsrvJbpnh3MiPVcVe++rgRrWXQ
+        LTpkxN0I1zPwnucQH9bAm/BGBn9Ebc8nG+GVDLz564lEhlFA08ZqpvFXMLHnbRyrlhU16rU3gusZ
+        cONkM2VmBvuBuWCwQDqQ1pP23CBKtgMdwrD+HX+lM2nOGqzXuexKU98Dt5nMAVkbHfmUHvZamz0g
+        a6WrYeSG0WZ81ko9h1i3fFqzuUvWUh3+XjS5/UqPrPku6MQLqTRiDpWIZcUrZIHKWq0JRj7vbR41
+        a7ijy25ajdgodXhlSXILLvCVCFGXQsRlgPRGwohMPAqI32vPjsoCq5w2LEVM3EeyaUitJHsJkLF0
+        CbFBL1257CG7Py+AeICA+33s9VLMUpwQyDi+54Uw9eeUi8QjUFmiL7rNtLqOOvdVQH1pQlwyphMq
+        HisIsLkckZAYnTRPZFlON1HnSSTLaJdSX770ZP5fOuIO0buBtOKmr9frWWabJ73medqQZfaI+fSe
+        OM78EllGD8Gjbc+bR5yeZbHXbLQaaUOWutZZyqie5QqocMBfpSC25XzMLHFd8XGEtHh0lILMVdMQ
+        KbihjrNqHUNZ8poQssl4nlKX2PP8UErerZ8DsozxDzPiNYpoWubMHQPnSznWWEoFZ500oIwsZWcn
+        KTNGdTUNsLvNGd7IctnviETT7m2OQCPL7aEf8czh+RBHMG8gGViW3X9Frrf51lRZ4thi4Nf84wHp
+        lLnRw+aeWQt0vCF32hbNekMla4Jzn1iA2GLcrHUaE/IF5n9b9MqarEscT2o44eZbYyVrzeOI3FO2
+        GZ8181El/drnK/zW1jjodzb3yNr5xLWYDTaRLmgw9dwgdeFK1sp95oeR9+XLZnWrylJA3Pf4NyhS
+        89fe6eZu6vPrLWg3zQi3XebsKbNPKkzn4zm9Uqo+F/c+fw5+kvlhb7Wp+MteSTS8sFfO8ukj/yuJ
+        oyyOKyspRVHeYvUf1yBf9uSy2clA/xrLp5xtkYSPHd0S8aJwGmG7UonY52n7twoe0oew5IU3cIvj
+        xffZ1EjcdZulfqzmX3mtn5AllMwl6DJu3Woz0uHZXAzFZ1Ovsh0J86syP2ACxtXb7k89qaXK8yLz
+        LurSRP01VE5iriulOiRfua7UlRfk5PSNTW7tF9Lhe6FneQ5GyaJpu91jawpnkc2PzJpMX8Nk2VsF
+        IuIFtUgQSv/gSys6xQ2ISBqjxYP+eAQovt17KXxCAgtNRPyk5U+zNRpQOiBO4KGqUpjKiqZdu3lt
+        eH658dFl3gYfzHZHXM9Tj7/G0qE2i/h328dszKVrwniMZ7Y3cbjAc6KcWOktmnZpkzUr/KPrTQOG
+        PUzsLZp2VPjIDaIpT6nxmy931LXF29ermlwtcPzdl36K+yEP6EJYyd0yd1weMT8IByMvcrGlzfIH
+        m0ccC8ssirvSn2J+MydG/BTBdryckj89Letufzf1y3nfsCzT0/WZJ9blF4TvgEl7/e5F8UX3vfRz
+        lh/49Q6HbrMgWFH9L7MumMcN/5GNrxPTC3PZWE9+Z5TfT4/Yg5i4NayQ3VExgwsif0Ss15nDhWRc
+        7rV+k8BadOz56KRgufkbnvzxEe6IE1HNhFZRWqnN7mbOq+souI6C1SoGVqsoWFcxsK7iI1fQkSv4
+        yAY6soEriII1HKyjbOg4GzrKho6zodVQMWr4yChYx8EayrOG84zql6Oeggqh4EKgYA0Ho/6JuyeG
+        RIGoLXBToA6B+4OKGkLFDWHo6MA6TpiGEqbhYqDsqji7OhpKOh5KBjqygY9soDIbuMwaKoaGi4GT
+        gXOBsqzmsIy6hZYToujIGj6ygUadgUcdOjA+rop6p5qTrvCBc0ZGw07F405HLaLnmATlQsW5QN0C
+        9wo0+PDYU1F5VVxeHWVCx5lQ0ZQJteuPfgIayjfiR5SSkuuFL5sk2PVRfTSsUrmmjizZsBRTNi1N
+        k62hYVKb2hXDqCCThy27fcOkQvxQodB4YNayuWKl4W3IUE2i1BTZsGsaaFXV5KEx0mVb1ay6Tolh
+        i1S+TsZW3b6PjHpFw8ngDW9BBr8EomxS/Y3KrKjwJoIrlmYRSqoyVZShbAxHRK6TYVVWrGGlVjGq
+        1siqIopt2e37rFit5liRN7wFGeqorhpVuwK6mDxQdUUmRlWXLYsaVU0dmUYVi+8tu30rGeIHPmPF
+        7UdoYNYqKwjiLeix7DoldVBMr1RBT1WryibhPwpIazVNJZqiGiZCz5bdvjP9mTnZz3wlKq75T8CG
+        6W8++nQCpIvVPdQ8PT//H4ugN2xdVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:46:10 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - de669b17bc5ebbfb4b4ea73231a8c6a6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEIK9rM5dfRbhSco1pUOAEJuQlJa08jYa8WA6pS4YODagV+Sx8
+        LFveBPDECVPCByDkws5Ti8kwuBxNHY8sm38AgviggFqpGXpFVXUDrssm4NpkMl2uviHB7XDeGc5I
+        BE4V+oQ5ax6VjMqt9AxYFoSe/ygsn5SFmwAbVd3UqomNBgnPlk9JCAYc2ODwyzI4BGJu4tlsxKw8
+        zMsMkSUcNUoch76wcQ7DqTNw34biXeSANmTIHBYymlSCiaYZDD91GHEtGp+PmBNSPw6OxA05usx4
+        8AIfNrd36riNIKChdNIqZLLJU6oJhYpH0WlMH+D8kyKbRB5dP9Wf5b35ifEsF5/05/m5qj3vlbaG
+        Fn/KSpVeSVE1HTJQTSZDy5bpSFFlXiFXa3WTV/EaiNGCBzFKwAm4tgX6Ow88cZyQ0LrhZ3EBWBn7
+        XjRNtc7S+ihiPWmYOtGYuWUCvsiGEaTl8hCl7TAag7f+vi1x/+UaX/8c03L9M67z2VXnsH0hhH9w
+        qDsOb8AZ6++iJH2AcIasPvIBwdPyAILvjgSI5s3GWb/Rk9pxD+ko7YHyYPve1IaAhEYHgpXLz29V
+        cCqcvXCdq913KBOLPpgS65aMab4K3TlgK8HjXlDR0hLl+QBw/uGGhXTQhRiDqPQh6N9Eqwefjg6a
+        7YtLudnEdIIWqWHfsQAy4tZu2WzIsUfKqYOu1hR/+jvmqwD7N/zJJy1pj9EDCc41RdFlpV58n7Cc
+        05HHRT871jfHKa489UOpfyWBCNSnkHdjDlQgQC3uSvx6Pur65xftnY7dKSp1t72V+cpoXr1sf7x8
+        H6e07mjZJ/eYBv3tNPjvHiBnkGqK8p5qmuZMUz4p6rVwx2Ickk9GCe6v2+HyHLjfhnCF6T7MYqql
+        5Kwqqwrcct+LqSAYDElAYdWT46n9Xk+CpQKFFUKM2D58P38uJwH8C6p/rVxZUxPmTAAdi+OreDLX
+        kC+1PJ84m7W8TFDfpSmqqFHW3lnRO1i3eX5uFGS17Qvoljcq6Kn9rX2wdzXrnjdnR7Pj2VmruH9x
+        erB3fjS7nH2YXcUVTYA0Z1cXsyY/F3HyTT2LOaHTPjguSe2DozVaXzk2vs7jy+lr9A/2TmeN2Vlx
+        vwHaHs86s1MoRgd7Z7PerFPcb/JSd9Ys7p/MS420NOfy+4bJIxZGPStJcGy8MbX6FnnnTi8rf/Tk
+        o2+ZfYSuf/wUpL8kBy3r/NJIOoDe+3FGEfnkY5JOkmzyMU4mkEtmF3CSxM3LOv3g9KNvy+E3UccT
+        yBkkkNNZN04hp7Pj4n73gteK4pXIGxfF/R7nqykyyjE0nYmMkpQaaSlL8CsP/UOTVbzE+dDGDPBh
+        2+lkEppfW9F8aK+uZmA59yZLucVu1cCmgeWzKd97w3S8odatdMZPXnnu/wqiz8nCBJ/DpIsMbCdU
+        WPeyZMN7QKx4/3ldn1aM2P/NhdWg1Ihxwe6sGdcXv7Y2oI7DPEybtmjY5TXwXPq471dVeIsQedNd
+        CnJHmMNlwHRLlGpkMDtiF5GP261DWWwm5QneIiHhE8zX3XLaqb3hpOYmGubzcCwad8RyicAJdkDB
+        PDkzm/YSUmoDcls1kq6BRHwqZV38zJMSASQWwG3294jxR52i4VbkVIp3fUsuqD0YPg4mxLkn6NKg
+        ncKkw0epM4ftlkFjJVwaBBH2qGJJh7MU9UNUEA/gksf564IeQysv7p90pYZt+yDqdyR01dTKarVe
+        VstaSa3xchkO8qKoKCVV4f/KFZgya0ZJSEcfCMxbqHgA/H5b+CeNfgNhhFe/MIPKnxryf4j85Vpe
+        zqir9TkZVlxxbQ6sqnJDVtSK+p6PNUCUQ5yTw3fn5BDl5PA9OQlCNh4E9I7y9xNwXjpSb9G+DTvs
+        7qR//XOOzovRYpVP+u9sfeyhFq9+d+tf/viIYO4gvAEW6D2W4k9c6fKGQnK/36EFSf5ddVdvpJnJ
+        3YSGJBCVmPzzxl1eQC1UyFtBZfT4w6yeRHLo9I6w5NBhlu8F3iiUDiPHoSFzt8sTnd7K4/+VipzM
+        0OmZpmyaJsAVRa7VzXdk4LzXb2F3R1H/p1l0TfkAg2k0dJZeTltXu8uBUncB5AvQnAQDDSNGHXuN
+        iCfjeT8uaIsCSgl/6WO/09lvtdZMzoeXHZ41khJNi+NwUZpXCsJE6Xu3SzbuInYFXmotgXZpK25E
+        JswR7zDmCn8kIBvz62ASOSFbZNn5VS5g9XNMQunUs/jTneQtT0lsrvJbpnh3MiPVcVe++rgRrWXQ
+        LTpkxN0I1zPwnucQH9bAm/BGBn9Ebc8nG+GVDLz564lEhlFA08ZqpvFXMLHnbRyrlhU16rU3gusZ
+        cONkM2VmBvuBuWCwQDqQ1pP23CBKtgMdwrD+HX+lM2nOGqzXuexKU98Dt5nMAVkbHfmUHvZamz0g
+        a6WrYeSG0WZ81ko9h1i3fFqzuUvWUh3+XjS5/UqPrPku6MQLqTRiDpWIZcUrZIHKWq0JRj7vbR41
+        a7ijy25ajdgodXhlSXILLvCVCFGXQsRlgPRGwohMPAqI32vPjsoCq5w2LEVM3EeyaUitJHsJkLF0
+        CbFBL1257CG7Py+AeICA+33s9VLMUpwQyDi+54Uw9eeUi8QjUFmiL7rNtLqOOvdVQH1pQlwyphMq
+        HisIsLkckZAYnTRPZFlON1HnSSTLaJdSX770ZP5fOuIO0buBtOKmr9frWWabJ73medqQZfaI+fSe
+        OM78EllGD8Gjbc+bR5yeZbHXbLQaaUOWutZZyqie5QqocMBfpSC25XzMLHFd8XGEtHh0lILMVdMQ
+        KbihjrNqHUNZ8poQssl4nlKX2PP8UErerZ8DsozxDzPiNYpoWubMHQPnSznWWEoFZ500oIwsZWcn
+        KTNGdTUNsLvNGd7IctnviETT7m2OQCPL7aEf8czh+RBHMG8gGViW3X9Frrf51lRZ4thi4Nf84wHp
+        lLnRw+aeWQt0vCF32hbNekMla4Jzn1iA2GLcrHUaE/IF5n9b9MqarEscT2o44eZbYyVrzeOI3FO2
+        GZ8181El/drnK/zW1jjodzb3yNr5xLWYDTaRLmgw9dwgdeFK1sp95oeR9+XLZnWrylJA3Pf4NyhS
+        89fe6eZu6vPrLWg3zQi3XebsKbNPKkzn4zm9Uqo+F/c+fw5+kvlhb7Wp+MteSTS8sFfO8ukj/yuJ
+        oyyOKyspRVHeYvUf1yBf9uSy2clA/xrLp5xtkYSPHd0S8aJwGmG7UonY52n7twoe0oew5IU3cIvj
+        xffZ1EjcdZulfqzmX3mtn5AllMwl6DJu3Woz0uHZXAzFZ1Ovsh0J86syP2ACxtXb7k89qaXK8yLz
+        LurSRP01VE5iriulOiRfua7UlRfk5PSNTW7tF9Lhe6FneQ5GyaJpu91jawpnkc2PzJpMX8Nk2VsF
+        IuIFtUgQSv/gSys6xQ2ISBqjxYP+eAQovt17KXxCAgtNRPyk5U+zNRpQOiBO4KGqUpjKiqZdu3lt
+        eH658dFl3gYfzHZHXM9Tj7/G0qE2i/h328dszKVrwniMZ7Y3cbjAc6KcWOktmnZpkzUr/KPrTQOG
+        PUzsLZp2VPjIDaIpT6nxmy931LXF29ermlwtcPzdl36K+yEP6EJYyd0yd1weMT8IByMvcrGlzfIH
+        m0ccC8ssirvSn2J+MydG/BTBdryckj89Letufzf1y3nfsCzT0/WZJ9blF4TvgEl7/e5F8UX3vfRz
+        lh/49Q6HbrMgWFH9L7MumMcN/5GNrxPTC3PZWE9+Z5TfT4/Yg5i4NayQ3VExgwsif0Ss15nDhWRc
+        7rV+k8BadOz56KRgufkbnvzxEe6IE1HNhFZRWqnN7mbOq+souI6C1SoGVqsoWFcxsK7iI1fQkSv4
+        yAY6soEriII1HKyjbOg4GzrKho6zodVQMWr4yChYx8EayrOG84zql6Oeggqh4EKgYA0Ho/6JuyeG
+        RIGoLXBToA6B+4OKGkLFDWHo6MA6TpiGEqbhYqDsqji7OhpKOh5KBjqygY9soDIbuMwaKoaGi4GT
+        gXOBsqzmsIy6hZYToujIGj6ygUadgUcdOjA+rop6p5qTrvCBc0ZGw07F405HLaLnmATlQsW5QN0C
+        9wo0+PDYU1F5VVxeHWVCx5lQ0ZQJteuPfgIayjfiR5SSkuuFL5sk2PVRfTSsUrmmjizZsBRTNi1N
+        k62hYVKb2hXDqCCThy27fcOkQvxQodB4YNayuWKl4W3IUE2i1BTZsGsaaFXV5KEx0mVb1ay6Tolh
+        i1S+TsZW3b6PjHpFw8ngDW9BBr8EomxS/Y3KrKjwJoIrlmYRSqoyVZShbAxHRK6TYVVWrGGlVjGq
+        1siqIopt2e37rFit5liRN7wFGeqorhpVuwK6mDxQdUUmRlWXLYsaVU0dmUYVi+8tu30rGeIHPmPF
+        7UdoYNYqKwjiLeix7DoldVBMr1RBT1WryibhPwpIazVNJZqiGiZCz5bdvjP9mTnZz3wlKq75T8CG
+        6W8++nQCpIvVPdQ8PT//H4ugN2xdVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:46:21 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - a5edb64ed4b77d5f9e163e6e9bb330c4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEIK9rM5dfRbhSco1pUOAEJuQlJa08jYa8WA6pS4YODagV+Sx8
+        LFveBPDECVPCByDkws5Ti8kwuBxNHY8sm38AgviggFqpGXpFVXUDrssm4NpkMl2uviHB7XDeGc5I
+        BE4V+oQ5ax6VjMqt9AxYFoSe/ygsn5SFmwAbVd3UqomNBgnPlk9JCAYc2ODwyzI4BGJu4tlsxKw8
+        zMsMkSUcNUoch76wcQ7DqTNw34biXeSANmTIHBYymlSCiaYZDD91GHEtGp+PmBNSPw6OxA05usx4
+        8AIfNrd36riNIKChdNIqZLLJU6oJhYpH0WlMH+D8kyKbRB5dP9Wf5b35ifEsF5/05/m5qj3vlbaG
+        Fn/KSpVeSVE1HTJQTSZDy5bpSFFlXiFXa3WTV/EaiNGCBzFKwAm4tgX6Ow88cZyQ0LrhZ3EBWBn7
+        XjRNtc7S+ihiPWmYOtGYuWUCvsiGEaTl8hCl7TAag7f+vi1x/+UaX/8c03L9M67z2VXnsH0hhH9w
+        qDsOb8AZ6++iJH2AcIasPvIBwdPyAILvjgSI5s3GWb/Rk9pxD+ko7YHyYPve1IaAhEYHgpXLz29V
+        cCqcvXCdq913KBOLPpgS65aMab4K3TlgK8HjXlDR0hLl+QBw/uGGhXTQhRiDqPQh6N9Eqwefjg6a
+        7YtLudnEdIIWqWHfsQAy4tZu2WzIsUfKqYOu1hR/+jvmqwD7N/zJJy1pj9EDCc41RdFlpV58n7Cc
+        05HHRT871jfHKa489UOpfyWBCNSnkHdjDlQgQC3uSvx6Pur65xftnY7dKSp1t72V+cpoXr1sf7x8
+        H6e07mjZJ/eYBv3tNPjvHiBnkGqK8p5qmuZMUz4p6rVwx2Ickk9GCe6v2+HyHLjfhnCF6T7MYqql
+        5Kwqqwrcct+LqSAYDElAYdWT46n9Xk+CpQKFFUKM2D58P38uJwH8C6p/rVxZUxPmTAAdi+OreDLX
+        kC+1PJ84m7W8TFDfpSmqqFHW3lnRO1i3eX5uFGS17Qvoljcq6Kn9rX2wdzXrnjdnR7Pj2VmruH9x
+        erB3fjS7nH2YXcUVTYA0Z1cXsyY/F3HyTT2LOaHTPjguSe2DozVaXzk2vs7jy+lr9A/2TmeN2Vlx
+        vwHaHs86s1MoRgd7Z7PerFPcb/JSd9Ys7p/MS420NOfy+4bJIxZGPStJcGy8MbX6FnnnTi8rf/Tk
+        o2+ZfYSuf/wUpL8kBy3r/NJIOoDe+3FGEfnkY5JOkmzyMU4mkEtmF3CSxM3LOv3g9KNvy+E3UccT
+        yBkkkNNZN04hp7Pj4n73gteK4pXIGxfF/R7nqykyyjE0nYmMkpQaaSlL8CsP/UOTVbzE+dDGDPBh
+        2+lkEppfW9F8aK+uZmA59yZLucVu1cCmgeWzKd97w3S8odatdMZPXnnu/wqiz8nCBJ/DpIsMbCdU
+        WPeyZMN7QKx4/3ldn1aM2P/NhdWg1Ihxwe6sGdcXv7Y2oI7DPEybtmjY5TXwXPq471dVeIsQedNd
+        CnJHmMNlwHRLlGpkMDtiF5GP261DWWwm5QneIiHhE8zX3XLaqb3hpOYmGubzcCwad8RyicAJdkDB
+        PDkzm/YSUmoDcls1kq6BRHwqZV38zJMSASQWwG3294jxR52i4VbkVIp3fUsuqD0YPg4mxLkn6NKg
+        ncKkw0epM4ftlkFjJVwaBBH2qGJJh7MU9UNUEA/gksf564IeQysv7p90pYZt+yDqdyR01dTKarVe
+        VstaSa3xchkO8qKoKCVV4f/KFZgya0ZJSEcfCMxbqHgA/H5b+CeNfgNhhFe/MIPKnxryf4j85Vpe
+        zqir9TkZVlxxbQ6sqnJDVtSK+p6PNUCUQ5yTw3fn5BDl5PA9OQlCNh4E9I7y9xNwXjpSb9G+DTvs
+        7qR//XOOzovRYpVP+u9sfeyhFq9+d+tf/viIYO4gvAEW6D2W4k9c6fKGQnK/36EFSf5ddVdvpJnJ
+        3YSGJBCVmPzzxl1eQC1UyFtBZfT4w6yeRHLo9I6w5NBhlu8F3iiUDiPHoSFzt8sTnd7K4/+VipzM
+        0OmZpmyaJsAVRa7VzXdk4LzXb2F3R1H/p1l0TfkAg2k0dJZeTltXu8uBUncB5AvQnAQDDSNGHXuN
+        iCfjeT8uaIsCSgl/6WO/09lvtdZMzoeXHZ41khJNi+NwUZpXCsJE6Xu3SzbuInYFXmotgXZpK25E
+        JswR7zDmCn8kIBvz62ASOSFbZNn5VS5g9XNMQunUs/jTneQtT0lsrvJbpnh3MiPVcVe++rgRrWXQ
+        LTpkxN0I1zPwnucQH9bAm/BGBn9Ebc8nG+GVDLz564lEhlFA08ZqpvFXMLHnbRyrlhU16rU3gusZ
+        cONkM2VmBvuBuWCwQDqQ1pP23CBKtgMdwrD+HX+lM2nOGqzXuexKU98Dt5nMAVkbHfmUHvZamz0g
+        a6WrYeSG0WZ81ko9h1i3fFqzuUvWUh3+XjS5/UqPrPku6MQLqTRiDpWIZcUrZIHKWq0JRj7vbR41
+        a7ijy25ajdgodXhlSXILLvCVCFGXQsRlgPRGwohMPAqI32vPjsoCq5w2LEVM3EeyaUitJHsJkLF0
+        CbFBL1257CG7Py+AeICA+33s9VLMUpwQyDi+54Uw9eeUi8QjUFmiL7rNtLqOOvdVQH1pQlwyphMq
+        HisIsLkckZAYnTRPZFlON1HnSSTLaJdSX770ZP5fOuIO0buBtOKmr9frWWabJ73medqQZfaI+fSe
+        OM78EllGD8Gjbc+bR5yeZbHXbLQaaUOWutZZyqie5QqocMBfpSC25XzMLHFd8XGEtHh0lILMVdMQ
+        KbihjrNqHUNZ8poQssl4nlKX2PP8UErerZ8DsozxDzPiNYpoWubMHQPnSznWWEoFZ500oIwsZWcn
+        KTNGdTUNsLvNGd7IctnviETT7m2OQCPL7aEf8czh+RBHMG8gGViW3X9Frrf51lRZ4thi4Nf84wHp
+        lLnRw+aeWQt0vCF32hbNekMla4Jzn1iA2GLcrHUaE/IF5n9b9MqarEscT2o44eZbYyVrzeOI3FO2
+        GZ8181El/drnK/zW1jjodzb3yNr5xLWYDTaRLmgw9dwgdeFK1sp95oeR9+XLZnWrylJA3Pf4NyhS
+        89fe6eZu6vPrLWg3zQi3XebsKbNPKkzn4zm9Uqo+F/c+fw5+kvlhb7Wp+MteSTS8sFfO8ukj/yuJ
+        oyyOKyspRVHeYvUf1yBf9uSy2clA/xrLp5xtkYSPHd0S8aJwGmG7UonY52n7twoe0oew5IU3cIvj
+        xffZ1EjcdZulfqzmX3mtn5AllMwl6DJu3Woz0uHZXAzFZ1Ovsh0J86syP2ACxtXb7k89qaXK8yLz
+        LurSRP01VE5iriulOiRfua7UlRfk5PSNTW7tF9Lhe6FneQ5GyaJpu91jawpnkc2PzJpMX8Nk2VsF
+        IuIFtUgQSv/gSys6xQ2ISBqjxYP+eAQovt17KXxCAgtNRPyk5U+zNRpQOiBO4KGqUpjKiqZdu3lt
+        eH658dFl3gYfzHZHXM9Tj7/G0qE2i/h328dszKVrwniMZ7Y3cbjAc6KcWOktmnZpkzUr/KPrTQOG
+        PUzsLZp2VPjIDaIpT6nxmy931LXF29ermlwtcPzdl36K+yEP6EJYyd0yd1weMT8IByMvcrGlzfIH
+        m0ccC8ssirvSn2J+MydG/BTBdryckj89Letufzf1y3nfsCzT0/WZJ9blF4TvgEl7/e5F8UX3vfRz
+        lh/49Q6HbrMgWFH9L7MumMcN/5GNrxPTC3PZWE9+Z5TfT4/Yg5i4NayQ3VExgwsif0Ss15nDhWRc
+        7rV+k8BadOz56KRgufkbnvzxEe6IE1HNhFZRWqnN7mbOq+souI6C1SoGVqsoWFcxsK7iI1fQkSv4
+        yAY6soEriII1HKyjbOg4GzrKho6zodVQMWr4yChYx8EayrOG84zql6Oeggqh4EKgYA0Ho/6JuyeG
+        RIGoLXBToA6B+4OKGkLFDWHo6MA6TpiGEqbhYqDsqji7OhpKOh5KBjqygY9soDIbuMwaKoaGi4GT
+        gXOBsqzmsIy6hZYToujIGj6ygUadgUcdOjA+rop6p5qTrvCBc0ZGw07F405HLaLnmATlQsW5QN0C
+        9wo0+PDYU1F5VVxeHWVCx5lQ0ZQJteuPfgIayjfiR5SSkuuFL5sk2PVRfTSsUrmmjizZsBRTNi1N
+        k62hYVKb2hXDqCCThy27fcOkQvxQodB4YNayuWKl4W3IUE2i1BTZsGsaaFXV5KEx0mVb1ay6Tolh
+        i1S+TsZW3b6PjHpFw8ngDW9BBr8EomxS/Y3KrKjwJoIrlmYRSqoyVZShbAxHRK6TYVVWrGGlVjGq
+        1siqIopt2e37rFit5liRN7wFGeqorhpVuwK6mDxQdUUmRlWXLYsaVU0dmUYVi+8tu30rGeIHPmPF
+        7UdoYNYqKwjiLeix7DoldVBMr1RBT1WryibhPwpIazVNJZqiGiZCz5bdvjP9mTnZz3wlKq75T8CG
+        6W8++nQCpIvVPdQ8PT//H4ugN2xdVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:46:31 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - fd145d10c26f60f4782e5a061c01d519
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEBT9yXebyqwhXSq4xDQqcwIS8pKSVp9GQF8shdcnQoQG1Ip+F
+        j2XLmwCeOGFK+ACEXNh5ajEZBpejqeORZfMPQBAfFFArNUOvqKpuwHXZBFybTKaLarMK6pLgdjjv
+        DGckAqcKfcKcNY9KRuVWegYsC0LPfxSWT8rCTYCNqm5q1cRGg4Rny6ckBAMObHD4ZdEcAjE38Ww2
+        YhaG4XK+zBBZwlGjxHHoCxvnMJw6A/dtKN5FDmhDhsxhIaNJJZhomsHwU4cR16Lx+Yg5IfXj4Ejc
+        kKPLjAcv8GFze6eO2wgCGkonrUImmzylmlCoeBSdxvQBzj8psknk0fVT/Vnem58Yz3LxSX+en6va
+        815pa2jxp6xU6ZUUVdMhA9VkMrRsmY4UVeYVcrVWN3kVr4EYLXgQowScgGtboL/zwBPHCQmtG34W
+        F4CVse9F01TrLK2PItaThqkTjZlbJuCLbBhBWi4PUdoOozF46+/bEvdfrvH1zzEt1z/jOp9ddQ7b
+        F0L4B4e64/AGnLH+LkrSBwhnyOojHxA8LQ8g+O5IgGjebJz1Gz2pHfeQjtIeKA+2701tCEhodCBY
+        ufz8VgWnwtkL17nafYcyseiDKbFuyZjmq9CdA7YSPO4FFS0tUZ4PAOcfblhIB12IMYhKH4L+TbR6
+        8OnooNm+uJSbTUwnaJEa9h0LICNu7ZbNhhx7pJw66GpN8ae/Y74KsH/Dn3zSkvYYPZDgXFMUXVbq
+        xfcJyzkdeVz0s2N9c5ziylM/lPpXEohAfQp5N+ZABQLU4q7Er+ejrn9+0d7p2J2iUnfbW5mvjObV
+        y/bHy/dxSuuOln1yj2nQ306D/+4BcgappijvqaZpzjTlk6JeC3csxiH5ZJTg/rodLs+B+20IV5ju
+        wyymWkrOqrKqwC33vZgKgsGQBBRWPTme2u/1JFgqUFghxIjtw/fz53ISwL+g+tfKlTU1Yc4E0LE4
+        vooncw35UsvzibNZy8sE9V2aoooaZe2dFb2DdZvn50ZBVtu+gG55o4Ke2t/aB3tXs+55c3Y0O56d
+        tYr7F6cHe+dHs8vZh9lVXNEESHN2dTFr8nMRJ9/Us5gTOu2D45LUPjhao/WVY+PrPL6cvkb/YO90
+        1pidFfcboO3xrDM7hWJ0sHc26806xf0mL3VnzeL+ybzUSEtzLr9vmDxiYdSzkgTHxhtTq2+Rd+70
+        svJHTz76ltlH6PrHT0H6S3LQss4vjaQD6L0fZxSRTz4m6STJJh/jZAK5ZHYBJ0ncvKzTD04/+rYc
+        fhN1PIGcQQI5nXXjFHI6Oy7udy94rSheibxxUdzvcb6aIqMcQ9OZyChJqZGWsgS/8tA/NFnFS5wP
+        bcwAH7adTiah+bUVzYf26moGlnNvspRb7FYNbBpYPpvyvTdMxxtq3Upn/OSV5/6vIPqcLEzwOUy6
+        yMB2QoV1L0s2vAfEivef1/VpxYj931xYDUqNGBfszppxffFrawPqOMzDtGmLhl1eA8+lj/t+VYW3
+        CJE33aUgd4Q5XAZMt0SpRgazI3YR+bjdOpTFZlKe4C0SEj7BfN0tp53aG05qbqJhPg/HonFHLJcI
+        nGAHFMyTM7NpLyGlNiC3VSPpGkjEp1LWxc88KRFAYgHcZn+PGH/UKRpuRU6leNe35ILag+HjYEKc
+        e4IuDdopTDp8lDpz2G4ZNFbCpUEQYY8qlnQ4S1E/RAXxAC55nL8u6DG08uL+SVdq2LYPon5HQldN
+        raxW62W1rJXUGi+X4SAviopSUhX+r1yBKbNmlIR09IHAvIWKB8Dvt4V/0ug3EEZ49QszqPypIf+H
+        yF+u5eWMulqfk2HFFdfmwKoqN2RFrajv+VgDRDnEOTl8d04OUU4O35OTIGTjQUDvKH8/AeelI/UW
+        7duww+5O+tc/5+i8GC1W+aT/ztbHHmrx6ne3/uWPjwjmDsIbYIHeYyn+xJUubygk9/sdWpDk31V3
+        9UaamdxNaEgCUYnJP2/c5QXUQoW8FVRGjz/M6kkkh07vCEsOHWb5XuCNQukwchwaMne7PNHprTz+
+        X6nIyQydnmnKpmkCXFHkWt18RwbOe/0WdncU9X+aRdeUDzCYRkNn6eW0dbW7HCh1F0C+AM1JMNAw
+        YtSx14h4Mp7344K2KKCU8Jc+9jud/VZrzeR8eNnhWSMp0bQ4DheleaUgTJS+d7tk4y5iV+Cl1hJo
+        l7biRmTCHPEOY67wRwKyMb8OJpETskWWnV/lAlY/xySUTj2LP91J3vKUxOYqv2WKdyczUh135auP
+        G9FaBt2iQ0bcjXA9A+95DvFhDbwJb2TwR9T2fLIRXsnAm7+eSGQYBTRtrGYafwUTe97GsWpZUaNe
+        eyO4ngE3TjZTZmawH5gLBgukA2k9ac8NomQ70CEM69/xVzqT5qzBep3LrjT1PXCbyRyQtdGRT+lh
+        r7XZA7JWuhpGbhhtxmet1HOIdcunNZu7ZC3V4e9Fk9uv9Mia74JOvJBKI+ZQiVhWvEIWqKzVmmDk
+        897mUbOGO7rsptWIjVKHV5Ykt+ACX4kQdSlEXAZIbySMyMSjgPi99uyoLLDKacNSxMR9JJuG1Eqy
+        lwAZS5cQG/TSlcsesvvzAogHCLjfx14vxSzFCYGM43teCFN/TrlIPAKVJfqi20yr66hzXwXUlybE
+        JWM6oeKxggCbyxEJidFJ80SW5XQTdZ5Esox2KfXlS0/m/6Uj7hC9G0grbvp6vZ5ltnnSa56nDVlm
+        j5hP74njzC+RZfQQPNr2vHnE6VkWe81Gq5E2ZKlrnaWM6lmugAoH/FUKYlvOx8wS1xUfR0iLR0cp
+        yFw1DZGCG+o4q9YxlCWvCSGbjOcpdYk9zw+l5N36OSDLGP8wI16jiKZlztwxcL6UY42lVHDWSQPK
+        yFJ2dpIyY1RX0wC725zhjSyX/Y5INO3e5gg0stwe+hHPHJ4PcQTzBpKBZdn9V+R6m29NlSWOLQZ+
+        zT8ekE6ZGz1s7pm1QMcbcqdt0aw3VLImOPeJBYgtxs1apzEhX2D+t0WvrMm6xPGkhhNuvjVWstY8
+        jsg9ZZvxWTMfVdKvfb7Cb22Ng35nc4+snU9ci9lgE+mCBlPPDVIXrmSt3Gd+GHlfvmxWt6osBcR9
+        j3+DIjV/7Z1u7qY+v96CdtOMcNtlzp4y+6TCdD6e0yul6nNx7/Pn4CeZH/ZWm4q/7JVEwwt75Syf
+        PvK/kjjK4riyklIU5S1W/3EN8mVPLpudDPSvsXzK2RZJ+NjRLREvCqcRtiuViH2etn+r4CF9CEte
+        eAO3OF58n02NxF23WerHav6V1/oJWULJXIIu49atNiMdns3FUHw29SrbkTC/KvMDJmBcve3+1JNa
+        qjwvMu+iLk3UX0PlJOa6UqpD8pXrSl15QU5O39jk1n4hHb4XepbnYJQsmrbbPbamcBbZ/MisyfQ1
+        TJa9VSAiXlCLBKH0D760olPcgIikMVo86I9HgOLbvZfCJySw0ETET1r+NFujAaUD4gQeqiqFqaxo
+        2rWb14bnlxsfXeZt8MFsd8T1PPX4aywdarOIf7d9zMZcuiaMx3hmexOHCzwnyomV3qJplzZZs8I/
+        ut40YNjDxN6iaUeFj9wgmvKUGr/5ckddW7x9varJ1QLH333pp7gf8oAuhJXcLXPH5RHzg3Aw8iIX
+        W9osf7B5xLGwzKK4K/0p5jdzYsRPEWzHyyn509Oy7vZ3U7+c9w3LMj1dn3liXX5B+A6YtNfvXhRf
+        dN9LP2f5gV/vcOg2C4IV1f8y64J53PAf2fg6Mb0wl4315HdG+f30iD2IiVvDCtkdFTO4IPJHxHqd
+        OVxIxuVe6zcJrEXHno9OCpabv+HJHx/hjjgR1UxoFaWV2uxu5ry6joLrKFitYmC1ioJ1FQPrKj5y
+        BR25go9soCMbuIIoWMPBOsqGjrOho2zoOBtaDRWjho+MgnUcrKE8azjPqH456imoEAouBArWcDDq
+        n7h7YkgUiNoCNwXqELg/qKghVNwQho4OrOOEaShhGi4Gyq6Ks6ujoaTjoWSgIxv4yAYqs4HLrKFi
+        aLgYOBk4FyjLag7LqFtoOSGKjqzhIxto1Bl41KED4+OqqHeqOekKHzhnZDTsVDzudNQieo5JUC5U
+        nAvULXCvQIMPjz0VlVfF5dVRJnScCRVNmVC7/ugnoKF8I35EKSm5XviySYJdH9VHwyqVa+rIkg1L
+        MWXT0jTZGhomtaldMYwKMnnYsts3TCrEDxUKjQdmLZsrVhrehgzVJEpNkQ27poFWVU0eGiNdtlXN
+        quuUGLZI5etkbNXt+8ioVzScDN7wFmTwSyDKJtXfqMyKCm8iuGJpFqGkKlNFGcrGcETkOhlWZcUa
+        VmoVo2qNrCqi2Jbdvs+K1WqOFXnDW5ChjuqqUbUroIvJA1VXZGJUddmyqFHV1JFpVLH43rLbt5Ih
+        fuAzVtx+hAZmrbKCIN6CHsuuU1IHxfRKFfRUtapsEv6jgLRW01SiKaphIvRs2e0705+Zk/3MV6Li
+        mv8EbJj+5qNPJ0C6WN1DzdPz8/8BPNSQF11WAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:46:42 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 0fff2dddddc73279f3f8a66e6db90130
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd/pause
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Nov 2019 15:46:42 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - ''
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - ce79e6d0aec057c4057c86a1ef6c40cb
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEhSmJAubyqwhXSq4xDQqcwIS8pKSVp9GQF8shdcnQoQG1Ip+F
+        j2XLmwCeOGFK+ACEXNh5ajEZBpejqeORZfMPQBAfFFArNUOvqKpuwHXZBFybTKbzak0B9W9IcDuc
+        d4YzEoFThT5hzppHJaNyKz0DlgWh5z8Kyydl4SbARlU3tWpio0HCs+VTEoIBBzY4/LJoDoGYm3g2
+        GzELwQg5X2aILOGoUeI49IWNcxhOnYH7NhTvIge0IUPmsJDRpBJMNM1g+KnDiGvR+HzEnJD6cXAk
+        bsjRZcaDF/iwub1Tx20EAQ2lk1Yhk02eUk0oVDyKTmP6AOefFNkk8uj6qf4s781PjGe5+KQ/z89V
+        7XmvtDW0+FNWqvRKiqrpkIFqMhlatkxHiirzCrlaq5u8itdAjBY8iFECTsC1LdDfeeCJ44SE1g0/
+        iwvAytj3ommqdZbWRxHrScPUicbMLRPwRTaMIC2Xhyhth9EYvPX3bYn7L9f4+ueYluufcZ3PrjqH
+        7Qsh/IND3XF4A85Yfxcl6QOEM2T1kQ8InpYHEHx3JEA0bzbO+o2e1I57SEdpD5QH2/emNgQkNDoQ
+        rFx+fquCU+Hshetc7b5DmVj0wZRYt2RM81XozgFbCR73goqWlijPB4DzDzcspIMuxBhEpQ9B/yZa
+        Pfh0dNBsX1zKzSamE7RIDfuOBZARt3bLZkOOPVJOHXS1pvjT3zFfBdi/4U8+aUl7jB5IcK4pii4r
+        9eL7hOWcjjwu+tmxvjlOceWpH0r9KwlEoD6FvBtzoAIBanFX4tfzUdc/v2jvdOxOUam77a3MV0bz
+        6mX74+X7OKV1R8s+ucc06G+nwX/3ADmDVFOU91TTNGea8klRr4U7FuOQfDJKcH/dDpfnwP02hCtM
+        92EWUy0lZ1VZVeCW+15MBcFgSAIKq54cT+33ehIsFSisEGLE9uH7+XM5CeBfUP1r5cqamjBnAuhY
+        HF/Fk7mGfKnl+cTZrOVlgvouTVFFjbL2zorewbrN83OjIKttX0C3vFFBT+1v7YO9q1n3vDk7mh3P
+        zlrF/YvTg73zo9nl7MPsKq5oAqQ5u7qYNfm5iJNv6lnMCZ32wXFJah8crdH6yrHxdR5fTl+jf7B3
+        OmvMzor7DdD2eNaZnUIxOtg7m/VmneJ+k5e6s2Zx/2ReaqSlOZffN0wesTDqWUmCY+ONqdW3yDt3
+        eln5oycffcvsI3T946cg/SU5aFnnl0bSAfTejzOKyCcfk3SSZJOPcTKBXDK7gJMkbl7W6QenH31b
+        Dr+JOp5AziCBnM66cQo5nR0X97sXvFYUr0TeuCju9zhfTZFRjqHpTGSUpNRIS1mCX3noH5qs4iXO
+        hzZmgA/bTieT0PzaiuZDe3U1A8u5N1nKLXarBjYNLJ9N+d4bpuMNtW6lM37yynP/VxB9ThYm+Bwm
+        XWRgO6HCupclG94DYsX7z+v6tGLE/m8urAalRowLdmfNuL74tbUBdRzmYdq0RcMur4Hn0sd9v6rC
+        W4TIm+5SkDvCHC4DpluiVCOD2RG7iHzcbh3KYjMpT/AWCQmfYL7ultNO7Q0nNTfRMJ+HY9G4I5ZL
+        BE6wAwrmyZnZtJeQUhuQ26qRdA0k4lMp6+JnnpQIILEAbrO/R4w/6hQNtyKnUrzrW3JB7cHwcTAh
+        zj1BlwbtFCYdPkqdOWy3DBor4dIgiLBHFUs6nKWoH6KCeACXPM5fF/QYWnlx/6QrNWzbB1G/I6Gr
+        plZWq/WyWtZKao2Xy3CQF0VFKakK/1euwJRZM0pCOvpAYN5CxQPg99vCP2n0GwgjvPqFGVT+1JD/
+        Q+Qv1/JyRl2tz8mw4oprc2BVlRuyolbU93ysAaIc4pwcvjsnhygnh+/JSRCy8SCgd5S/n4Dz0pF6
+        i/Zt2GF3J/3rn3N0XowWq3zSf2frYw+1ePW7W//yx0cEcwfhDbBA77EUf+JKlzcUkvv9Di1I8u+q
+        u3ojzUzuJjQkgajE5J837vICaqFC3goqo8cfZvUkkkOnd4Qlhw6zfC/wRqF0GDkODZm7XZ7o9FYe
+        /69U5GSGTs80ZdM0Aa4ocq1uviMD571+C7s7ivo/zaJrygcYTKOhs/Ry2rraXQ6UugsgX4DmJBho
+        GDHq2GtEPBnP+3FBWxRQSvhLH/udzn6rtWZyPrzs8KyRlGhaHIeL0rxSECZK37tdsnEXsSvwUmsJ
+        tEtbcSMyYY54hzFX+CMB2ZhfB5PICdkiy86vcgGrn2MSSqeexZ/uJG95SmJzld8yxbuTGamOu/LV
+        x41oLYNu0SEj7ka4noH3PIf4sAbehDcy+CNqez7ZCK9k4M1fTyQyjAKaNlYzjb+CiT1v41i1rKhR
+        r70RXM+AGyebKTMz2A/MBYMF0oG0nrTnBlGyHegQhvXv+CudSXPWYL3OZVea+h64zWQOyNroyKf0
+        sNfa7AFZK10NIzeMNuOzVuo5xLrl05rNXbKW6vD3osntV3pkzXdBJ15IpRFzqEQsK14hC1TWak0w
+        8nlv86hZwx1ddtNqxEapwytLkltwga9EiLoUIi4DpDcSRmTiUUD8Xnt2VBZY5bRhKWLiPpJNQ2ol
+        2UuAjKVLiA166cplD9n9eQHEAwTc72Ovl2KW4oRAxvE9L4SpP6dcJB6ByhJ90W2m1XXUua8C6ksT
+        4pIxnVDxWEGAzeWIhMTopHkiy3K6iTpPIllGu5T68qUn8//SEXeI3g2kFTd9vV7PMts86TXP04Ys
+        s0fMp/fEceaXyDJ6CB5te9484vQsi71mo9VIG7LUtc5SRvUsV0CFA/4qBbEt52NmieuKjyOkxaOj
+        FGSumoZIwQ11nFXrGMqS14SQTcbzlLrEnueHUvJu/RyQZYx/mBGvUUTTMmfuGDhfyrHGUio466QB
+        ZWQpOztJmTGqq2mA3W3O8EaWy35HJJp2b3MEGlluD/2IZw7PhziCeQPJwLLs/ityvc23psoSxxYD
+        v+YfD0inzI0eNvfMWqDjDbnTtmjWGypZE5z7xALEFuNmrdOYkC8w/9uiV9ZkXeJ4UsMJN98aK1lr
+        HkfknrLN+KyZjyrp1z5f4be2xkG/s7lH1s4nrsVssIl0QYOp5wapC1eyVu4zP4y8L182q1tVlgLi
+        vse/QZGav/ZON3dTn19vQbtpRrjtMmdPmX1SYTofz+mVUvW5uPf5c/CTzA97q03FX/ZKouGFvXKW
+        Tx/5X0kcZXFcWUkpivIWq/+4BvmyJ5fNTgb611g+5WyLJHzs6JaIF4XTCNuVSsQ+T9u/VfCQPoQl
+        L7yBWxwvvs+mRuKu2yz1YzX/ymv9hCyhZC5Bl3HrVpuRDs/mYig+m3qV7UiYX5X5ARMwrt52f+pJ
+        LVWeF5l3UZcm6q+hchJzXSnVIfnKdaWuvCAnp29scmu/kA7fCz3LczBKFk3b7R5bUziLbH5k1mT6
+        GibL3ioQES+oRYJQ+gdfWtEpbkBE0hgtHvTHI0Dx7d5L4RMSWGgi4ictf5qt0YDSAXECD1WVwlRW
+        NO3azWvD88uNjy7zNvhgtjviep56/DWWDrVZxL/bPmZjLl0TxmM8s72JwwWeE+XESm/RtEubrFnh
+        H11vGjDsYWJv0bSjwkduEE15So3ffLmjri3evl7V5GqB4+++9FPcD3lAF8JK7pa54/KI+UE4GHmR
+        iy1tlj/YPOJYWGZR3JX+FPObOTHipwi24+WU/OlpWXf7u6lfzvuGZZmers88sS6/IHwHTNrrdy+K
+        L7rvpZ+z/MCvdzh0mwXBiup/mXXBPG74j2x8nZhemMvGevI7o/x+esQexMStYYXsjooZXBD5I2K9
+        zhwuJONyr/WbBNaiY89HJwXLzd/w5I+PcEeciGomtIrSSm12N3NeXUfBdRSsVjGwWkXBuoqBdRUf
+        uYKOXMFHNtCRDVxBFKzhYB1lQ8fZ0FE2dJwNrYaKUcNHRsE6DtZQnjWcZ1S/HPUUVAgFFwIFazgY
+        9U/cPTEkCkRtgZsCdQjcH1TUECpuCENHB9ZxwjSUMA0XA2VXxdnV0VDS8VAy0JENfGQDldnAZdZQ
+        MTRcDJwMnAuUZTWHZdQttJwQRUfW8JENNOoMPOrQgfFxVdQ71Zx0hQ+cMzIadioedzpqET3HJCgX
+        Ks4F6ha4V6DBh8eeisqr4vLqKBM6zoSKpkyoXX/0E9BQvhE/opSUXC982STBro/qo2GVyjV1ZMmG
+        pZiyaWmabA0Nk9rUrhhGBZk8bNntGyYV4ocKhcYDs5bNFSsNb0OGahKlpsiGXdNAq6omD42RLtuq
+        ZtV1SgxbpPJ1Mrbq9n1k1CsaTgZveAsy+CUQZZPqb1RmRYU3EVyxNItQUpWpogxlYzgicp0Mq7Ji
+        DSu1ilG1RlYVUWzLbt9nxWo1x4q84S3IUEd11ajaFdDF5IGqKzIxqrpsWdSoaurINKpYfG/Z7VvJ
+        ED/wGStuP0IDs1ZZQRBvQY9l1ympg2J6pQp6qlpVNgn/UUBaq2kq0RTVMBF6tuz2nenPzMl+5itR
+        cc1/AjZMf/PRpxMgXazuoebp+fn/XOr7lV1WAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:46:43 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - ea3ed49ff46adf49e84ebd0c006d1a99
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEhSmJAubyqwhXSq4xDQqcwIS8pKSVp9GQF8shdcnQoQG1Ip+F
+        j2XLmwCeOGFK+ACEXNh5ajEZBpejqeORZfMPQBAfFFArNUOvqKpuwHXZBFybTKbzak0B9W9IcDuc
+        d4YzEoFThT5hzppHJaNyKz0DlgWh5z8Kyydl4SbARlU3tWpio0HCs+VTEoIBBzY4/LJoDoGYm3g2
+        GzELwQg5X2aILOGoUeI49IWNcxhOnYH7NhTvIge0IUPmsJDRpBJMNM1g+KnDiGvR+HzEnJD6cXAk
+        bsjRZcaDF/iwub1Tx20EAQ2lk1Yhk02eUk0oVDyKTmP6AOefFNkk8uj6qf4s781PjGe5+KQ/z89V
+        7XmvtDW0+FNWqvRKiqrpkIFqMhlatkxHiirzCrlaq5u8itdAjBY8iFECTsC1LdDfeeCJ44SE1g0/
+        iwvAytj3ommqdZbWRxHrScPUicbMLRPwRTaMIC2Xhyhth9EYvPX3bYn7L9f4+ueYluufcZ3PrjqH
+        7Qsh/IND3XF4A85Yfxcl6QOEM2T1kQ8InpYHEHx3JEA0bzbO+o2e1I57SEdpD5QH2/emNgQkNDoQ
+        rFx+fquCU+Hshetc7b5DmVj0wZRYt2RM81XozgFbCR73goqWlijPB4DzDzcspIMuxBhEpQ9B/yZa
+        Pfh0dNBsX1zKzSamE7RIDfuOBZARt3bLZkOOPVJOHXS1pvjT3zFfBdi/4U8+aUl7jB5IcK4pii4r
+        9eL7hOWcjjwu+tmxvjlOceWpH0r9KwlEoD6FvBtzoAIBanFX4tfzUdc/v2jvdOxOUam77a3MV0bz
+        6mX74+X7OKV1R8s+ucc06G+nwX/3ADmDVFOU91TTNGea8klRr4U7FuOQfDJKcH/dDpfnwP02hCtM
+        92EWUy0lZ1VZVeCW+15MBcFgSAIKq54cT+33ehIsFSisEGLE9uH7+XM5CeBfUP1r5cqamjBnAuhY
+        HF/Fk7mGfKnl+cTZrOVlgvouTVFFjbL2zorewbrN83OjIKttX0C3vFFBT+1v7YO9q1n3vDk7mh3P
+        zlrF/YvTg73zo9nl7MPsKq5oAqQ5u7qYNfm5iJNv6lnMCZ32wXFJah8crdH6yrHxdR5fTl+jf7B3
+        OmvMzor7DdD2eNaZnUIxOtg7m/VmneJ+k5e6s2Zx/2ReaqSlOZffN0wesTDqWUmCY+ONqdW3yDt3
+        eln5oycffcvsI3T946cg/SU5aFnnl0bSAfTejzOKyCcfk3SSZJOPcTKBXDK7gJMkbl7W6QenH31b
+        Dr+JOp5AziCBnM66cQo5nR0X97sXvFYUr0TeuCju9zhfTZFRjqHpTGSUpNRIS1mCX3noH5qs4iXO
+        hzZmgA/bTieT0PzaiuZDe3U1A8u5N1nKLXarBjYNLJ9N+d4bpuMNtW6lM37yynP/VxB9ThYm+Bwm
+        XWRgO6HCupclG94DYsX7z+v6tGLE/m8urAalRowLdmfNuL74tbUBdRzmYdq0RcMur4Hn0sd9v6rC
+        W4TIm+5SkDvCHC4DpluiVCOD2RG7iHzcbh3KYjMpT/AWCQmfYL7ultNO7Q0nNTfRMJ+HY9G4I5ZL
+        BE6wAwrmyZnZtJeQUhuQ26qRdA0k4lMp6+JnnpQIILEAbrO/R4w/6hQNtyKnUrzrW3JB7cHwcTAh
+        zj1BlwbtFCYdPkqdOWy3DBor4dIgiLBHFUs6nKWoH6KCeACXPM5fF/QYWnlx/6QrNWzbB1G/I6Gr
+        plZWq/WyWtZKao2Xy3CQF0VFKakK/1euwJRZM0pCOvpAYN5CxQPg99vCP2n0GwgjvPqFGVT+1JD/
+        Q+Qv1/JyRl2tz8mw4oprc2BVlRuyolbU93ysAaIc4pwcvjsnhygnh+/JSRCy8SCgd5S/n4Dz0pF6
+        i/Zt2GF3J/3rn3N0XowWq3zSf2frYw+1ePW7W//yx0cEcwfhDbBA77EUf+JKlzcUkvv9Di1I8u+q
+        u3ojzUzuJjQkgajE5J837vICaqFC3goqo8cfZvUkkkOnd4Qlhw6zfC/wRqF0GDkODZm7XZ7o9FYe
+        /69U5GSGTs80ZdM0Aa4ocq1uviMD571+C7s7ivo/zaJrygcYTKOhs/Ry2rraXQ6UugsgX4DmJBho
+        GDHq2GtEPBnP+3FBWxRQSvhLH/udzn6rtWZyPrzs8KyRlGhaHIeL0rxSECZK37tdsnEXsSvwUmsJ
+        tEtbcSMyYY54hzFX+CMB2ZhfB5PICdkiy86vcgGrn2MSSqeexZ/uJG95SmJzld8yxbuTGamOu/LV
+        x41oLYNu0SEj7ka4noH3PIf4sAbehDcy+CNqez7ZCK9k4M1fTyQyjAKaNlYzjb+CiT1v41i1rKhR
+        r70RXM+AGyebKTMz2A/MBYMF0oG0nrTnBlGyHegQhvXv+CudSXPWYL3OZVea+h64zWQOyNroyKf0
+        sNfa7AFZK10NIzeMNuOzVuo5xLrl05rNXbKW6vD3osntV3pkzXdBJ15IpRFzqEQsK14hC1TWak0w
+        8nlv86hZwx1ddtNqxEapwytLkltwga9EiLoUIi4DpDcSRmTiUUD8Xnt2VBZY5bRhKWLiPpJNQ2ol
+        2UuAjKVLiA166cplD9n9eQHEAwTc72Ovl2KW4oRAxvE9L4SpP6dcJB6ByhJ90W2m1XXUua8C6ksT
+        4pIxnVDxWEGAzeWIhMTopHkiy3K6iTpPIllGu5T68qUn8//SEXeI3g2kFTd9vV7PMts86TXP04Ys
+        s0fMp/fEceaXyDJ6CB5te9484vQsi71mo9VIG7LUtc5SRvUsV0CFA/4qBbEt52NmieuKjyOkxaOj
+        FGSumoZIwQ11nFXrGMqS14SQTcbzlLrEnueHUvJu/RyQZYx/mBGvUUTTMmfuGDhfyrHGUio466QB
+        ZWQpOztJmTGqq2mA3W3O8EaWy35HJJp2b3MEGlluD/2IZw7PhziCeQPJwLLs/ityvc23psoSxxYD
+        v+YfD0inzI0eNvfMWqDjDbnTtmjWGypZE5z7xALEFuNmrdOYkC8w/9uiV9ZkXeJ4UsMJN98aK1lr
+        HkfknrLN+KyZjyrp1z5f4be2xkG/s7lH1s4nrsVssIl0QYOp5wapC1eyVu4zP4y8L182q1tVlgLi
+        vse/QZGav/ZON3dTn19vQbtpRrjtMmdPmX1SYTofz+mVUvW5uPf5c/CTzA97q03FX/ZKouGFvXKW
+        Tx/5X0kcZXFcWUkpivIWq/+4BvmyJ5fNTgb611g+5WyLJHzs6JaIF4XTCNuVSsQ+T9u/VfCQPoQl
+        L7yBWxwvvs+mRuKu2yz1YzX/ymv9hCyhZC5Bl3HrVpuRDs/mYig+m3qV7UiYX5X5ARMwrt52f+pJ
+        LVWeF5l3UZcm6q+hchJzXSnVIfnKdaWuvCAnp29scmu/kA7fCz3LczBKFk3b7R5bUziLbH5k1mT6
+        GibL3ioQES+oRYJQ+gdfWtEpbkBE0hgtHvTHI0Dx7d5L4RMSWGgi4ictf5qt0YDSAXECD1WVwlRW
+        NO3azWvD88uNjy7zNvhgtjviep56/DWWDrVZxL/bPmZjLl0TxmM8s72JwwWeE+XESm/RtEubrFnh
+        H11vGjDsYWJv0bSjwkduEE15So3ffLmjri3evl7V5GqB4+++9FPcD3lAF8JK7pa54/KI+UE4GHmR
+        iy1tlj/YPOJYWGZR3JX+FPObOTHipwi24+WU/OlpWXf7u6lfzvuGZZmers88sS6/IHwHTNrrdy+K
+        L7rvpZ+z/MCvdzh0mwXBiup/mXXBPG74j2x8nZhemMvGevI7o/x+esQexMStYYXsjooZXBD5I2K9
+        zhwuJONyr/WbBNaiY89HJwXLzd/w5I+PcEeciGomtIrSSm12N3NeXUfBdRSsVjGwWkXBuoqBdRUf
+        uYKOXMFHNtCRDVxBFKzhYB1lQ8fZ0FE2dJwNrYaKUcNHRsE6DtZQnjWcZ1S/HPUUVAgFFwIFazgY
+        9U/cPTEkCkRtgZsCdQjcH1TUECpuCENHB9ZxwjSUMA0XA2VXxdnV0VDS8VAy0JENfGQDldnAZdZQ
+        MTRcDJwMnAuUZTWHZdQttJwQRUfW8JENNOoMPOrQgfFxVdQ71Zx0hQ+cMzIadioedzpqET3HJCgX
+        Ks4F6ha4V6DBh8eeisqr4vLqKBM6zoSKpkyoXX/0E9BQvhE/opSUXC982STBro/qo2GVyjV1ZMmG
+        pZiyaWmabA0Nk9rUrhhGBZk8bNntGyYV4ocKhcYDs5bNFSsNb0OGahKlpsiGXdNAq6omD42RLtuq
+        ZtV1SgxbpPJ1Mrbq9n1k1CsaTgZveAsy+CUQZZPqb1RmRYU3EVyxNItQUpWpogxlYzgicp0Mq7Ji
+        DSu1ilG1RlYVUWzLbt9nxWo1x4q84S3IUEd11ajaFdDF5IGqKzIxqrpsWdSoaurINKpYfG/Z7VvJ
+        ED/wGStuP0IDs1ZZQRBvQY9l1ympg2J6pQp6qlpVNgn/UUBaq2kq0RTVMBF6tuz2nenPzMl+5itR
+        cc1/AjZMf/PRpxMgXazuoebp+fn/XOr7lV1WAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:46:43 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - deafbd0736a4a1324f50d2f2ac911f24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEhSmJAubyqwhXSq4xDQqcwIS8pKSVp9GQF8shdcnQoQG1Ip+F
+        j2XLmwCeOGFK+ACEXNh5ajEZBpejqeORZfMPQBAfFFArNUOvqKpuwHXZBFybTKbzak0B9W9IcDuc
+        d4YzEoFThT5hzppHJaNyKz0DlgWh5z8Kyydl4SbARlU3tWpio0HCs+VTEoIBBzY4/LJoDoGYm3g2
+        GzELwQg5X2aILOGoUeI49IWNcxhOnYH7NhTvIge0IUPmsJDRpBJMNM1g+KnDiGvR+HzEnJD6cXAk
+        bsjRZcaDF/iwub1Tx20EAQ2lk1Yhk02eUk0oVDyKTmP6AOefFNkk8uj6qf4s781PjGe5+KQ/z89V
+        7XmvtDW0+FNWqvRKiqrpkIFqMhlatkxHiirzCrlaq5u8itdAjBY8iFECTsC1LdDfeeCJ44SE1g0/
+        iwvAytj3ommqdZbWRxHrScPUicbMLRPwRTaMIC2Xhyhth9EYvPX3bYn7L9f4+ueYluufcZ3PrjqH
+        7Qsh/IND3XF4A85Yfxcl6QOEM2T1kQ8InpYHEHx3JEA0bzbO+o2e1I57SEdpD5QH2/emNgQkNDoQ
+        rFx+fquCU+Hshetc7b5DmVj0wZRYt2RM81XozgFbCR73goqWlijPB4DzDzcspIMuxBhEpQ9B/yZa
+        Pfh0dNBsX1zKzSamE7RIDfuOBZARt3bLZkOOPVJOHXS1pvjT3zFfBdi/4U8+aUl7jB5IcK4pii4r
+        9eL7hOWcjjwu+tmxvjlOceWpH0r9KwlEoD6FvBtzoAIBanFX4tfzUdc/v2jvdOxOUam77a3MV0bz
+        6mX74+X7OKV1R8s+ucc06G+nwX/3ADmDVFOU91TTNGea8klRr4U7FuOQfDJKcH/dDpfnwP02hCtM
+        92EWUy0lZ1VZVeCW+15MBcFgSAIKq54cT+33ehIsFSisEGLE9uH7+XM5CeBfUP1r5cqamjBnAuhY
+        HF/Fk7mGfKnl+cTZrOVlgvouTVFFjbL2zorewbrN83OjIKttX0C3vFFBT+1v7YO9q1n3vDk7mh3P
+        zlrF/YvTg73zo9nl7MPsKq5oAqQ5u7qYNfm5iJNv6lnMCZ32wXFJah8crdH6yrHxdR5fTl+jf7B3
+        OmvMzor7DdD2eNaZnUIxOtg7m/VmneJ+k5e6s2Zx/2ReaqSlOZffN0wesTDqWUmCY+ONqdW3yDt3
+        eln5oycffcvsI3T946cg/SU5aFnnl0bSAfTejzOKyCcfk3SSZJOPcTKBXDK7gJMkbl7W6QenH31b
+        Dr+JOp5AziCBnM66cQo5nR0X97sXvFYUr0TeuCju9zhfTZFRjqHpTGSUpNRIS1mCX3noH5qs4iXO
+        hzZmgA/bTieT0PzaiuZDe3U1A8u5N1nKLXarBjYNLJ9N+d4bpuMNtW6lM37yynP/VxB9ThYm+Bwm
+        XWRgO6HCupclG94DYsX7z+v6tGLE/m8urAalRowLdmfNuL74tbUBdRzmYdq0RcMur4Hn0sd9v6rC
+        W4TIm+5SkDvCHC4DpluiVCOD2RG7iHzcbh3KYjMpT/AWCQmfYL7ultNO7Q0nNTfRMJ+HY9G4I5ZL
+        BE6wAwrmyZnZtJeQUhuQ26qRdA0k4lMp6+JnnpQIILEAbrO/R4w/6hQNtyKnUrzrW3JB7cHwcTAh
+        zj1BlwbtFCYdPkqdOWy3DBor4dIgiLBHFUs6nKWoH6KCeACXPM5fF/QYWnlx/6QrNWzbB1G/I6Gr
+        plZWq/WyWtZKao2Xy3CQF0VFKakK/1euwJRZM0pCOvpAYN5CxQPg99vCP2n0GwgjvPqFGVT+1JD/
+        Q+Qv1/JyRl2tz8mw4oprc2BVlRuyolbU93ysAaIc4pwcvjsnhygnh+/JSRCy8SCgd5S/n4Dz0pF6
+        i/Zt2GF3J/3rn3N0XowWq3zSf2frYw+1ePW7W//yx0cEcwfhDbBA77EUf+JKlzcUkvv9Di1I8u+q
+        u3ojzUzuJjQkgajE5J837vICaqFC3goqo8cfZvUkkkOnd4Qlhw6zfC/wRqF0GDkODZm7XZ7o9FYe
+        /69U5GSGTs80ZdM0Aa4ocq1uviMD571+C7s7ivo/zaJrygcYTKOhs/Ry2rraXQ6UugsgX4DmJBho
+        GDHq2GtEPBnP+3FBWxRQSvhLH/udzn6rtWZyPrzs8KyRlGhaHIeL0rxSECZK37tdsnEXsSvwUmsJ
+        tEtbcSMyYY54hzFX+CMB2ZhfB5PICdkiy86vcgGrn2MSSqeexZ/uJG95SmJzld8yxbuTGamOu/LV
+        x41oLYNu0SEj7ka4noH3PIf4sAbehDcy+CNqez7ZCK9k4M1fTyQyjAKaNlYzjb+CiT1v41i1rKhR
+        r70RXM+AGyebKTMz2A/MBYMF0oG0nrTnBlGyHegQhvXv+CudSXPWYL3OZVea+h64zWQOyNroyKf0
+        sNfa7AFZK10NIzeMNuOzVuo5xLrl05rNXbKW6vD3osntV3pkzXdBJ15IpRFzqEQsK14hC1TWak0w
+        8nlv86hZwx1ddtNqxEapwytLkltwga9EiLoUIi4DpDcSRmTiUUD8Xnt2VBZY5bRhKWLiPpJNQ2ol
+        2UuAjKVLiA166cplD9n9eQHEAwTc72Ovl2KW4oRAxvE9L4SpP6dcJB6ByhJ90W2m1XXUua8C6ksT
+        4pIxnVDxWEGAzeWIhMTopHkiy3K6iTpPIllGu5T68qUn8//SEXeI3g2kFTd9vV7PMts86TXP04Ys
+        s0fMp/fEceaXyDJ6CB5te9484vQsi71mo9VIG7LUtc5SRvUsV0CFA/4qBbEt52NmieuKjyOkxaOj
+        FGSumoZIwQ11nFXrGMqS14SQTcbzlLrEnueHUvJu/RyQZYx/mBGvUUTTMmfuGDhfyrHGUio466QB
+        ZWQpOztJmTGqq2mA3W3O8EaWy35HJJp2b3MEGlluD/2IZw7PhziCeQPJwLLs/ityvc23psoSxxYD
+        v+YfD0inzI0eNvfMWqDjDbnTtmjWGypZE5z7xALEFuNmrdOYkC8w/9uiV9ZkXeJ4UsMJN98aK1lr
+        HkfknrLN+KyZjyrp1z5f4be2xkG/s7lH1s4nrsVssIl0QYOp5wapC1eyVu4zP4y8L182q1tVlgLi
+        vse/QZGav/ZON3dTn19vQbtpRrjtMmdPmX1SYTofz+mVUvW5uPf5c/CTzA97q03FX/ZKouGFvXKW
+        Tx/5X0kcZXFcWUkpivIWq/+4BvmyJ5fNTgb611g+5WyLJHzs6JaIF4XTCNuVSsQ+T9u/VfCQPoQl
+        L7yBWxwvvs+mRuKu2yz1YzX/ymv9hCyhZC5Bl3HrVpuRDs/mYig+m3qV7UiYX5X5ARMwrt52f+pJ
+        LVWeF5l3UZcm6q+hchJzXSnVIfnKdaWuvCAnp29scmu/kA7fCz3LczBKFk3b7R5bUziLbH5k1mT6
+        GibL3ioQES+oRYJQ+gdfWtEpbkBE0hgtHvTHI0Dx7d5L4RMSWGgi4ictf5qt0YDSAXECD1WVwlRW
+        NO3azWvD88uNjy7zNvhgtjviep56/DWWDrVZxL/bPmZjLl0TxmM8s72JwwWeE+XESm/RtEubrFnh
+        H11vGjDsYWJv0bSjwkduEE15So3ffLmjri3evl7V5GqB4+++9FPcD3lAF8JK7pa54/KI+UE4GHmR
+        iy1tlj/YPOJYWGZR3JX+FPObOTHipwi24+WU/OlpWXf7u6lfzvuGZZmers88sS6/IHwHTNrrdy+K
+        L7rvpZ+z/MCvdzh0mwXBiup/mXXBPG74j2x8nZhemMvGevI7o/x+esQexMStYYXsjooZXBD5I2K9
+        zhwuJONyr/WbBNaiY89HJwXLzd/w5I+PcEeciGomtIrSSm12N3NeXUfBdRSsVjGwWkXBuoqBdRUf
+        uYKOXMFHNtCRDVxBFKzhYB1lQ8fZ0FE2dJwNrYaKUcNHRsE6DtZQnjWcZ1S/HPUUVAgFFwIFazgY
+        9U/cPTEkCkRtgZsCdQjcH1TUECpuCENHB9ZxwjSUMA0XA2VXxdnV0VDS8VAy0JENfGQDldnAZdZQ
+        MTRcDJwMnAuUZTWHZdQttJwQRUfW8JENNOoMPOrQgfFxVdQ71Zx0hQ+cMzIadioedzpqET3HJCgX
+        Ks4F6ha4V6DBh8eeisqr4vLqKBM6zoSKpkyoXX/0E9BQvhE/opSUXC982STBro/qo2GVyjV1ZMmG
+        pZiyaWmabA0Nk9rUrhhGBZk8bNntGyYV4ocKhcYDs5bNFSsNb0OGahKlpsiGXdNAq6omD42RLtuq
+        ZtV1SgxbpPJ1Mrbq9n1k1CsaTgZveAsy+CUQZZPqb1RmRYU3EVyxNItQUpWpogxlYzgicp0Mq7Ji
+        DSu1ilG1RlYVUWzLbt9nxWo1x4q84S3IUEd11ajaFdDF5IGqKzIxqrpsWdSoaurINKpYfG/Z7VvJ
+        ED/wGStuP0IDs1ZZQRBvQY9l1ympg2J6pQp6qlpVNgn/UUBaq2kq0RTVMBF6tuz2nenPzMl+5itR
+        cc1/AjZMf/PRpxMgXazuoebp+fn/XOr7lV1WAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:46:54 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 46c59f6eaa4588637c59a56f07b65b76
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEhSmJAubyqwhXSq4xDQqcwIS8pKSVp9GQF8shdcnQoQG1Ip+F
+        j2XLmwCeOGFK+ACEXNh5ajEZBpejqeORZfMPQBAfFFArNUOvqKpuwHXZBFybTKbzak0B9W9IcDuc
+        d4YzEoFThT5hzppHJaNyKz0DlgWh5z8Kyydl4SbARlU3tWpio0HCs+VTEoIBBzY4/LJoDoGYm3g2
+        GzELwQg5X2aILOGoUeI49IWNcxhOnYH7NhTvIge0IUPmsJDRpBJMNM1g+KnDiGvR+HzEnJD6cXAk
+        bsjRZcaDF/iwub1Tx20EAQ2lk1Yhk02eUk0oVDyKTmP6AOefFNkk8uj6qf4s781PjGe5+KQ/z89V
+        7XmvtDW0+FNWqvRKiqrpkIFqMhlatkxHiirzCrlaq5u8itdAjBY8iFECTsC1LdDfeeCJ44SE1g0/
+        iwvAytj3ommqdZbWRxHrScPUicbMLRPwRTaMIC2Xhyhth9EYvPX3bYn7L9f4+ueYluufcZ3PrjqH
+        7Qsh/IND3XF4A85Yfxcl6QOEM2T1kQ8InpYHEHx3JEA0bzbO+o2e1I57SEdpD5QH2/emNgQkNDoQ
+        rFx+fquCU+Hshetc7b5DmVj0wZRYt2RM81XozgFbCR73goqWlijPB4DzDzcspIMuxBhEpQ9B/yZa
+        Pfh0dNBsX1zKzSamE7RIDfuOBZARt3bLZkOOPVJOHXS1pvjT3zFfBdi/4U8+aUl7jB5IcK4pii4r
+        9eL7hOWcjjwu+tmxvjlOceWpH0r9KwlEoD6FvBtzoAIBanFX4tfzUdc/v2jvdOxOUam77a3MV0bz
+        6mX74+X7OKV1R8s+ucc06G+nwX/3ADmDVFOU91TTNGea8klRr4U7FuOQfDJKcH/dDpfnwP02hCtM
+        92EWUy0lZ1VZVeCW+15MBcFgSAIKq54cT+33ehIsFSisEGLE9uH7+XM5CeBfUP1r5cqamjBnAuhY
+        HF/Fk7mGfKnl+cTZrOVlgvouTVFFjbL2zorewbrN83OjIKttX0C3vFFBT+1v7YO9q1n3vDk7mh3P
+        zlrF/YvTg73zo9nl7MPsKq5oAqQ5u7qYNfm5iJNv6lnMCZ32wXFJah8crdH6yrHxdR5fTl+jf7B3
+        OmvMzor7DdD2eNaZnUIxOtg7m/VmneJ+k5e6s2Zx/2ReaqSlOZffN0wesTDqWUmCY+ONqdW3yDt3
+        eln5oycffcvsI3T946cg/SU5aFnnl0bSAfTejzOKyCcfk3SSZJOPcTKBXDK7gJMkbl7W6QenH31b
+        Dr+JOp5AziCBnM66cQo5nR0X97sXvFYUr0TeuCju9zhfTZFRjqHpTGSUpNRIS1mCX3noH5qs4iXO
+        hzZmgA/bTieT0PzaiuZDe3U1A8u5N1nKLXarBjYNLJ9N+d4bpuMNtW6lM37yynP/VxB9ThYm+Bwm
+        XWRgO6HCupclG94DYsX7z+v6tGLE/m8urAalRowLdmfNuL74tbUBdRzmYdq0RcMur4Hn0sd9v6rC
+        W4TIm+5SkDvCHC4DpluiVCOD2RG7iHzcbh3KYjMpT/AWCQmfYL7ultNO7Q0nNTfRMJ+HY9G4I5ZL
+        BE6wAwrmyZnZtJeQUhuQ26qRdA0k4lMp6+JnnpQIILEAbrO/R4w/6hQNtyKnUrzrW3JB7cHwcTAh
+        zj1BlwbtFCYdPkqdOWy3DBor4dIgiLBHFUs6nKWoH6KCeACXPM5fF/QYWnlx/6QrNWzbB1G/I6Gr
+        plZWq/WyWtZKao2Xy3CQF0VFKakK/1euwJRZM0pCOvpAYN5CxQPg99vCP2n0GwgjvPqFGVT+1JD/
+        Q+Qv1/JyRl2tz8mw4oprc2BVlRuyolbU93ysAaIc4pwcvjsnhygnh+/JSRCy8SCgd5S/n4Dz0pF6
+        i/Zt2GF3J/3rn3N0XowWq3zSf2frYw+1ePW7W//yx0cEcwfhDbBA77EUf+JKlzcUkvv9Di1I8u+q
+        u3ojzUzuJjQkgajE5J837vICaqFC3goqo8cfZvUkkkOnd4Qlhw6zfC/wRqF0GDkODZm7XZ7o9FYe
+        /69U5GSGTs80ZdM0Aa4ocq1uviMD571+C7s7ivo/zaJrygcYTKOhs/Ry2rraXQ6UugsgX4DmJBho
+        GDHq2GtEPBnP+3FBWxRQSvhLH/udzn6rtWZyPrzs8KyRlGhaHIeL0rxSECZK37tdsnEXsSvwUmsJ
+        tEtbcSMyYY54hzFX+CMB2ZhfB5PICdkiy86vcgGrn2MSSqeexZ/uJG95SmJzld8yxbuTGamOu/LV
+        x41oLYNu0SEj7ka4noH3PIf4sAbehDcy+CNqez7ZCK9k4M1fTyQyjAKaNlYzjb+CiT1v41i1rKhR
+        r70RXM+AGyebKTMz2A/MBYMF0oG0nrTnBlGyHegQhvXv+CudSXPWYL3OZVea+h64zWQOyNroyKf0
+        sNfa7AFZK10NIzeMNuOzVuo5xLrl05rNXbKW6vD3osntV3pkzXdBJ15IpRFzqEQsK14hC1TWak0w
+        8nlv86hZwx1ddtNqxEapwytLkltwga9EiLoUIi4DpDcSRmTiUUD8Xnt2VBZY5bRhKWLiPpJNQ2ol
+        2UuAjKVLiA166cplD9n9eQHEAwTc72Ovl2KW4oRAxvE9L4SpP6dcJB6ByhJ90W2m1XXUua8C6ksT
+        4pIxnVDxWEGAzeWIhMTopHkiy3K6iTpPIllGu5T68qUn8//SEXeI3g2kFTd9vV7PMts86TXP04Ys
+        s0fMp/fEceaXyDJ6CB5te9484vQsi71mo9VIG7LUtc5SRvUsV0CFA/4qBbEt52NmieuKjyOkxaOj
+        FGSumoZIwQ11nFXrGMqS14SQTcbzlLrEnueHUvJu/RyQZYx/mBGvUUTTMmfuGDhfyrHGUio466QB
+        ZWQpOztJmTGqq2mA3W3O8EaWy35HJJp2b3MEGlluD/2IZw7PhziCeQPJwLLs/ityvc23psoSxxYD
+        v+YfD0inzI0eNvfMWqDjDbnTtmjWGypZE5z7xALEFuNmrdOYkC8w/9uiV9ZkXeJ4UsMJN98aK1lr
+        HkfknrLN+KyZjyrp1z5f4be2xkG/s7lH1s4nrsVssIl0QYOp5wapC1eyVu4zP4y8L182q1tVlgLi
+        vse/QZGav/ZON3dTn19vQbtpRrjtMmdPmX1SYTofz+mVUvW5uPf5c/CTzA97q03FX/ZKouGFvXKW
+        Tx/5X0kcZXFcWUkpivIWq/+4BvmyJ5fNTgb611g+5WyLJHzs6JaIF4XTCNuVSsQ+T9u/VfCQPoQl
+        L7yBWxwvvs+mRuKu2yz1YzX/ymv9hCyhZC5Bl3HrVpuRDs/mYig+m3qV7UiYX5X5ARMwrt52f+pJ
+        LVWeF5l3UZcm6q+hchJzXSnVIfnKdaWuvCAnp29scmu/kA7fCz3LczBKFk3b7R5bUziLbH5k1mT6
+        GibL3ioQES+oRYJQ+gdfWtEpbkBE0hgtHvTHI0Dx7d5L4RMSWGgi4ictf5qt0YDSAXECD1WVwlRW
+        NO3azWvD88uNjy7zNvhgtjviep56/DWWDrVZxL/bPmZjLl0TxmM8s72JwwWeE+XESm/RtEubrFnh
+        H11vGjDsYWJv0bSjwkduEE15So3ffLmjri3evl7V5GqB4+++9FPcD3lAF8JK7pa54/KI+UE4GHmR
+        iy1tlj/YPOJYWGZR3JX+FPObOTHipwi24+WU/OlpWXf7u6lfzvuGZZmers88sS6/IHwHTNrrdy+K
+        L7rvpZ+z/MCvdzh0mwXBiup/mXXBPG74j2x8nZhemMvGevI7o/x+esQexMStYYXsjooZXBD5I2K9
+        zhwuJONyr/WbBNaiY89HJwXLzd/w5I+PcEeciGomtIrSSm12N3NeXUfBdRSsVjGwWkXBuoqBdRUf
+        uYKOXMFHNtCRDVxBFKzhYB1lQ8fZ0FE2dJwNrYaKUcNHRsE6DtZQnjWcZ1S/HPUUVAgFFwIFazgY
+        9U/cPTEkCkRtgZsCdQjcH1TUECpuCENHB9ZxwjSUMA0XA2VXxdnV0VDS8VAy0JENfGQDldnAZdZQ
+        MTRcDJwMnAuUZTWHZdQttJwQRUfW8JENNOoMPOrQgfFxVdQ71Zx0hQ+cMzIadioedzpqET3HJCgX
+        Ks4F6ha4V6DBh8eeisqr4vLqKBM6zoSKpkyoXX/0E9BQvhE/opSUXC982STBro/qo2GVyjV1ZMmG
+        pZiyaWmabA0Nk9rUrhhGBZk8bNntGyYV4ocKhcYDs5bNFSsNb0OGahKlpsiGXdNAq6omD42RLtuq
+        ZtV1SgxbpPJ1Mrbq9n1k1CsaTgZveAsy+CUQZZPqb1RmRYU3EVyxNItQUpWpogxlYzgicp0Mq7Ji
+        DSu1ilG1RlYVUWzLbt9nxWo1x4q84S3IUEd11ajaFdDF5IGqKzIxqrpsWdSoaurINKpYfG/Z7VvJ
+        ED/wGStuP0IDs1ZZQRBvQY9l1ympg2J6pQp6qlpVNgn/UUBaq2kq0RTVMBF6tuz2nenPzMl+5itR
+        cc1/AjZMf/PRpxMgXazuoebp+fn/XOr7lV1WAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:47:04 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - f0fbc903599566344c143b14482f485d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEhSmB8biFhCcll5gGBc5fwl1S0srTaMiL5ZC6ZOjQgFqRz8LH
+        suVNAE+cMOV7IMZMzTy1mAyDy9HU8ciy9Qcghw/yq5WaoVdUVTfgumwCnk0m03m1xmm8IcHtcN4Z
+        zkgEPhX6hDlrDpWMyo30DFgWhJ7/KAyflIWXABlV3dSqiYkGCc2WT0kI9hvY4O/LojkEQm7i2WzE
+        LAQj5HyZHbKEYzaJo9AXFs4hOHUF7tlQvIscUIYMmcNCRpNKsNA0g+GnDiOuRePzEXNC6sehkTgh
+        R5cZFwLosLm5U7dtBAENpZNWIZNLnlJFKFQ8ik5j+gDnnxTZJPLo+qn+LO/NT4xnufikP8/PVe15
+        r7Q1tPhTVqr0Soqq6ZB/ajIZWrZMR4oq8wq5WqubvIrXQIQWPIhQAj7AtS3Q33nYieOEhNYNP4sL
+        wMrY96JpqnWW1kcR6UnD1InGzC0TcEU2jCApl4cobYfRGJz1922J+y/X+PrnmJbrn3Gdz646h+0L
+        IfyDQ91xeAO+WH8XJekDRDPk9JEPCJ6UBxB7dyRANG82zvqNntSOe0hHaQ+UB9v3pjbEIzQ6EKtc
+        fn6jglPh7IXrXO2+Q5lY9MGUWLdkTPNV6M4BWwke94KKlpYozweA8w83LKSDLsQYRKUPMf8mWj34
+        dHTQbF9cys0mphO0SA37jgWQELd2y2ZDjj1STh10tab4098xXwXYv+FPPmlJe4weSHCuKYouK/Xi
+        +4TlnI48LvrZsb45TnHlqR9K/SsJRKA+hbwbc6ACAWpxV+LX81HXP79o73TsTlGpu+2tzFdG8+pl
+        ++Pl+zildUfLPrnHNOhvp8F/9wA5g1RTlPdU0zRnmvJJUa+FOxbjkHwySnB/3Q6X58D9NoQrTPZh
+        ElMtJWdVWVXglvteTAXBYEgCCmueHE/t93oSLBQorA9ixPbh+/lzOQngX1D9a+XKmpowZwLoWBxf
+        xZO5hnyh5fnE2azlZYL6Lk1RRY2y9s6K3sGqzfNzoyCrbV9At7xRQU/tb+2DvatZ97w5O5odz85a
+        xf2L04O986PZ5ezD7CquaAKkObu6mDX5uYiTb+pZzAmd9sFxSWofHK3R+sqx8XUeX05fo3+wdzpr
+        zM6K+w3Q9njWmZ1CMTrYO5v1Zp3ifpOXurNmcf9kXmqkpTmX3zdMHrEw6llJgmPjjanVt8g7d3pZ
+        +aMnH33L7CN0/eOnIP0lOWhZ55dG0gH03o8zisgnH5N0kmSTj3EygVwyu4CTJG5e1ukHpx99Ww6/
+        iTqeQM4ggZzOunEKOZ0dF/e7F7xWFK9E3rgo7vc4X02RUY6h6UxklKTUSEtZgl956B+arOIlzoc2
+        ZoAP204nk9D82ormQ3t1NQPLuTdZyi12qwY2DSyfTfnWG6bjDbVupTN+8spz/1cQfU4WJvgcJl1k
+        YDuhwrqXJdvdA2LFu8/r+rRixP5vLqwGpUaMC3Znzbi++LW1AXUc5mHatEXDLq+B59LHfb+qwluE
+        yJvuUpA7whwuA6ZbolQjg9kRu4h83G4dymIzKU/wFgkJn2C+7pbTTu0NJzU30TCfh2PRuCOWSwRO
+        sAMK5smZ2bSXkFIbkNuqkXQNJOJTKeviZ56UCCCxAG6zv0fMFw+EoOFW5FSKd31LLqg9GD4OJsS5
+        J+jSoJ3CpMNHqTOH7ZZBYyVcGgQR9qhiSYezFPVDVBAP4JKH+euCHkMrL+6fdKWGbfsg6nckdNXU
+        ymq1XlbLWkmt8XIZDvKiqCglVeH/yhWYMmtGSUhHHwjMW6h4/vt+W/gnjX4DYYRXvzCDyp8a8n+I
+        /OVaXs6oq/U5GVZccW0OrKpyQ1bUivqejzVAlEOck8N35+QQ5eTwPTkJQjYeBPSO8tcTcF46Um/R
+        vg077O6kf/1zjs6L0WKVT/rvbH3soRavfnfrX/74iGDuILwBFug9luJPXOnyhkJyv9+hBUn+XXVX
+        b6SZyd2EhiQQlZj888ZdXkAtVMhbQWX0+MOsnkRy6PSOsOTQYZbvBd4olA4jx6Ehc7fLE53eyuP/
+        lYqczNDpmaZsmibAFUWu1c13ZOC8129hd0dR/6dZdE35AINpNHSW3k1bV7vLgVJ3AeQL0JwEAw0j
+        Rh17jYgn43k/LmiLAkoJf+ljv9PZb7XWTM6Hlx2eNZISTYvjcFGaVwrCROl7t0s27iJ2BV5qLYF2
+        aStuRCbMEa8w5gp/JCAb8+tgEjkhW2TZ+VUuYPVzTELp1LP4053kJU9JbK7yW6Z4dTIj1XFXvvq4
+        Ea1l0C06ZMTdCNcz8J7nEB/WwJvwRgZ/RG3PJxvhlQy8+euJRIZRQNPGaqbxVzCx520cq5YVNeq1
+        N4LrGXDjZDNlZgb7gblgsEA6kNaT9twgSrYDHcKw/h1/pTNpzhqs17nsSlPfA7eZzAFZGx35lB72
+        Wps9IGulq2HkhtFmfNZKPYdYt3xas7lL1lId/lY0uf1Kj6z5LujEC6k0Yg6ViGXFK2SBylqtCUY+
+        720eNWu4o8tuWo3YKHV4ZUlyCy7wlQhRl0LEZYD0RsKITDwKiN9qz47KAqucNixFTNxHsmlIrSR7
+        CZCxdAmxQS9duewhuz8vgHiAgPt97PVSzFKcEMg4vueFMPXnlIvEI1BZoi+6zbS6jjr3VUB9aUJc
+        MqYTKh4rCLC5HJGQGJ00T2RZTjdR50kky2iXUl++9GT+XzriDtG7gbTipi/X61lmmye95nnakGX2
+        iPn0njjO/BJZRg/Bo23Pm0ecnmWx12y0GmlDlrrWWcqonuUKqHDAX6UgtuV8zCxxXfFphLR4dJSC
+        zFXTECm4oY6zah1DWfKaELLJeJ5Sl9jz/FBKXq2fA7KM8c8y4jWKaFrmzB0D50s51lhKBWedNKCM
+        LGVnJykzRnU1DbC7zRneyHLZ74hE0+5tjkAjy+2hH/HM4fkQRzBvIBlYlt1/Ra63+dZUWeLYYuDX
+        /NsB6ZS50cPmnlkLdLwhd9oWzXpDJWuCc59YgNhi3Kx1GhPyBeZ/W/TKmqxLHE9qOOHmW2Mla83j
+        iNxTthmfNfNRJf3W5yv81tY46Hc298ja+cS1mA02kS5oMPXcIHXhStbKfeaHkffly2Z1q8pSQNz3
+        +CcoUvPX3unmburz6y1oN80It13m7CmzTypM5+M5vVKqPhf3Pn8OfpL5YW+1qfjLXkk0vLBXzvLp
+        I/8riaMsjisrKUVR3mL1H9cgH/bkstnJQP8ay6ecbZGEjx3dEvGicBphu1KJ2Odp+7cKHtKHsOSF
+        N3CL48X32dRI3HWbpX6s5l95rZ+QJZTMJegybt1qM9Lh2VwMxWdTr7IdCfOrMj9gAsbV2+5PPaml
+        yvMi8y7q0kT9NVROYq4rpTokX7mu1JUX5OT0jU1u7RfS4XuhZ3kORsmiabvdY2sKZ5HNj8yaTF/D
+        ZNlbBSLiBbVIEEr/4EsrOsUNiEgao8WD/ngEKL7deyl8QgILTUT8pOVPszUaUDogTuChqlKYyoqm
+        Xbt5bXh+ufHRZd4GH8x2R1zPU4+/xtKhNov4Z9vHbMyla8J4jGe2N3G4wHOinFjpLZp2aZM1K/yj
+        600Dhj1M7C2adlT4yA2iKU+p8Zsvd9S1xdvXq5pcLXD83Zd+ivshD+hCWMndMndcHjE/CAcjL3Kx
+        pc3yB5tHHAvLLIq70p9ifjMnRvwSwXa8nJI/PS3rbn839ct537As09P1mSfW5ReE74BJe/3uRfFF
+        9730c5Yf+PUOh26zIFhR/S+zLpjHDf+Nja8T0wtz2VhPfmeU30+P2IOYuDWskN1RMYMLIn9ErNeZ
+        w4VkXO61fpPAWnTs+eikYLn5G5788RHuiBNRzYRWUVqpze5mzqvrKLiOgtUqBlarKFhXMbCu4iNX
+        0JEr+MgGOrKBK4iCNRyso2zoOBs6yoaOs6HVUDFq+MgoWMfBGsqzhvOM6pejnoIKoeBCoGANB6P+
+        ibsnhkSBqC1wU6AOgfuDihpCxQ1h6OjAOk6YhhKm4WKg7Ko4uzoaSjoeSgY6soGPbKAyG7jMGiqG
+        houBk4FzgbKs5rCMuoWWE6LoyBo+soFGnYFHHTowPq6Keqeak67wgXNGRsNOxeNORy2i55gE5ULF
+        uUDdAvcKNPjw2FNReVVcXh1lQseZUNGUCbXrj34CGso34keUkpLrhS+bJNj1UX00rFK5po4s2bAU
+        UzYtTZOtoWFSm9oVw6ggk4ctu33DpEL8TKHQeGDWsrlipeFtyFBNotQU2bBrGmhV1eShMdJlW9Ws
+        uk6JYYtUvk7GVt2+j4x6RcPJ4A1vQQa/BKJsUv2Nyqyo8CaCK5ZmEUqqMlWUoWwMR0Suk2FVVqxh
+        pVYxqtbIqiKKbdnt+6xYreZYkTe8BRnqqK4aVbsCupg8UHVFJkZVly2LGlVNHZlGFYvvLbt9Kxni
+        5z1jxe1HaGDWKisI4i3osew6JXVQTK9UQU9Vq8om4T8KSGs1TSWaohomQs+W3b4z/Zk52c98JSqu
+        +Q/AhulvPvp0AqSL1T3UPD0//x8hvB4DW1YAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:47:15 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - aac694c864ffc9c011ebc324092bd4ef
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd/resume
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Nov 2019 15:47:15 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - ''
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 519071f97939577b2d5c50dded64558e
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEBZ8G0YS5/DLCl5KLTIMCZzBhLylp5Wk05MVySF0ydGhArchn
+        4WPZ8iaAJ06YMj4AKReGnlpMhsHlaOp4ZNn+A5DEBw3USs3QK6qqG3BdNgHfJpPpvFrTK6AvCW6H
+        885wRiLwqtAnzFlzqWRUbqZnwLIg9PxHYfqkLPwE6KjqplZNjDRIiLZ8SkKw4MAGj18WzSEQdBPP
+        ZiNmIRgh58sskSUct0ocib6wcg7FqTtw74biXeSAOmTIHBYymlSCjaYZDD91GHEtGp+PmBNSPw6P
+        xBE5usx4+AIhNjd46rqNIKChdNIqZPLJU6oKhYpH0WlMH+D8kyKbRB5dP9Wf5b35ifEsF5/05/m5
+        qj3vlbaGFn/KSpVeSQEDQA6qyWRo2TIdKarMK+RqrW7yKl4DUVrwIEoJeAHXtkB/56EnjhMSWjf8
+        LC4AK2Pfi6ap1llaH0W0Jw1TJxozt0zAGdkwgsRcHqK0HUZjcNfftyXuv1zj659jWq5/xnU+u+oc
+        ti+E8A8OdcfhDXhj/V2UpA8Qz5DXRz4geGIeQPTdkQDRvNk46zd6UjvuIR2lPVAebN+b2hCR0OhA
+        tHL5+c0KToWzF65ztfsOZWLRB1Ni3ZIxzVehOwdsJXjcCypaWqI8HwDOP9ywkA66EGMQlT5E/Zto
+        9eDT0UGzfXEpN5uYTtAiNew7FkBK3Notmw059kg5ddDVmuJPf8d8FWD/hj/5pCXtMXogwbmmKLqs
+        1IvvE5ZzOvK46GfH+uY4xZWnfij1ryQQgfoU8m7MgQoEqMVdiV/PR13//KK907E7RaXutrcyXxnN
+        q5ftj5fv45TWHS375B7ToL+dBv/dA+QMUk1R3lNN05xpyidFvRbuWIxD8skowf11O1yeA/fbEK4w
+        4YdpTLWUnFVlVYFb7nsxFQSDIQkorHtyPLXf60mwWKCwRogR24fv58/lJIB/QfWvlStrasKcCaBj
+        cXwVT+Ya8sWW5xNns5aXCeq7NEUVNcraOyt6Bys3z8+Ngqy2fQHd8kYFPbW/tQ/2rmbd8+bsaHY8
+        O2sV9y9OD/bOj2aXsw+zq7iiCZDm7Opi1uTnIk6+qWcxJ3TaB8clqX1wtEbrK8fG13l8OX2N/sHe
+        6awxOyvuN0Db41lndgrF6GDvbNabdYr7TV7qzprF/ZN5qZGW5lx+3zB5xMKoZyUJjo03plbfIu/c
+        6WXlj5589C2zj9D1j5+C9JfkoGWdXxpJB9B7P84oIp98TNJJkk0+xskEcsnsAk6SuHlZpx+cfvRt
+        Ofwm6ngCOYMEcjrrxinkdHZc3O9e8FpRvBJ546K43+N8NUVGOYamM5FRklIjLWUJfuWhf2iyipc4
+        H9qYAT5sO51MQvNrK5oP7dXVDCzn3mQpt9itGtg0sHw25ZtvmI431LqVzvjJK8/9X0H0OVmY4HOY
+        dJGB7YQK616WbHkPiBXvQK/r04oR+7+5sBqUGjEu2J014/ri19YG1HGYh2nTFg27vAaeSx/3/aoK
+        bxEib7pLQe4Ic7gMmG6JUo0MZkfsIvJxu3Uoi82kPMFbJCR8gvm6W047tTec1NxEw3wejkXjjlgu
+        ETjBDiiYJ2dm015CSm1AbqtG0jWQiE+lrIufeVIigMQCuM3+HjH+sFM03IqcSvGub8kFtQfDx8GE
+        OPcEXRq0U5h0+Ch15rDdMmishEuDIMIeVSzpcJaifogK4gFc8kB/XdBjaOXF/ZOu1LBtH0T9joSu
+        mlpZrdbLalkrqTVeLsNBXhQVpaQq/F+5AlNmzSgJ6egDgXkLFU+A328L/6TRbyCM8OoXZlD5U0P+
+        D5G/XMvLGXW1PifDiiuuzYFVVW7IilpR3/OxBohyiHNy+O6cHKKcHL4nJ0HIxoOA3lH+ggLOS0fq
+        Ldq3YYfdnfSvf87ReTFarPJJ/52tjz3U4tXvbv3LHx8RzB2EN8ACvcdS/IkrXd5QSO73O7Qgyb+r
+        7uqNNDO5m9CQBKISk3/euMsLqIUKeSuojB5/mNWTSA6d3hGWHDrM8r3AG4XSYeQ4NGTudnmi01t5
+        /L9SkZMZOj3TlE3TBLiiyLW6+Y4MnPf6LezuKOr/NIuuKR9gMI2GztLbaetqdzlQ6i6AfAGak2Cg
+        YcSoY68R8WQ878cFbVFAKeEvfex3Ovut1prJ+fCyw7NGUqJpcRwuSvNKQZgofe92ycZdxK7AS60l
+        0C5txY3IhDniJcZc4Y8EZGN+HUwiJ2SLLDu/ygWsfo5JKJ16Fn+6k7zmKYnNVX7LFC9PZqQ67spX
+        HzeitQy6RYeMuBvhegbe8xziwxp4E97I4I+o7flkI7ySgTd/PZHIMApo2ljNNP4KJva8jWPVsqJG
+        vfZGcD0DbpxspszMYD8wFwwWSAfSetKeG0TJdqBDGNa/4690Js1Zg/U6l11p6nvgNpM5IGujI5/S
+        w15rswdkrXQ1jNww2ozPWqnnEOuWT2s2d8laqsPfjCa3X+mRNd8FnXghlUbMoRKxrHiFLFBZqzXB
+        yOe9zaNmDXd02U2rERulDq8sSW7BBb4SIepSiLgMkN5IGJGJRwHxm+3ZUVlgldOGpYiJ+0g2DamV
+        ZC8BMpYuITbopSuXPWT35wUQDxBwv4+9XopZihMCGcf3vBCm/pxykXgEKkv0RbeZVtdR574KqC9N
+        iEvGdELFYwUBNpcjEhKjk+aJLMvpJuo8iWQZ7VLqy5eezP9LR9whejeQVtz0BXs9y2zzpNc8Txuy
+        zB4xn94Tx5lfIsvoIXi07XnziNOzLPaajVYjbchS1zpLGdWzXAEVDvirFMS2nI+ZJa4rPo+QFo+O
+        UpC5ahoiBTfUcVatYyhLXhNCNhnPU+oSe54fSsnL9XNAljH+aUa8RhFNy5y5Y+B8KccaS6ngrJMG
+        lJGl7OwkZcaorqYBdrc5wxtZLvsdkWjavc0RaGS5PfQjnjk8H+II5g0kA8uy+6/I9TbfmipLHFsM
+        /Jp/PSCdMjd62Nwza4GON+RO26JZb6hkTXDuEwsQW4ybtU5jQr7A/G+LXlmTdYnjSQ0n3HxrrGSt
+        eRyRe8o247NmPqqk3/t8hd/aGgf9zuYeWTufuBazwSbSBQ2mnhukLlzJWrnP/DDyvnzZrG5VWQqI
+        +x7/CEVq/to73dxNfX69Be2mGeG2y5w9ZfZJhel8PKdXStXn4t7nz8FPMj/srTYVf9kriYYX9spZ
+        Pn3kfyVxlMVxZSWlKMpbrP7jGuTTnlw2OxnoX2P5lLMtkvCxo1siXhROI2xXKhH7PG3/VsFD+hCW
+        vPAGbnG8+D6bGom7brPUj9X8K6/1E7KEkrkEXcatW21GOjybi6H4bOpVtiNhflXmB0zAuHrb/akn
+        tVR5XmTeRV2aqL+GyknMdaVUh+Qr15W68oKcnL6xya39Qjp8L/Qsz8EoWTRtt3tsTeEssvmRWZPp
+        a5gse6tARLygFglC6R98aUWnuAERSWO0eNAfjwDFt3svhU9IYKGJiJ+0/Gm2RgNKB8QJPFRVClNZ
+        0bRrN68Nzy83PrrM2+CD2e6I63nq8ddYOtRmEf9w+5iNuXRNGI/xzPYmDhd4TpQTK71F0y5tsmaF
+        f3S9acCwh4m9RdOOCh+5QTTlKTV+8+WOurZ4+3pVk6sFjr/70k9xP+QBXQgruVvmjssj5gfhYORF
+        Lra0Wf5g84hjYZlFcVf6U8xv5sSI3yLYjpdT8qenZd3t76Z+Oe8blmV6uj7zxLr8gvAdMGmv370o
+        vui+l37O8gO/3uHQbRYEK6r/ZdYF87jhv7LxdWJ6YS4b68nvjPL76RF7EBO3hhWyOypmcEHkj4j1
+        OnO4kIzLvdZvEliLjj0fnRQsN3/Dkz8+wh1xIqqZ0CpKK7XZ3cx5dR0F11GwWsXAahUF6yoG1lV8
+        5Ao6cgUf2UBHNnAFUbCGg3WUDR1nQ0fZ0HE2tBoqRg0fGQXrOFhDedZwnlH9ctRTUCEUXAgUrOFg
+        1D9x98SQKBC1BW4K1CFwf1BRQ6i4IQwdHVjHCdNQwjRcDJRdFWdXR0NJx0PJQEc28JENVGYDl1lD
+        xdBwMXAycC5QltUcllG30HJCFB1Zw0c20Kgz8KhDB8bHVVHvVHPSFT5wzsho2Kl43OmoRfQck6Bc
+        qDgXqFvgXoEGHx57Kiqvisuro0zoOBMqmjKhdv3RT0BD+Ub8iFJScr3wZZMEuz6qj4ZVKtfUkSUb
+        lmLKpqVpsjU0TGpTu2IYFWTysGW3b5hUiJ8qFBoPzFo2V6w0vA0ZqkmUmiIbdk0DraqaPDRGumyr
+        mlXXKTFskcrXydiq2/eRUa9oOBm84S3I4JdAlE2qv1GZFRXeRHDF0ixCSVWmijKUjeGIyHUyrMqK
+        NazUKkbVGllVRLEtu32fFavVHCvyhrcgQx3VVaNqV0AXkweqrsjEqOqyZVGjqqkj06hi8b1lt28l
+        Q/zEZ6y4/QgNzFplBUG8BT2WXaekDorplSroqWpV2ST8RwFpraapRFNUw0To2bLbd6Y/Myf7ma9E
+        xTX/Edgw/c1Hn06AdLG6h5qn5+f/A4pU4I1fVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:47:17 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 4c2d46ae2f5a2becd0bcab3bc81c5e17
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEBZ8G0YS5/DLCl5KLTIMCZzBhLylp5Wk05MVySF0ydGhArchn
+        4WPZ8iaAJ06YMj4AKReGnlpMhsHlaOp4ZNn+A5DEBw3USs3QK6qqG3BdNgHfJpPpvFrTK6AvCW6H
+        885wRiLwqtAnzFlzqWRUbqZnwLIg9PxHYfqkLPwE6KjqplZNjDRIiLZ8SkKw4MAGj18WzSEQdBPP
+        ZiNmIRgh58sskSUct0ocib6wcg7FqTtw74biXeSAOmTIHBYymlSCjaYZDD91GHEtGp+PmBNSPw6P
+        xBE5usx4+AIhNjd46rqNIKChdNIqZPLJU6oKhYpH0WlMH+D8kyKbRB5dP9Wf5b35ifEsF5/05/m5
+        qj3vlbaGFn/KSpVeSQEDQA6qyWRo2TIdKarMK+RqrW7yKl4DUVrwIEoJeAHXtkB/56EnjhMSWjf8
+        LC4AK2Pfi6ap1llaH0W0Jw1TJxozt0zAGdkwgsRcHqK0HUZjcNfftyXuv1zj659jWq5/xnU+u+oc
+        ti+E8A8OdcfhDXhj/V2UpA8Qz5DXRz4geGIeQPTdkQDRvNk46zd6UjvuIR2lPVAebN+b2hCR0OhA
+        tHL5+c0KToWzF65ztfsOZWLRB1Ni3ZIxzVehOwdsJXjcCypaWqI8HwDOP9ywkA66EGMQlT5E/Zto
+        9eDT0UGzfXEpN5uYTtAiNew7FkBK3Notmw059kg5ddDVmuJPf8d8FWD/hj/5pCXtMXogwbmmKLqs
+        1IvvE5ZzOvK46GfH+uY4xZWnfij1ryQQgfoU8m7MgQoEqMVdiV/PR13//KK907E7RaXutrcyXxnN
+        q5ftj5fv45TWHS375B7ToL+dBv/dA+QMUk1R3lNN05xpyidFvRbuWIxD8skowf11O1yeA/fbEK4w
+        4YdpTLWUnFVlVYFb7nsxFQSDIQkorHtyPLXf60mwWKCwRogR24fv58/lJIB/QfWvlStrasKcCaBj
+        cXwVT+Ya8sWW5xNns5aXCeq7NEUVNcraOyt6Bys3z8+Ngqy2fQHd8kYFPbW/tQ/2rmbd8+bsaHY8
+        O2sV9y9OD/bOj2aXsw+zq7iiCZDm7Opi1uTnIk6+qWcxJ3TaB8clqX1wtEbrK8fG13l8OX2N/sHe
+        6awxOyvuN0Db41lndgrF6GDvbNabdYr7TV7qzprF/ZN5qZGW5lx+3zB5xMKoZyUJjo03plbfIu/c
+        6WXlj5589C2zj9D1j5+C9JfkoGWdXxpJB9B7P84oIp98TNJJkk0+xskEcsnsAk6SuHlZpx+cfvRt
+        Ofwm6ngCOYMEcjrrxinkdHZc3O9e8FpRvBJ546K43+N8NUVGOYamM5FRklIjLWUJfuWhf2iyipc4
+        H9qYAT5sO51MQvNrK5oP7dXVDCzn3mQpt9itGtg0sHw25ZtvmI431LqVzvjJK8/9X0H0OVmY4HOY
+        dJGB7YQK616WbHkPiBXvQK/r04oR+7+5sBqUGjEu2J014/ri19YG1HGYh2nTFg27vAaeSx/3/aoK
+        bxEib7pLQe4Ic7gMmG6JUo0MZkfsIvJxu3Uoi82kPMFbJCR8gvm6W047tTec1NxEw3wejkXjjlgu
+        ETjBDiiYJ2dm015CSm1AbqtG0jWQiE+lrIufeVIigMQCuM3+HjH+sFM03IqcSvGub8kFtQfDx8GE
+        OPcEXRq0U5h0+Ch15rDdMmishEuDIMIeVSzpcJaifogK4gFc8kB/XdBjaOXF/ZOu1LBtH0T9joSu
+        mlpZrdbLalkrqTVeLsNBXhQVpaQq/F+5AlNmzSgJ6egDgXkLFU+A328L/6TRbyCM8OoXZlD5U0P+
+        D5G/XMvLGXW1PifDiiuuzYFVVW7IilpR3/OxBohyiHNy+O6cHKKcHL4nJ0HIxoOA3lH+ggLOS0fq
+        Ldq3YYfdnfSvf87ReTFarPJJ/52tjz3U4tXvbv3LHx8RzB2EN8ACvcdS/IkrXd5QSO73O7Qgyb+r
+        7uqNNDO5m9CQBKISk3/euMsLqIUKeSuojB5/mNWTSA6d3hGWHDrM8r3AG4XSYeQ4NGTudnmi01t5
+        /L9SkZMZOj3TlE3TBLiiyLW6+Y4MnPf6LezuKOr/NIuuKR9gMI2GztLbaetqdzlQ6i6AfAGak2Cg
+        YcSoY68R8WQ878cFbVFAKeEvfex3Ovut1prJ+fCyw7NGUqJpcRwuSvNKQZgofe92ycZdxK7AS60l
+        0C5txY3IhDniJcZc4Y8EZGN+HUwiJ2SLLDu/ygWsfo5JKJ16Fn+6k7zmKYnNVX7LFC9PZqQ67spX
+        HzeitQy6RYeMuBvhegbe8xziwxp4E97I4I+o7flkI7ySgTd/PZHIMApo2ljNNP4KJva8jWPVsqJG
+        vfZGcD0DbpxspszMYD8wFwwWSAfSetKeG0TJdqBDGNa/4690Js1Zg/U6l11p6nvgNpM5IGujI5/S
+        w15rswdkrXQ1jNww2ozPWqnnEOuWT2s2d8laqsPfjCa3X+mRNd8FnXghlUbMoRKxrHiFLFBZqzXB
+        yOe9zaNmDXd02U2rERulDq8sSW7BBb4SIepSiLgMkN5IGJGJRwHxm+3ZUVlgldOGpYiJ+0g2DamV
+        ZC8BMpYuITbopSuXPWT35wUQDxBwv4+9XopZihMCGcf3vBCm/pxykXgEKkv0RbeZVtdR574KqC9N
+        iEvGdELFYwUBNpcjEhKjk+aJLMvpJuo8iWQZ7VLqy5eezP9LR9whejeQVtz0BXs9y2zzpNc8Txuy
+        zB4xn94Tx5lfIsvoIXi07XnziNOzLPaajVYjbchS1zpLGdWzXAEVDvirFMS2nI+ZJa4rPo+QFo+O
+        UpC5ahoiBTfUcVatYyhLXhNCNhnPU+oSe54fSsnL9XNAljH+aUa8RhFNy5y5Y+B8KccaS6ngrJMG
+        lJGl7OwkZcaorqYBdrc5wxtZLvsdkWjavc0RaGS5PfQjnjk8H+II5g0kA8uy+6/I9TbfmipLHFsM
+        /Jp/PSCdMjd62Nwza4GON+RO26JZb6hkTXDuEwsQW4ybtU5jQr7A/G+LXlmTdYnjSQ0n3HxrrGSt
+        eRyRe8o247NmPqqk3/t8hd/aGgf9zuYeWTufuBazwSbSBQ2mnhukLlzJWrnP/DDyvnzZrG5VWQqI
+        +x7/CEVq/to73dxNfX69Be2mGeG2y5w9ZfZJhel8PKdXStXn4t7nz8FPMj/srTYVf9kriYYX9spZ
+        Pn3kfyVxlMVxZSWlKMpbrP7jGuTTnlw2OxnoX2P5lLMtkvCxo1siXhROI2xXKhH7PG3/VsFD+hCW
+        vPAGbnG8+D6bGom7brPUj9X8K6/1E7KEkrkEXcatW21GOjybi6H4bOpVtiNhflXmB0zAuHrb/akn
+        tVR5XmTeRV2aqL+GyknMdaVUh+Qr15W68oKcnL6xya39Qjp8L/Qsz8EoWTRtt3tsTeEssvmRWZPp
+        a5gse6tARLygFglC6R98aUWnuAERSWO0eNAfjwDFt3svhU9IYKGJiJ+0/Gm2RgNKB8QJPFRVClNZ
+        0bRrN68Nzy83PrrM2+CD2e6I63nq8ddYOtRmEf9w+5iNuXRNGI/xzPYmDhd4TpQTK71F0y5tsmaF
+        f3S9acCwh4m9RdOOCh+5QTTlKTV+8+WOurZ4+3pVk6sFjr/70k9xP+QBXQgruVvmjssj5gfhYORF
+        Lra0Wf5g84hjYZlFcVf6U8xv5sSI3yLYjpdT8qenZd3t76Z+Oe8blmV6uj7zxLr8gvAdMGmv370o
+        vui+l37O8gO/3uHQbRYEK6r/ZdYF87jhv7LxdWJ6YS4b68nvjPL76RF7EBO3hhWyOypmcEHkj4j1
+        OnO4kIzLvdZvEliLjj0fnRQsN3/Dkz8+wh1xIqqZ0CpKK7XZ3cx5dR0F11GwWsXAahUF6yoG1lV8
+        5Ao6cgUf2UBHNnAFUbCGg3WUDR1nQ0fZ0HE2tBoqRg0fGQXrOFhDedZwnlH9ctRTUCEUXAgUrOFg
+        1D9x98SQKBC1BW4K1CFwf1BRQ6i4IQwdHVjHCdNQwjRcDJRdFWdXR0NJx0PJQEc28JENVGYDl1lD
+        xdBwMXAycC5QltUcllG30HJCFB1Zw0c20Kgz8KhDB8bHVVHvVHPSFT5wzsho2Kl43OmoRfQck6Bc
+        qDgXqFvgXoEGHx57Kiqvisuro0zoOBMqmjKhdv3RT0BD+Ub8iFJScr3wZZMEuz6qj4ZVKtfUkSUb
+        lmLKpqVpsjU0TGpTu2IYFWTysGW3b5hUiJ8qFBoPzFo2V6w0vA0ZqkmUmiIbdk0DraqaPDRGumyr
+        mlXXKTFskcrXydiq2/eRUa9oOBm84S3I4JdAlE2qv1GZFRXeRHDF0ixCSVWmijKUjeGIyHUyrMqK
+        NazUKkbVGllVRLEtu32fFavVHCvyhrcgQx3VVaNqV0AXkweqrsjEqOqyZVGjqqkj06hi8b1lt28l
+        Q/zEZ6y4/QgNzFplBUG8BT2WXaekDorplSroqWpV2ST8RwFpraapRFNUw0To2bLbd6Y/Myf7ma9E
+        xTX/Edgw/c1Hn06AdLG6h5qn5+f/A4pU4I1fVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:47:18 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 9004ad4bbc84bfbdffaa9441e1c7a08e
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEBZ8G0YS5/DLCl5KLTIMCZzBhLylp5Wk05MVySF0ydGhArchn
+        4WPZ8iaAJ06YMj4AKReGnlpMhsHlaOp4ZNn+A5DEBw3USs3QK6qqG3BdNgHfJpPpvFrTK6AvCW6H
+        885wRiLwqtAnzFlzqWRUbqZnwLIg9PxHYfqkLPwE6KjqplZNjDRIiLZ8SkKw4MAGj18WzSEQdBPP
+        ZiNmIRgh58sskSUct0ocib6wcg7FqTtw74biXeSAOmTIHBYymlSCjaYZDD91GHEtGp+PmBNSPw6P
+        xBE5usx4+AIhNjd46rqNIKChdNIqZPLJU6oKhYpH0WlMH+D8kyKbRB5dP9Wf5b35ifEsF5/05/m5
+        qj3vlbaGFn/KSpVeSQEDQA6qyWRo2TIdKarMK+RqrW7yKl4DUVrwIEoJeAHXtkB/56EnjhMSWjf8
+        LC4AK2Pfi6ap1llaH0W0Jw1TJxozt0zAGdkwgsRcHqK0HUZjcNfftyXuv1zj659jWq5/xnU+u+oc
+        ti+E8A8OdcfhDXhj/V2UpA8Qz5DXRz4geGIeQPTdkQDRvNk46zd6UjvuIR2lPVAebN+b2hCR0OhA
+        tHL5+c0KToWzF65ztfsOZWLRB1Ni3ZIxzVehOwdsJXjcCypaWqI8HwDOP9ywkA66EGMQlT5E/Zto
+        9eDT0UGzfXEpN5uYTtAiNew7FkBK3Notmw059kg5ddDVmuJPf8d8FWD/hj/5pCXtMXogwbmmKLqs
+        1IvvE5ZzOvK46GfH+uY4xZWnfij1ryQQgfoU8m7MgQoEqMVdiV/PR13//KK907E7RaXutrcyXxnN
+        q5ftj5fv45TWHS375B7ToL+dBv/dA+QMUk1R3lNN05xpyidFvRbuWIxD8skowf11O1yeA/fbEK4w
+        4YdpTLWUnFVlVYFb7nsxFQSDIQkorHtyPLXf60mwWKCwRogR24fv58/lJIB/QfWvlStrasKcCaBj
+        cXwVT+Ya8sWW5xNns5aXCeq7NEUVNcraOyt6Bys3z8+Ngqy2fQHd8kYFPbW/tQ/2rmbd8+bsaHY8
+        O2sV9y9OD/bOj2aXsw+zq7iiCZDm7Opi1uTnIk6+qWcxJ3TaB8clqX1wtEbrK8fG13l8OX2N/sHe
+        6awxOyvuN0Db41lndgrF6GDvbNabdYr7TV7qzprF/ZN5qZGW5lx+3zB5xMKoZyUJjo03plbfIu/c
+        6WXlj5589C2zj9D1j5+C9JfkoGWdXxpJB9B7P84oIp98TNJJkk0+xskEcsnsAk6SuHlZpx+cfvRt
+        Ofwm6ngCOYMEcjrrxinkdHZc3O9e8FpRvBJ546K43+N8NUVGOYamM5FRklIjLWUJfuWhf2iyipc4
+        H9qYAT5sO51MQvNrK5oP7dXVDCzn3mQpt9itGtg0sHw25ZtvmI431LqVzvjJK8/9X0H0OVmY4HOY
+        dJGB7YQK616WbHkPiBXvQK/r04oR+7+5sBqUGjEu2J014/ri19YG1HGYh2nTFg27vAaeSx/3/aoK
+        bxEib7pLQe4Ic7gMmG6JUo0MZkfsIvJxu3Uoi82kPMFbJCR8gvm6W047tTec1NxEw3wejkXjjlgu
+        ETjBDiiYJ2dm015CSm1AbqtG0jWQiE+lrIufeVIigMQCuM3+HjH+sFM03IqcSvGub8kFtQfDx8GE
+        OPcEXRq0U5h0+Ch15rDdMmishEuDIMIeVSzpcJaifogK4gFc8kB/XdBjaOXF/ZOu1LBtH0T9joSu
+        mlpZrdbLalkrqTVeLsNBXhQVpaQq/F+5AlNmzSgJ6egDgXkLFU+A328L/6TRbyCM8OoXZlD5U0P+
+        D5G/XMvLGXW1PifDiiuuzYFVVW7IilpR3/OxBohyiHNy+O6cHKKcHL4nJ0HIxoOA3lH+ggLOS0fq
+        Ldq3YYfdnfSvf87ReTFarPJJ/52tjz3U4tXvbv3LHx8RzB2EN8ACvcdS/IkrXd5QSO73O7Qgyb+r
+        7uqNNDO5m9CQBKISk3/euMsLqIUKeSuojB5/mNWTSA6d3hGWHDrM8r3AG4XSYeQ4NGTudnmi01t5
+        /L9SkZMZOj3TlE3TBLiiyLW6+Y4MnPf6LezuKOr/NIuuKR9gMI2GztLbaetqdzlQ6i6AfAGak2Cg
+        YcSoY68R8WQ878cFbVFAKeEvfex3Ovut1prJ+fCyw7NGUqJpcRwuSvNKQZgofe92ycZdxK7AS60l
+        0C5txY3IhDniJcZc4Y8EZGN+HUwiJ2SLLDu/ygWsfo5JKJ16Fn+6k7zmKYnNVX7LFC9PZqQ67spX
+        HzeitQy6RYeMuBvhegbe8xziwxp4E97I4I+o7flkI7ySgTd/PZHIMApo2ljNNP4KJva8jWPVsqJG
+        vfZGcD0DbpxspszMYD8wFwwWSAfSetKeG0TJdqBDGNa/4690Js1Zg/U6l11p6nvgNpM5IGujI5/S
+        w15rswdkrXQ1jNww2ozPWqnnEOuWT2s2d8laqsPfjCa3X+mRNd8FnXghlUbMoRKxrHiFLFBZqzXB
+        yOe9zaNmDXd02U2rERulDq8sSW7BBb4SIepSiLgMkN5IGJGJRwHxm+3ZUVlgldOGpYiJ+0g2DamV
+        ZC8BMpYuITbopSuXPWT35wUQDxBwv4+9XopZihMCGcf3vBCm/pxykXgEKkv0RbeZVtdR574KqC9N
+        iEvGdELFYwUBNpcjEhKjk+aJLMvpJuo8iWQZ7VLqy5eezP9LR9whejeQVtz0BXs9y2zzpNc8Txuy
+        zB4xn94Tx5lfIsvoIXi07XnziNOzLPaajVYjbchS1zpLGdWzXAEVDvirFMS2nI+ZJa4rPo+QFo+O
+        UpC5ahoiBTfUcVatYyhLXhNCNhnPU+oSe54fSsnL9XNAljH+aUa8RhFNy5y5Y+B8KccaS6ngrJMG
+        lJGl7OwkZcaorqYBdrc5wxtZLvsdkWjavc0RaGS5PfQjnjk8H+II5g0kA8uy+6/I9TbfmipLHFsM
+        /Jp/PSCdMjd62Nwza4GON+RO26JZb6hkTXDuEwsQW4ybtU5jQr7A/G+LXlmTdYnjSQ0n3HxrrGSt
+        eRyRe8o247NmPqqk3/t8hd/aGgf9zuYeWTufuBazwSbSBQ2mnhukLlzJWrnP/DDyvnzZrG5VWQqI
+        +x7/CEVq/to73dxNfX69Be2mGeG2y5w9ZfZJhel8PKdXStXn4t7nz8FPMj/srTYVf9kriYYX9spZ
+        Pn3kfyVxlMVxZSWlKMpbrP7jGuTTnlw2OxnoX2P5lLMtkvCxo1siXhROI2xXKhH7PG3/VsFD+hCW
+        vPAGbnG8+D6bGom7brPUj9X8K6/1E7KEkrkEXcatW21GOjybi6H4bOpVtiNhflXmB0zAuHrb/akn
+        tVR5XmTeRV2aqL+GyknMdaVUh+Qr15W68oKcnL6xya39Qjp8L/Qsz8EoWTRtt3tsTeEssvmRWZPp
+        a5gse6tARLygFglC6R98aUWnuAERSWO0eNAfjwDFt3svhU9IYKGJiJ+0/Gm2RgNKB8QJPFRVClNZ
+        0bRrN68Nzy83PrrM2+CD2e6I63nq8ddYOtRmEf9w+5iNuXRNGI/xzPYmDhd4TpQTK71F0y5tsmaF
+        f3S9acCwh4m9RdOOCh+5QTTlKTV+8+WOurZ4+3pVk6sFjr/70k9xP+QBXQgruVvmjssj5gfhYORF
+        Lra0Wf5g84hjYZlFcVf6U8xv5sSI3yLYjpdT8qenZd3t76Z+Oe8blmV6uj7zxLr8gvAdMGmv370o
+        vui+l37O8gO/3uHQbRYEK6r/ZdYF87jhv7LxdWJ6YS4b68nvjPL76RF7EBO3hhWyOypmcEHkj4j1
+        OnO4kIzLvdZvEliLjj0fnRQsN3/Dkz8+wh1xIqqZ0CpKK7XZ3cx5dR0F11GwWsXAahUF6yoG1lV8
+        5Ao6cgUf2UBHNnAFUbCGg3WUDR1nQ0fZ0HE2tBoqRg0fGQXrOFhDedZwnlH9ctRTUCEUXAgUrOFg
+        1D9x98SQKBC1BW4K1CFwf1BRQ6i4IQwdHVjHCdNQwjRcDJRdFWdXR0NJx0PJQEc28JENVGYDl1lD
+        xdBwMXAycC5QltUcllG30HJCFB1Zw0c20Kgz8KhDB8bHVVHvVHPSFT5wzsho2Kl43OmoRfQck6Bc
+        qDgXqFvgXoEGHx57Kiqvisuro0zoOBMqmjKhdv3RT0BD+Ub8iFJScr3wZZMEuz6qj4ZVKtfUkSUb
+        lmLKpqVpsjU0TGpTu2IYFWTysGW3b5hUiJ8qFBoPzFo2V6w0vA0ZqkmUmiIbdk0DraqaPDRGumyr
+        mlXXKTFskcrXydiq2/eRUa9oOBm84S3I4JdAlE2qv1GZFRXeRHDF0ixCSVWmijKUjeGIyHUyrMqK
+        NazUKkbVGllVRLEtu32fFavVHCvyhrcgQx3VVaNqV0AXkweqrsjEqOqyZVGjqqkj06hi8b1lt28l
+        Q/zEZ6y4/QgNzFplBUG8BT2WXaekDorplSroqWpV2ST8RwFpraapRFNUw0To2bLbd6Y/Myf7ma9E
+        xTX/Edgw/c1Hn06AdLG6h5qn5+f/A4pU4I1fVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:47:28 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - a0b6e3a8422859e5946e40fee8dd44be
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEBZ8G0YS5/DLCl5KLTIMCZzBhLylp5Wk05MVySF0ydGhArchn
+        4WPZ8iaAJ06YMj4AKReGnlpMhsHlaOp4ZNn+A5DEBw3USs3QK6qqG3BdNgHfJpPpvFrTK6AvCW6H
+        885wRiLwqtAnzFlzqWRUbqZnwLIg9PxHYfqkLPwE6KjqplZNjDRIiLZ8SkKw4MAGj18WzSEQdBPP
+        ZiNmIRgh58sskSUct0ocib6wcg7FqTtw74biXeSAOmTIHBYymlSCjaYZDD91GHEtGp+PmBNSPw6P
+        xBE5usx4+AIhNjd46rqNIKChdNIqZPLJU6oKhYpH0WlMH+D8kyKbRB5dP9Wf5b35ifEsF5/05/m5
+        qj3vlbaGFn/KSpVeSQEDQA6qyWRo2TIdKarMK+RqrW7yKl4DUVrwIEoJeAHXtkB/56EnjhMSWjf8
+        LC4AK2Pfi6ap1llaH0W0Jw1TJxozt0zAGdkwgsRcHqK0HUZjcNfftyXuv1zj659jWq5/xnU+u+oc
+        ti+E8A8OdcfhDXhj/V2UpA8Qz5DXRz4geGIeQPTdkQDRvNk46zd6UjvuIR2lPVAebN+b2hCR0OhA
+        tHL5+c0KToWzF65ztfsOZWLRB1Ni3ZIxzVehOwdsJXjcCypaWqI8HwDOP9ywkA66EGMQlT5E/Zto
+        9eDT0UGzfXEpN5uYTtAiNew7FkBK3Notmw059kg5ddDVmuJPf8d8FWD/hj/5pCXtMXogwbmmKLqs
+        1IvvE5ZzOvK46GfH+uY4xZWnfij1ryQQgfoU8m7MgQoEqMVdiV/PR13//KK907E7RaXutrcyXxnN
+        q5ftj5fv45TWHS375B7ToL+dBv/dA+QMUk1R3lNN05xpyidFvRbuWIxD8skowf11O1yeA/fbEK4w
+        4YdpTLWUnFVlVYFb7nsxFQSDIQkorHtyPLXf60mwWKCwRogR24fv58/lJIB/QfWvlStrasKcCaBj
+        cXwVT+Ya8sWW5xNns5aXCeq7NEUVNcraOyt6Bys3z8+Ngqy2fQHd8kYFPbW/tQ/2rmbd8+bsaHY8
+        O2sV9y9OD/bOj2aXsw+zq7iiCZDm7Opi1uTnIk6+qWcxJ3TaB8clqX1wtEbrK8fG13l8OX2N/sHe
+        6awxOyvuN0Db41lndgrF6GDvbNabdYr7TV7qzprF/ZN5qZGW5lx+3zB5xMKoZyUJjo03plbfIu/c
+        6WXlj5589C2zj9D1j5+C9JfkoGWdXxpJB9B7P84oIp98TNJJkk0+xskEcsnsAk6SuHlZpx+cfvRt
+        Ofwm6ngCOYMEcjrrxinkdHZc3O9e8FpRvBJ546K43+N8NUVGOYamM5FRklIjLWUJfuWhf2iyipc4
+        H9qYAT5sO51MQvNrK5oP7dXVDCzn3mQpt9itGtg0sHw25ZtvmI431LqVzvjJK8/9X0H0OVmY4HOY
+        dJGB7YQK616WbHkPiBXvQK/r04oR+7+5sBqUGjEu2J014/ri19YG1HGYh2nTFg27vAaeSx/3/aoK
+        bxEib7pLQe4Ic7gMmG6JUo0MZkfsIvJxu3Uoi82kPMFbJCR8gvm6W047tTec1NxEw3wejkXjjlgu
+        ETjBDiiYJ2dm015CSm1AbqtG0jWQiE+lrIufeVIigMQCuM3+HjH+sFM03IqcSvGub8kFtQfDx8GE
+        OPcEXRq0U5h0+Ch15rDdMmishEuDIMIeVSzpcJaifogK4gFc8kB/XdBjaOXF/ZOu1LBtH0T9joSu
+        mlpZrdbLalkrqTVeLsNBXhQVpaQq/F+5AlNmzSgJ6egDgXkLFU+A328L/6TRbyCM8OoXZlD5U0P+
+        D5G/XMvLGXW1PifDiiuuzYFVVW7IilpR3/OxBohyiHNy+O6cHKKcHL4nJ0HIxoOA3lH+ggLOS0fq
+        Ldq3YYfdnfSvf87ReTFarPJJ/52tjz3U4tXvbv3LHx8RzB2EN8ACvcdS/IkrXd5QSO73O7Qgyb+r
+        7uqNNDO5m9CQBKISk3/euMsLqIUKeSuojB5/mNWTSA6d3hGWHDrM8r3AG4XSYeQ4NGTudnmi01t5
+        /L9SkZMZOj3TlE3TBLiiyLW6+Y4MnPf6LezuKOr/NIuuKR9gMI2GztLbaetqdzlQ6i6AfAGak2Cg
+        YcSoY68R8WQ878cFbVFAKeEvfex3Ovut1prJ+fCyw7NGUqJpcRwuSvNKQZgofe92ycZdxK7AS60l
+        0C5txY3IhDniJcZc4Y8EZGN+HUwiJ2SLLDu/ygWsfo5JKJ16Fn+6k7zmKYnNVX7LFC9PZqQ67spX
+        HzeitQy6RYeMuBvhegbe8xziwxp4E97I4I+o7flkI7ySgTd/PZHIMApo2ljNNP4KJva8jWPVsqJG
+        vfZGcD0DbpxspszMYD8wFwwWSAfSetKeG0TJdqBDGNa/4690Js1Zg/U6l11p6nvgNpM5IGujI5/S
+        w15rswdkrXQ1jNww2ozPWqnnEOuWT2s2d8laqsPfjCa3X+mRNd8FnXghlUbMoRKxrHiFLFBZqzXB
+        yOe9zaNmDXd02U2rERulDq8sSW7BBb4SIepSiLgMkN5IGJGJRwHxm+3ZUVlgldOGpYiJ+0g2DamV
+        ZC8BMpYuITbopSuXPWT35wUQDxBwv4+9XopZihMCGcf3vBCm/pxykXgEKkv0RbeZVtdR574KqC9N
+        iEvGdELFYwUBNpcjEhKjk+aJLMvpJuo8iWQZ7VLqy5eezP9LR9whejeQVtz0BXs9y2zzpNc8Txuy
+        zB4xn94Tx5lfIsvoIXi07XnziNOzLPaajVYjbchS1zpLGdWzXAEVDvirFMS2nI+ZJa4rPo+QFo+O
+        UpC5ahoiBTfUcVatYyhLXhNCNhnPU+oSe54fSsnL9XNAljH+aUa8RhFNy5y5Y+B8KccaS6ngrJMG
+        lJGl7OwkZcaorqYBdrc5wxtZLvsdkWjavc0RaGS5PfQjnjk8H+II5g0kA8uy+6/I9TbfmipLHFsM
+        /Jp/PSCdMjd62Nwza4GON+RO26JZb6hkTXDuEwsQW4ybtU5jQr7A/G+LXlmTdYnjSQ0n3HxrrGSt
+        eRyRe8o247NmPqqk3/t8hd/aGgf9zuYeWTufuBazwSbSBQ2mnhukLlzJWrnP/DDyvnzZrG5VWQqI
+        +x7/CEVq/to73dxNfX69Be2mGeG2y5w9ZfZJhel8PKdXStXn4t7nz8FPMj/srTYVf9kriYYX9spZ
+        Pn3kfyVxlMVxZSWlKMpbrP7jGuTTnlw2OxnoX2P5lLMtkvCxo1siXhROI2xXKhH7PG3/VsFD+hCW
+        vPAGbnG8+D6bGom7brPUj9X8K6/1E7KEkrkEXcatW21GOjybi6H4bOpVtiNhflXmB0zAuHrb/akn
+        tVR5XmTeRV2aqL+GyknMdaVUh+Qr15W68oKcnL6xya39Qjp8L/Qsz8EoWTRtt3tsTeEssvmRWZPp
+        a5gse6tARLygFglC6R98aUWnuAERSWO0eNAfjwDFt3svhU9IYKGJiJ+0/Gm2RgNKB8QJPFRVClNZ
+        0bRrN68Nzy83PrrM2+CD2e6I63nq8ddYOtRmEf9w+5iNuXRNGI/xzPYmDhd4TpQTK71F0y5tsmaF
+        f3S9acCwh4m9RdOOCh+5QTTlKTV+8+WOurZ4+3pVk6sFjr/70k9xP+QBXQgruVvmjssj5gfhYORF
+        Lra0Wf5g84hjYZlFcVf6U8xv5sSI3yLYjpdT8qenZd3t76Z+Oe8blmV6uj7zxLr8gvAdMGmv370o
+        vui+l37O8gO/3uHQbRYEK6r/ZdYF87jhv7LxdWJ6YS4b68nvjPL76RF7EBO3hhWyOypmcEHkj4j1
+        OnO4kIzLvdZvEliLjj0fnRQsN3/Dkz8+wh1xIqqZ0CpKK7XZ3cx5dR0F11GwWsXAahUF6yoG1lV8
+        5Ao6cgUf2UBHNnAFUbCGg3WUDR1nQ0fZ0HE2tBoqRg0fGQXrOFhDedZwnlH9ctRTUCEUXAgUrOFg
+        1D9x98SQKBC1BW4K1CFwf1BRQ6i4IQwdHVjHCdNQwjRcDJRdFWdXR0NJx0PJQEc28JENVGYDl1lD
+        xdBwMXAycC5QltUcllG30HJCFB1Zw0c20Kgz8KhDB8bHVVHvVHPSFT5wzsho2Kl43OmoRfQck6Bc
+        qDgXqFvgXoEGHx57Kiqvisuro0zoOBMqmjKhdv3RT0BD+Ub8iFJScr3wZZMEuz6qj4ZVKtfUkSUb
+        lmLKpqVpsjU0TGpTu2IYFWTysGW3b5hUiJ8qFBoPzFo2V6w0vA0ZqkmUmiIbdk0DraqaPDRGumyr
+        mlXXKTFskcrXydiq2/eRUa9oOBm84S3I4JdAlE2qv1GZFRXeRHDF0ixCSVWmijKUjeGIyHUyrMqK
+        NazUKkbVGllVRLEtu32fFavVHCvyhrcgQx3VVaNqV0AXkweqrsjEqOqyZVGjqqkj06hi8b1lt28l
+        Q/zEZ6y4/QgNzFplBUG8BT2WXaekDorplSroqWpV2ST8RwFpraapRFNUw0To2bLbd6Y/Myf7ma9E
+        xTX/Edgw/c1Hn06AdLG6h5qn5+f/A4pU4I1fVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:47:39 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - c625a3b96c2b5db33314c982e1f92970
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEBZ8G0YS5/DLCl5KLTIMCZzBhLylp5Wk05MVySF0ydGhArchn
+        4WPZ8iaAJ06YMj4AKReGnlpMhsHlaOp4ZNn+A5DEBw3USs3QK6qqG3BdNgHfJpPpvFrTK6AvCW6H
+        885wRiLwqtAnzFlzqWRUbqZnwLIg9PxHYfqkLPwE6KjqplZNjDRIiLZ8SkKw4MAGj18WzSEQdBPP
+        ZiNmIRgh58sskSUct0ocib6wcg7FqTtw74biXeSAOmTIHBYymlSCjaYZDD91GHEtGp+PmBNSPw6P
+        xBE5usx4+AIhNjd46rqNIKChdNIqZPLJU6oKhYpH0WlMH+D8kyKbRB5dP9Wf5b35ifEsF5/05/m5
+        qj3vlbaGFn/KSpVeSQEDQA6qyWRo2TIdKarMK+RqrW7yKl4DUVrwIEoJeAHXtkB/56EnjhMSWjf8
+        LC4AK2Pfi6ap1llaH0W0Jw1TJxozt0zAGdkwgsRcHqK0HUZjcNfftyXuv1zj659jWq5/xnU+u+oc
+        ti+E8A8OdcfhDXhj/V2UpA8Qz5DXRz4geGIeQPTdkQDRvNk46zd6UjvuIR2lPVAebN+b2hCR0OhA
+        tHL5+c0KToWzF65ztfsOZWLRB1Ni3ZIxzVehOwdsJXjcCypaWqI8HwDOP9ywkA66EGMQlT5E/Zto
+        9eDT0UGzfXEpN5uYTtAiNew7FkBK3Notmw059kg5ddDVmuJPf8d8FWD/hj/5pCXtMXogwbmmKLqs
+        1IvvE5ZzOvK46GfH+uY4xZWnfij1ryQQgfoU8m7MgQoEqMVdiV/PR13//KK907E7RaXutrcyXxnN
+        q5ftj5fv45TWHS375B7ToL+dBv/dA+QMUk1R3lNN05xpyidFvRbuWIxD8skowf11O1yeA/fbEK4w
+        4YdpTLWUnFVlVYFb7nsxFQSDIQkorHtyPLXf60mwWKCwRogR24fv58/lJIB/QfWvlStrasKcCaBj
+        cXwVT+Ya8sWW5xNns5aXCeq7NEUVNcraOyt6Bys3z8+Ngqy2fQHd8kYFPbW/tQ/2rmbd8+bsaHY8
+        O2sV9y9OD/bOj2aXsw+zq7iiCZDm7Opi1uTnIk6+qWcxJ3TaB8clqX1wtEbrK8fG13l8OX2N/sHe
+        6awxOyvuN0Db41lndgrF6GDvbNabdYr7TV7qzprF/ZN5qZGW5lx+3zB5xMKoZyUJjo03plbfIu/c
+        6WXlj5589C2zj9D1j5+C9JfkoGWdXxpJB9B7P84oIp98TNJJkk0+xskEcsnsAk6SuHlZpx+cfvRt
+        Ofwm6ngCOYMEcjrrxinkdHZc3O9e8FpRvBJ546K43+N8NUVGOYamM5FRklIjLWUJfuWhf2iyipc4
+        H9qYAT5sO51MQvNrK5oP7dXVDCzn3mQpt9itGtg0sHw25ZtvmI431LqVzvjJK8/9X0H0OVmY4HOY
+        dJGB7YQK616WbHkPiBXvQK/r04oR+7+5sBqUGjEu2J014/ri19YG1HGYh2nTFg27vAaeSx/3/aoK
+        bxEib7pLQe4Ic7gMmG6JUo0MZkfsIvJxu3Uoi82kPMFbJCR8gvm6W047tTec1NxEw3wejkXjjlgu
+        ETjBDiiYJ2dm015CSm1AbqtG0jWQiE+lrIufeVIigMQCuM3+HjH+sFM03IqcSvGub8kFtQfDx8GE
+        OPcEXRq0U5h0+Ch15rDdMmishEuDIMIeVSzpcJaifogK4gFc8kB/XdBjaOXF/ZOu1LBtH0T9joSu
+        mlpZrdbLalkrqTVeLsNBXhQVpaQq/F+5AlNmzSgJ6egDgXkLFU+A328L/6TRbyCM8OoXZlD5U0P+
+        D5G/XMvLGXW1PifDiiuuzYFVVW7IilpR3/OxBohyiHNy+O6cHKKcHL4nJ0HIxoOA3lH+ggLOS0fq
+        Ldq3YYfdnfSvf87ReTFarPJJ/52tjz3U4tXvbv3LHx8RzB2EN8ACvcdS/IkrXd5QSO73O7Qgyb+r
+        7uqNNDO5m9CQBKISk3/euMsLqIUKeSuojB5/mNWTSA6d3hGWHDrM8r3AG4XSYeQ4NGTudnmi01t5
+        /L9SkZMZOj3TlE3TBLiiyLW6+Y4MnPf6LezuKOr/NIuuKR9gMI2GztLbaetqdzlQ6i6AfAGak2Cg
+        YcSoY68R8WQ878cFbVFAKeEvfex3Ovut1prJ+fCyw7NGUqJpcRwuSvNKQZgofe92ycZdxK7AS60l
+        0C5txY3IhDniJcZc4Y8EZGN+HUwiJ2SLLDu/ygWsfo5JKJ16Fn+6k7zmKYnNVX7LFC9PZqQ67spX
+        HzeitQy6RYeMuBvhegbe8xziwxp4E97I4I+o7flkI7ySgTd/PZHIMApo2ljNNP4KJva8jWPVsqJG
+        vfZGcD0DbpxspszMYD8wFwwWSAfSetKeG0TJdqBDGNa/4690Js1Zg/U6l11p6nvgNpM5IGujI5/S
+        w15rswdkrXQ1jNww2ozPWqnnEOuWT2s2d8laqsPfjCa3X+mRNd8FnXghlUbMoRKxrHiFLFBZqzXB
+        yOe9zaNmDXd02U2rERulDq8sSW7BBb4SIepSiLgMkN5IGJGJRwHxm+3ZUVlgldOGpYiJ+0g2DamV
+        ZC8BMpYuITbopSuXPWT35wUQDxBwv4+9XopZihMCGcf3vBCm/pxykXgEKkv0RbeZVtdR574KqC9N
+        iEvGdELFYwUBNpcjEhKjk+aJLMvpJuo8iWQZ7VLqy5eezP9LR9whejeQVtz0BXs9y2zzpNc8Txuy
+        zB4xn94Tx5lfIsvoIXi07XnziNOzLPaajVYjbchS1zpLGdWzXAEVDvirFMS2nI+ZJa4rPo+QFo+O
+        UpC5ahoiBTfUcVatYyhLXhNCNhnPU+oSe54fSsnL9XNAljH+aUa8RhFNy5y5Y+B8KccaS6ngrJMG
+        lJGl7OwkZcaorqYBdrc5wxtZLvsdkWjavc0RaGS5PfQjnjk8H+II5g0kA8uy+6/I9TbfmipLHFsM
+        /Jp/PSCdMjd62Nwza4GON+RO26JZb6hkTXDuEwsQW4ybtU5jQr7A/G+LXlmTdYnjSQ0n3HxrrGSt
+        eRyRe8o247NmPqqk3/t8hd/aGgf9zuYeWTufuBazwSbSBQ2mnhukLlzJWrnP/DDyvnzZrG5VWQqI
+        +x7/CEVq/to73dxNfX69Be2mGeG2y5w9ZfZJhel8PKdXStXn4t7nz8FPMj/srTYVf9kriYYX9spZ
+        Pn3kfyVxlMVxZSWlKMpbrP7jGuTTnlw2OxnoX2P5lLMtkvCxo1siXhROI2xXKhH7PG3/VsFD+hCW
+        vPAGbnG8+D6bGom7brPUj9X8K6/1E7KEkrkEXcatW21GOjybi6H4bOpVtiNhflXmB0zAuHrb/akn
+        tVR5XmTeRV2aqL+GyknMdaVUh+Qr15W68oKcnL6xya39Qjp8L/Qsz8EoWTRtt3tsTeEssvmRWZPp
+        a5gse6tARLygFglC6R98aUWnuAERSWO0eNAfjwDFt3svhU9IYKGJiJ+0/Gm2RgNKB8QJPFRVClNZ
+        0bRrN68Nzy83PrrM2+CD2e6I63nq8ddYOtRmEf9w+5iNuXRNGI/xzPYmDhd4TpQTK71F0y5tsmaF
+        f3S9acCwh4m9RdOOCh+5QTTlKTV+8+WOurZ4+3pVk6sFjr/70k9xP+QBXQgruVvmjssj5gfhYORF
+        Lra0Wf5g84hjYZlFcVf6U8xv5sSI3yLYjpdT8qenZd3t76Z+Oe8blmV6uj7zxLr8gvAdMGmv370o
+        vui+l37O8gO/3uHQbRYEK6r/ZdYF87jhv7LxdWJ6YS4b68nvjPL76RF7EBO3hhWyOypmcEHkj4j1
+        OnO4kIzLvdZvEliLjj0fnRQsN3/Dkz8+wh1xIqqZ0CpKK7XZ3cx5dR0F11GwWsXAahUF6yoG1lV8
+        5Ao6cgUf2UBHNnAFUbCGg3WUDR1nQ0fZ0HE2tBoqRg0fGQXrOFhDedZwnlH9ctRTUCEUXAgUrOFg
+        1D9x98SQKBC1BW4K1CFwf1BRQ6i4IQwdHVjHCdNQwjRcDJRdFWdXR0NJx0PJQEc28JENVGYDl1lD
+        xdBwMXAycC5QltUcllG30HJCFB1Zw0c20Kgz8KhDB8bHVVHvVHPSFT5wzsho2Kl43OmoRfQck6Bc
+        qDgXqFvgXoEGHx57Kiqvisuro0zoOBMqmjKhdv3RT0BD+Ub8iFJScr3wZZMEuz6qj4ZVKtfUkSUb
+        lmLKpqVpsjU0TGpTu2IYFWTysGW3b5hUiJ8qFBoPzFo2V6w0vA0ZqkmUmiIbdk0DraqaPDRGumyr
+        mlXXKTFskcrXydiq2/eRUa9oOBm84S3I4JdAlE2qv1GZFRXeRHDF0ixCSVWmijKUjeGIyHUyrMqK
+        NazUKkbVGllVRLEtu32fFavVHCvyhrcgQx3VVaNqV0AXkweqrsjEqOqyZVGjqqkj06hi8b1lt28l
+        Q/zEZ6y4/QgNzFplBUG8BT2WXaekDorplSroqWpV2ST8RwFpraapRFNUw0To2bLbd6Y/Myf7ma9E
+        xTX/Edgw/c1Hn06AdLG6h5qn5+f/A4pU4I1fVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:47:50 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - add3b5af01ab4ead926cb68f48a1502f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEBZ8G0YS5/DLCl5KLTIMCZzBhLylp5Wk05MVySF0ydGhArchn
+        4WPZ8iaAJ06YMj4AKReGnlpMhsHlaOp4ZNn+A5DEBw3USs3QK6qqG3BdNgHfJpPpvFrTK6AvCW6H
+        885wRiLwqtAnzFlzqWRUbqZnwLIg9PxHYfqkLPwE6KjqplZNjDRIiLZ8SkKw4MAGj18WzSEQdBPP
+        ZiNmIRgh58sskSUct0ocib6wcg7FqTtw74biXeSAOmTIHBYymlSCjaYZDD91GHEtGp+PmBNSPw6P
+        xBE5usx4+AIhNjd46rqNIKChdNIqZPLJU6oKhYpH0WlMH+D8kyKbRB5dP9Wf5b35ifEsF5/05/m5
+        qj3vlbaGFn/KSpVeSQEDQA6qyWRo2TIdKarMK+RqrW7yKl4DUVrwIEoJeAHXtkB/56EnjhMSWjf8
+        LC4AK2Pfi6ap1llaH0W0Jw1TJxozt0zAGdkwgsRcHqK0HUZjcNfftyXuv1zj659jWq5/xnU+u+oc
+        ti+E8A8OdcfhDXhj/V2UpA8Qz5DXRz4geGIeQPTdkQDRvNk46zd6UjvuIR2lPVAebN+b2hCR0OhA
+        tHL5+c0KToWzF65ztfsOZWLRB1Ni3ZIxzVehOwdsJXjcCypaWqI8HwDOP9ywkA66EGMQlT5E/Zto
+        9eDT0UGzfXEpN5uYTtAiNew7FkBK3Notmw059kg5ddDVmuJPf8d8FWD/hj/5pCXtMXogwbmmKLqs
+        1IvvE5ZzOvK46GfH+uY4xZWnfij1ryQQgfoU8m7MgQoEqMVdiV/PR13//KK907E7RaXutrcyXxnN
+        q5ftj5fv45TWHS375B7ToL+dBv/dA+QMUk1R3lNN05xpyidFvRbuWIxD8skowf11O1yeA/fbEK4w
+        4YdpTLWUnFVlVYFb7nsxFQSDIQkorHtyPLXf60mwWKCwRogR24fv58/lJIB/QfWvlStrasKcCaBj
+        cXwVT+Ya8sWW5xNns5aXCeq7NEUVNcraOyt6Bys3z8+Ngqy2fQHd8kYFPbW/tQ/2rmbd8+bsaHY8
+        O2sV9y9OD/bOj2aXsw+zq7iiCZDm7Opi1uTnIk6+qWcxJ3TaB8clqX1wtEbrK8fG13l8OX2N/sHe
+        6awxOyvuN0Db41lndgrF6GDvbNabdYr7TV7qzprF/ZN5qZGW5lx+3zB5xMKoZyUJjo03plbfIu/c
+        6WXlj5589C2zj9D1j5+C9JfkoGWdXxpJB9B7P84oIp98TNJJkk0+xskEcsnsAk6SuHlZpx+cfvRt
+        Ofwm6ngCOYMEcjrrxinkdHZc3O9e8FpRvBJ546K43+N8NUVGOYamM5FRklIjLWUJfuWhf2iyipc4
+        H9qYAT5sO51MQvNrK5oP7dXVDCzn3mQpt9itGtg0sHw25ZtvmI431LqVzvjJK8/9X0H0OVmY4HOY
+        dJGB7YQK616WbHkPiBXvQK/r04oR+7+5sBqUGjEu2J014/ri19YG1HGYh2nTFg27vAaeSx/3/aoK
+        bxEib7pLQe4Ic7gMmG6JUo0MZkfsIvJxu3Uoi82kPMFbJCR8gvm6W047tTec1NxEw3wejkXjjlgu
+        ETjBDiiYJ2dm015CSm1AbqtG0jWQiE+lrIufeVIigMQCuM3+HjH+sFM03IqcSvGub8kFtQfDx8GE
+        OPcEXRq0U5h0+Ch15rDdMmishEuDIMIeVSzpcJaifogK4gFc8kB/XdBjaOXF/ZOu1LBtH0T9joSu
+        mlpZrdbLalkrqTVeLsNBXhQVpaQq/F+5AlNmzSgJ6egDgXkLFU+A328L/6TRbyCM8OoXZlD5U0P+
+        D5G/XMvLGXW1PifDiiuuzYFVVW7IilpR3/OxBohyiHNy+O6cHKKcHL4nJ0HIxoOA3lH+ggLOS0fq
+        Ldq3YYfdnfSvf87ReTFarPJJ/52tjz3U4tXvbv3LHx8RzB2EN8ACvcdS/IkrXd5QSO73O7Qgyb+r
+        7uqNNDO5m9CQBKISk3/euMsLqIUKeSuojB5/mNWTSA6d3hGWHDrM8r3AG4XSYeQ4NGTudnmi01t5
+        /L9SkZMZOj3TlE3TBLiiyLW6+Y4MnPf6LezuKOr/NIuuKR9gMI2GztLbaetqdzlQ6i6AfAGak2Cg
+        YcSoY68R8WQ878cFbVFAKeEvfex3Ovut1prJ+fCyw7NGUqJpcRwuSvNKQZgofe92ycZdxK7AS60l
+        0C5txY3IhDniJcZc4Y8EZGN+HUwiJ2SLLDu/ygWsfo5JKJ16Fn+6k7zmKYnNVX7LFC9PZqQ67spX
+        HzeitQy6RYeMuBvhegbe8xziwxp4E97I4I+o7flkI7ySgTd/PZHIMApo2ljNNP4KJva8jWPVsqJG
+        vfZGcD0DbpxspszMYD8wFwwWSAfSetKeG0TJdqBDGNa/4690Js1Zg/U6l11p6nvgNpM5IGujI5/S
+        w15rswdkrXQ1jNww2ozPWqnnEOuWT2s2d8laqsPfjCa3X+mRNd8FnXghlUbMoRKxrHiFLFBZqzXB
+        yOe9zaNmDXd02U2rERulDq8sSW7BBb4SIepSiLgMkN5IGJGJRwHxm+3ZUVlgldOGpYiJ+0g2DamV
+        ZC8BMpYuITbopSuXPWT35wUQDxBwv4+9XopZihMCGcf3vBCm/pxykXgEKkv0RbeZVtdR574KqC9N
+        iEvGdELFYwUBNpcjEhKjk+aJLMvpJuo8iWQZ7VLqy5eezP9LR9whejeQVtz0BXs9y2zzpNc8Txuy
+        zB4xn94Tx5lfIsvoIXi07XnziNOzLPaajVYjbchS1zpLGdWzXAEVDvirFMS2nI+ZJa4rPo+QFo+O
+        UpC5ahoiBTfUcVatYyhLXhNCNhnPU+oSe54fSsnL9XNAljH+aUa8RhFNy5y5Y+B8KccaS6ngrJMG
+        lJGl7OwkZcaorqYBdrc5wxtZLvsdkWjavc0RaGS5PfQjnjk8H+II5g0kA8uy+6/I9TbfmipLHFsM
+        /Jp/PSCdMjd62Nwza4GON+RO26JZb6hkTXDuEwsQW4ybtU5jQr7A/G+LXlmTdYnjSQ0n3HxrrGSt
+        eRyRe8o247NmPqqk3/t8hd/aGgf9zuYeWTufuBazwSbSBQ2mnhukLlzJWrnP/DDyvnzZrG5VWQqI
+        +x7/CEVq/to73dxNfX69Be2mGeG2y5w9ZfZJhel8PKdXStXn4t7nz8FPMj/srTYVf9kriYYX9spZ
+        Pn3kfyVxlMVxZSWlKMpbrP7jGuTTnlw2OxnoX2P5lLMtkvCxo1siXhROI2xXKhH7PG3/VsFD+hCW
+        vPAGbnG8+D6bGom7brPUj9X8K6/1E7KEkrkEXcatW21GOjybi6H4bOpVtiNhflXmB0zAuHrb/akn
+        tVR5XmTeRV2aqL+GyknMdaVUh+Qr15W68oKcnL6xya39Qjp8L/Qsz8EoWTRtt3tsTeEssvmRWZPp
+        a5gse6tARLygFglC6R98aUWnuAERSWO0eNAfjwDFt3svhU9IYKGJiJ+0/Gm2RgNKB8QJPFRVClNZ
+        0bRrN68Nzy83PrrM2+CD2e6I63nq8ddYOtRmEf9w+5iNuXRNGI/xzPYmDhd4TpQTK71F0y5tsmaF
+        f3S9acCwh4m9RdOOCh+5QTTlKTV+8+WOurZ4+3pVk6sFjr/70k9xP+QBXQgruVvmjssj5gfhYORF
+        Lra0Wf5g84hjYZlFcVf6U8xv5sSI3yLYjpdT8qenZd3t76Z+Oe8blmV6uj7zxLr8gvAdMGmv370o
+        vui+l37O8gO/3uHQbRYEK6r/ZdYF87jhv7LxdWJ6YS4b68nvjPL76RF7EBO3hhWyOypmcEHkj4j1
+        OnO4kIzLvdZvEliLjj0fnRQsN3/Dkz8+wh1xIqqZ0CpKK7XZ3cx5dR0F11GwWsXAahUF6yoG1lV8
+        5Ao6cgUf2UBHNnAFUbCGg3WUDR1nQ0fZ0HE2tBoqRg0fGQXrOFhDedZwnlH9ctRTUCEUXAgUrOFg
+        1D9x98SQKBC1BW4K1CFwf1BRQ6i4IQwdHVjHCdNQwjRcDJRdFWdXR0NJx0PJQEc28JENVGYDl1lD
+        xdBwMXAycC5QltUcllG30HJCFB1Zw0c20Kgz8KhDB8bHVVHvVHPSFT5wzsho2Kl43OmoRfQck6Bc
+        qDgXqFvgXoEGHx57Kiqvisuro0zoOBMqmjKhdv3RT0BD+Ub8iFJScr3wZZMEuz6qj4ZVKtfUkSUb
+        lmLKpqVpsjU0TGpTu2IYFWTysGW3b5hUiJ8qFBoPzFo2V6w0vA0ZqkmUmiIbdk0DraqaPDRGumyr
+        mlXXKTFskcrXydiq2/eRUa9oOBm84S3I4JdAlE2qv1GZFRXeRHDF0ixCSVWmijKUjeGIyHUyrMqK
+        NazUKkbVGllVRLEtu32fFavVHCvyhrcgQx3VVaNqV0AXkweqrsjEqOqyZVGjqqkj06hi8b1lt28l
+        Q/zEZ6y4/QgNzFplBUG8BT2WXaekDorplSroqWpV2ST8RwFpraapRFNUw0To2bLbd6Y/Myf7ma9E
+        xTX/Edgw/c1Hn06AdLG6h5qn5+f/A4pU4I1fVgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:48:00 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 55480bba4fb3ae86b781147e1ef0658f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEBT9yXebyqwhXSq4xDQqcwIS8pKSVp9GQF8shdcnQoQG1Ip+F
+        j2XLmwCeOGFK+ACEXNh5ajEZBpejqeORZfMPQBAfFFArNUOvqKpuwHXZBFybTKbzaq1eBXVJcDuc
+        d4YzEoFThT5hzppHJaNyKz0DlgWh5z8Kyydl4SbARlU3tWpio0HCs+VTEoIBBzY4/LJoDoGYm3g2
+        GzELwQg5X2aILOGoUeI49IWNcxhOnYH7NhTvIge0IUPmsJDRpBJMNM1g+KnDiGvR+HzEnJD6cXAk
+        bsjRZcaDF/iwub1Tx20EAQ2lk1Yhk02eUk0oVDyKTmP6AOefFNkk8uj6qf4s781PjGe5+KQ/z89V
+        7XmvtDW0+FNWqvRKiqrpkIFqMhlatkxHiirzCrlaq5u8itdAjBY8iFECTsC1LdDfeeCJ44SE1g0/
+        iwvAytj3ommqdZbWRxHrScPUicbMLRPwRTaMIC2Xhyhth9EYvPX3bYn7L9f4+ueYluufcZ3PrjqH
+        7Qsh/IND3XF4A85Yfxcl6QOEM2T1kQ8InpYHEHx3JEA0bzbO+o2e1I57SEdpD5QH2/emNgQkNDoQ
+        rFx+fquCU+Hshetc7b5DmVj0wZRYt2RM81XozgFbCR73goqWlijPB4DzDzcspIMuxBhEpQ9B/yZa
+        Pfh0dNBsX1zKzSamE7RIDfuOBZARt3bLZkOOPVJOHXS1pvjT3zFfBdi/4U8+aUl7jB5IcK4pii4r
+        9eL7hOWcjjwu+tmxvjlOceWpH0r9KwlEoD6FvBtzoAIBanFX4tfzUdc/v2jvdOxOUam77a3MV0bz
+        6mX74+X7OKV1R8s+ucc06G+nwX/3ADmDVFOU91TTNGea8klRr4U7FuOQfDJKcH/dDpfnwP02hCtM
+        92EWUy0lZ1VZVeCW+15MBcFgSAIKq54cT+33ehIsFSisEGLE9uH7+XM5CeBfUP1r5cqamjBnAuhY
+        HF/Fk7mGfKnl+cTZrOVlgvouTVFFjbL2zorewbrN83OjIKttX0C3vFFBT+1v7YO9q1n3vDk7mh3P
+        zlrF/YvTg73zo9nl7MPsKq5oAqQ5u7qYNfm5iJNv6lnMCZ32wXFJah8crdH6yrHxdR5fTl+jf7B3
+        OmvMzor7DdD2eNaZnUIxOtg7m/VmneJ+k5e6s2Zx/2ReaqSlOZffN0wesTDqWUmCY+ONqdW3yDt3
+        eln5oycffcvsI3T946cg/SU5aFnnl0bSAfTejzOKyCcfk3SSZJOPcTKBXDK7gJMkbl7W6QenH31b
+        Dr+JOp5AziCBnM66cQo5nR0X97sXvFYUr0TeuCju9zhfTZFRjqHpTGSUpNRIS1mCX3noH5qs4iXO
+        hzZmgA/bTieT0PzaiuZDe3U1A8u5N1nKLXarBjYNLJ9N+d4bpuMNtW6lM37yynP/VxB9ThYm+Bwm
+        XWRgO6HCupclG94DYsX7z+v6tGLE/m8urAalRowLdmfNuL74tbUBdRzmYdq0RcMur4Hn0sd9v6rC
+        W4TIm+5SkDvCHC4DpluiVCOD2RG7iHzcbh3KYjMpT/AWCQmfYL7ultNO7Q0nNTfRMJ+HY9G4I5ZL
+        BE6wAwrmyZnZtJeQUhuQ26qRdA0k4lMp6+JnnpQIILEAbrO/R4w/6hQNtyKnUrzrW3JB7cHwcTAh
+        zj1BlwbtFCYdPkqdOWy3DBor4dIgiLBHFUs6nKWoH6KCeACXPM5fF/QYWnlx/6QrNWzbB1G/I6Gr
+        plZWq/WyWtZKao2Xy3CQF0VFKakK/1euwJRZM0pCOvpAYN5CxQPg99vCP2n0GwgjvPqFGVT+1JD/
+        Q+Qv1/JyRl2tz8mw4oprc2BVlRuyolbU93ysAaIc4pwcvjsnhygnh+/JSRCy8SCgd5S/n4Dz0pF6
+        i/Zt2GF3J/3rn3N0XowWq3zSf2frYw+1ePW7W//yx0cEcwfhDbBA77EUf+JKlzcUkvv9Di1I8u+q
+        u3ojzUzuJjQkgajE5J837vICaqFC3goqo8cfZvUkkkOnd4Qlhw6zfC/wRqF0GDkODZm7XZ7o9FYe
+        /69U5GSGTs80ZdM0Aa4ocq1uviMD571+C7s7ivo/zaJrygcYTKOhs/Ry2rraXQ6UugsgX4DmJBho
+        GDHq2GtEPBnP+3FBWxRQSvhLH/udzn6rtWZyPrzs8KyRlGhaHIeL0rxSECZK37tdsnEXsSvwUmsJ
+        tEtbcSMyYY54hzFX+CMB2ZhfB5PICdkiy86vcgGrn2MSSqeexZ/uJG95SmJzld8yxbuTGamOu/LV
+        x41oLYNu0SEj7ka4noH3PIf4sAbehDcy+CNqez7ZCK9k4M1fTyQyjAKaNlYzjb+CiT1v41i1rKhR
+        r70RXM+AGyebKTMz2A/MBYMF0oG0nrTnBlGyHegQhvXv+CudSXPWYL3OZVea+h64zWQOyNroyKf0
+        sNfa7AFZK10NIzeMNuOzVuo5xLrl05rNXbKW6vD3osntV3pkzXdBJ15IpRFzqEQsK14hC1TWak0w
+        8nlv86hZwx1ddtNqxEapwytLkltwga9EiLoUIi4DpDcSRmTiUUD8Xnt2VBZY5bRhKWLiPpJNQ2ol
+        2UuAjKVLiA166cplD9n9eQHEAwTc72Ovl2KW4oRAxvE9L4SpP6dcJB6ByhJ90W2m1XXUua8C6ksT
+        4pIxnVDxWEGAzeWIhMTopHkiy3K6iTpPIllGu5T68qUn8//SEXeI3g2kFTd9vV7PMts86TXP04Ys
+        s0fMp/fEceaXyDJ6CB5te9484vQsi71mo9VIG7LUtc5SRvUsV0CFA/4qBbEt52NmieuKjyOkxaOj
+        FGSumoZIwQ11nFXrGMqS14SQTcbzlLrEnueHUvJu/RyQZYx/mBGvUUTTMmfuGDhfyrHGUio466QB
+        ZWQpOztJmTGqq2mA3W3O8EaWy35HJJp2b3MEGlluD/2IZw7PhziCeQPJwLLs/ityvc23psoSxxYD
+        v+YfD0inzI0eNvfMWqDjDbnTtmjWGypZE5z7xALEFuNmrdOYkC8w/9uiV9ZkXeJ4UsMJN98aK1lr
+        HkfknrLN+KyZjyrp1z5f4be2xkG/s7lH1s4nrsVssIl0QYOp5wapC1eyVu4zP4y8L182q1tVlgLi
+        vse/QZGav/ZON3dTn19vQbtpRrjtMmdPmX1SYTofz+mVUvW5uPf5c/CTzA97q03FX/ZKouGFvXKW
+        Tx/5X0kcZXFcWUkpivIWq/+4BvmyJ5fNTgb611g+5WyLJHzs6JaIF4XTCNuVSsQ+T9u/VfCQPoQl
+        L7yBWxwvvs+mRuKu2yz1YzX/ymv9hCyhZC5Bl3HrVpuRDs/mYig+m3qV7UiYX5X5ARMwrt52f+pJ
+        LVWeF5l3UZcm6q+hchJzXSnVIfnKdaWuvCAnp29scmu/kA7fCz3LczBKFk3b7R5bUziLbH5k1mT6
+        GibL3ioQES+oRYJQ+gdfWtEpbkBE0hgtHvTHI0Dx7d5L4RMSWGgi4ictf5qt0YDSAXECD1WVwlRW
+        NO3azWvD88uNjy7zNvhgtjviep56/DWWDrVZxL/bPmZjLl0TxmM8s72JwwWeE+XESm/RtEubrFnh
+        H11vGjDsYWJv0bSjwkduEE15So3ffLmjri3evl7V5GqB4+++9FPcD3lAF8JK7pa54/KI+UE4GHmR
+        iy1tlj/YPOJYWGZR3JX+FPObOTHipwi24+WU/OlpWXf7u6lfzvuGZZmers88sS6/IHwHTNrrdy+K
+        L7rvpZ+z/MCvdzh0mwXBiup/mXXBPG74j2x8nZhemMvGevI7o/x+esQexMStYYXsjooZXBD5I2K9
+        zhwuJONyr/WbBNaiY89HJwXLzd/w5I+PcEeciGomtIrSSm12N3NeXUfBdRSsVjGwWkXBuoqBdRUf
+        uYKOXMFHNtCRDVxBFKzhYB1lQ8fZ0FE2dJwNrYaKUcNHRsE6DtZQnjWcZ1S/HPUUVAgFFwIFazgY
+        9U/cPTEkCkRtgZsCdQjcH1TUECpuCENHB9ZxwjSUMA0XA2VXxdnV0VDS8VAy0JENfGQDldnAZdZQ
+        MTRcDJwMnAuUZTWHZdQttJwQRUfW8JENNOoMPOrQgfFxVdQ71Zx0hQ+cMzIadioedzpqET3HJCgX
+        Ks4F6ha4V6DBh8eeisqr4vLqKBM6zoSKpkyoXX/0E9BQvhE/opSUXC982STBro/qo2GVyjV1ZMmG
+        pZiyaWmabA0Nk9rUrhhGBZk8bNntGyYV4ocKhcYDs5bNFSsNb0OGahKlpsiGXdNAq6omD42RLtuq
+        ZtV1SgxbpPJ1Mrbq9n1k1CsaTgZveAsy+CUQZZPqb1RmRYU3EVyxNItQUpWpogxlYzgicp0Mq7Ji
+        DSu1ilG1RlYVUWzLbt9nxWo1x4q84S3IUEd11ajaFdDF5IGqKzIxqrpsWdSoaurINKpYfG/Z7VvJ
+        ED/wGStuP0IDs1ZZQRBvQY9l1ympg2J6pQp6qlpVNgn/UUBaq2kq0RTVMBF6tuz2nenPzMl+5itR
+        cc1/AjZMf/PRpxMgXazuoebp+fn/c1k1dV1WAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:48:17 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - b187c6169b92b70ff2f8a4a5ab6071a0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd/stop
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Nov 2019 15:48:17 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - ''
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 74e074899799d5dcca1e085b5a50e2fd
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEUPCmU+byywhfSi4yDQqcwYS9pKSVp9GQF8shdcnQoQG1Ip+F
+        j2XLmwCeOGHK+ACkXBh6ajEZBpejqeORZfsPQBIfNFArNUOvqKpuwHXZBHybTKbzas2sgb4kuB3O
+        O8MZicCrQp8wZ82lklG5mZ4By0BN/1GYPikLPwE6qrqpVRMjDRKiLZ+SECw4sMHjl0VzCATdxLPZ
+        iFkIRsj5MktkCcetEkeiL6ycQ3HqDty7oXgXOaAOGTKHhYwmlWCjaQbDTx1GXIvG5yPmhNSPwyNx
+        RI4uMx6+QIjNDZ66biMIaCidtAqZfPKUqkKh4lF0GtMHOP+kyCaRR9dP9Wd5b35iPMvFJ/15fq5q
+        z3ulraHFn7JSpVdSVE2HHFSTydCyZTpSVJlXyNVa3eRVvAaitOBBlBLwAq5tgf7OQ08cJyS0bvhZ
+        XABWxr4XTVOts7Q+imhPGqZONGZumYAzsmEEibk8RGk7jMbgrr9vS9x/ucbXP8e0XP+M63x21Tls
+        XwjhHxzqjsMb8Mb6uyhJHyCeIa+PfEDwxDyA6LsjAaJ5s3HWb/SkdtxDOkp7oDzYvje1ISKh0YFo
+        5fLzmxWcCmcvXOdq9x3KxKIPpsS6JWOar0J3DthK8LgXVLS0RHk+AJx/uGEhHXQhxiAqfYj6N9Hq
+        waejg2b74lJuNjGdoEVq2HcsgJS4tVs2G3LskXLqoKs1xZ/+jvkqwP4Nf/JJS9pj9ECCc01RdFmp
+        F98nLOd05HHRz471zXGKK0/9UOpfSSAC9Snk3ZgDFQhQi7sSv56Puv75RXunY3eKSt1tb2W+MppX
+        L9sfL9/HKa07WvbJPaZBfzsN/rsHyBmkmqK8p5qmOdOUT4p6LdyxGIfkk1GC++t2uDwH7rchXGHC
+        D9OYaik5q8qqArfc92IqCAZDElBY9+R4ar/Xk2CxQGGNECO2D9/Pn8tJAP+C6l8rV9bUhDkTQMfi
+        +CqezDXkiy3PJ85mLS8T1HdpiipqlLV3VvQOVm6enxsFWW37ArrljQp6an9rH+xdzbrnzdnR7Hh2
+        1iruX5we7J0fzS5nH2ZXcUUTIM3Z1cWsyc9FnHxTz2JO6LQPjktS++BojdZXjo2v8/hy+hr9g73T
+        WWN2VtxvgLbHs87sFIrRwd7ZrDfrFPebvNSdNYv7J/NSIy3Nufy+YfKIhVHPShIcG29Mrb5F3rnT
+        y8ofPfnoW2YfoesfPwXpL8lByzq/NJIOoPd+nFFEPvmYpJMkm3yMkwnkktkFnCRx87JOPzj96Nty
+        +E3U8QRyBgnkdNaNU8jp7Li4373gtaJ4JfLGRXG/x/lqioxyDE1nIqMkpUZayhL8ykP/0GQVL3E+
+        tDEDfNh2OpmE5tdWNB/aq6sZWM69yVJusVs1sGlg+WzKN98wHW+odSud8ZNXnvu/guhzsjDB5zDp
+        IgPbCRXWvSzZ8h4QK96BXtenFSP2f3NhNSg1YlywO2vG9cWvrQ2o4zAP06YtGnZ5DTyXPu77VRXe
+        IkTedJeC3BHmcBkw3RKlGhnMjthF5ON261AWm0l5grdISPgE83W3nHZqbzipuYmG+Twci8YdsVwi
+        cIIdUDBPzsymvYSU2oDcVo2kayARn0pZFz/zpEQAiQVwm/09Yvxhp2i4FTmV4l3fkgtqD4aPgwlx
+        7gm6NGinMOnwUerMYbtl0FgJlwZBhD2qWNLhLEX9EBXEA7jkgf66oMfQyov7J12pYds+iPodCV01
+        tbJarZfVslZSa7xchoO8KCpKSVX4v3IFpsyaURLS0QcC8xYqngC/3xb+SaPfQBjh1S/MoPKnhvwf
+        In+5lpcz6mp9ToYVV1ybA6uq3JAVtaK+52MNEOUQ5+Tw3Tk5RDk5fE9OgpCNBwG9o/wFBZyXjtRb
+        tG/DDrs76V//nKPzYrRY5ZP+O1sfe6jFq9/d+pc/PiKYOwhvgAV6j6X4E1e6vKGQ3O93aEGSf1fd
+        1RtpZnI3oSEJRCUm/7xxlxdQCxXyVlAZPf4wqyeRHDq9Iyw5dJjle4E3CqXDyHFoyNzt8kSnt/L4
+        f6UiJzN0eqYpm6YJcEWRa3XzHRk47/Vb2N1R1P9pFl1TPsBgGg2dpbfT1tXucqDUXQD5AjQnwUDD
+        iFHHXiPiyXjejwvaooBSwl/62O909lutNZPz4WWHZ42kRNPiOFyU5pWCMFH63u2SjbuIXYGXWkug
+        XdqKG5EJc8RLjLnCHwnIxvw6mEROyBZZdn6VC1j9HJNQOvUs/nQnec1TEpur/JYpXp7MSHXcla8+
+        bkRrGXSLDhlxN8L1DLznOcSHNfAmvJHBH1Hb88lGeCUDb/56IpFhFNC0sZpp/BVM7Hkbx6plRY16
+        7Y3gegbcONlMmZnBfmAuGCyQDqT1pD03iJLtQIcwrH/HX+lMmrMG63Uuu9LU98BtJnNA1kZHPqWH
+        vdZmD8ha6WoYuWG0GZ+1Us8h1i2f1mzukrVUh78ZTW6/0iNrvgs68UIqjZhDJWJZ8QpZoLJWa4KR
+        z3ubR80a7uiym1YjNkodXlmS3IILfCVC1KUQcRkgvZEwIhOPAuI327OjssAqpw1LERP3kWwaUivJ
+        XgJkLF1CbNBLVy57yO7PCyAeIOB+H3u9FLMUJwQyju95IUz9OeUi8QhUluiLbjOtrqPOfRVQX5oQ
+        l4zphIrHCgJsLkckJEYnzRNZltNN1HkSyTLapdSXLz2Z/5eOuEP0biCtuOkL9nqW2eZJr3meNmSZ
+        PWI+vSeOM79EltFD8Gjb8+YRp2dZ7DUbrUbakKWudZYyqme5Aioc8FcpiG05HzNLXFd8HiEtHh2l
+        IHPVNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Ukpfr54AsY/zTjHiNIpqWOXPHwPlSjjWWUsFZJw0o
+        I0vZ2UnKjFFdTQPsbnOGN7Jc9jsi0bR7myPQyHJ76Ec8c3g+xBHMG0gGlmX3X5Hrbb41VZY4thj4
+        Nf96QDplbvSwuWfWAh1vyJ22RbPeUMma4NwnFiC2GDdrncaEfIH53xa9sibrEseTGk64+dZYyVrz
+        OCL3lG3GZ818VEm/9/kKv7U1DvqdzT2ydj5xLWaDTaQLGkw9N0hduJK1cp/5YeR9+bJZ3aqyFBD3
+        Pf4RitT8tXe6uZv6/HoL2k0zwm2XOXvK7JMK0/l4Tq+Uqs/Fvc+fg59kfthbbSr+slcSDS/slbN8
+        +sj/SuIoi+PKSkpRlLdY/cc1yKc9uWx2MtC/xvIpZ1sk4WNHt0S8KJxG2K5UIvZ52v6tgof0ISx5
+        4Q3c4njxfTY1EnfdZqkfq/lXXusnZAklcwm6jFu32ox0eDYXQ/HZ1KtsR8L8qswPmIBx9bb7U09q
+        qfK8yLyLujRRfw2Vk5jrSqkOyVeuK3XlBTk5fWOTW/uFdPhe6Fmeg1GyaNpu99iawllk8yOzJtPX
+        MFn2VoGIeEEtEoTSP/jSik5xAyKSxmjxoD8eAYpv914Kn5DAQhMRP2n502yNBpQOiBN4qKoUprKi
+        adduXhueX258dJm3wQez3RHX89Tjr7F0qM0i/uH2MRtz6ZowHuOZ7U0cLvCcKCdWeoumXdpkzQr/
+        6HrTgGEPE3uLph0VPnKDaMpTavzmyx11bfH29aomVwscf/eln+J+yAO6EFZyt8wdl0fMD8LByItc
+        bGmz/MHmEcfCMovirvSnmN/MiRG/RbAdL6fkT0/LutvfTf1y3jcsy/R0feaJdfkF4Ttg0l6/e1F8
+        0X0v/ZzlB369w6HbLAhWVP/LrAvmccN/ZePrxPTCXDbWk98Z5ffTI/YgJm4NK2R3VMzggsgfEet1
+        5nAhGZd7rd8ksBYdez46KVhu/oYnf3yEO+JEVDOhVZRWarO7mfPqOgquo2C1ioHVKgrWVQysq/jI
+        FXTkCj6ygY5s4AqiYA0H6ygbOs6GjrKh42xoNVSMGj4yCtZxsIbyrOE8o/rlqKegQii4EChYw8Go
+        f+LuiSFRIGoL3BSoQ+D+oKKGUHFDGDo6sI4TpqGEabgYKLsqzq6OhpKOh5KBjmzgIxuozAYus4aK
+        oeFi4GTgXKAsqzkso26h5YQoOrKGj2ygUWfgUYcOjI+rot6p5qQrfOCckdGwU/G401GL6DkmQblQ
+        cS5Qt8C9Ag0+PPZUVF4Vl1dHmdBxJlQ0ZULt+qOfgIbyjfgRpaTkeuHLJgl2fVQfDatUrqkjSzYs
+        xZRNS9Nka2iY1KZ2xTAqyORhy27fMKkQP1UoNB6YtWyuWGl4GzJUkyg1RTbsmgZaVTV5aIx02VY1
+        q65TYtgila+TsVW37yOjXtFwMnjDW5DBL4Eom1R/ozIrKryJ4IqlWYSSqkwVZSgbwxGR62RYlRVr
+        WKlVjKo1sqqIYlt2+z4rVqs5VuQNb0GGOqqrRtWugC4mD1RdkYlR1WXLokZVU0emUcXie8tu30qG
+        +InPWHH7ERqYtcoKgngLeiy7TkkdFNMrVdBT1aqySfiPAtJaTVOJpqiGidCzZbfvTH9mTvYzX4mK
+        a/4jsGH6m48+nQDpYnUPNU/Pz/8Hj2GcyV9WAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:48:18 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - aaaec2f8b2f8ee4bd4ab47a79476380a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEUPCmU+byywhfSi4yDQqcwYS9pKSVp9GQF8shdcnQoQG1Ip+F
+        j2XLmwCeOGHK+ACkXBh6ajEZBpejqeORZfsPQBIfNFArNUOvqKpuwHXZBHybTKbzas2sgb4kuB3O
+        O8MZicCrQp8wZ82lklG5mZ4By0BN/1GYPikLPwE6qrqpVRMjDRKiLZ+SECw4sMHjl0VzCATdxLPZ
+        iFkIRsj5MktkCcetEkeiL6ycQ3HqDty7oXgXOaAOGTKHhYwmlWCjaQbDTx1GXIvG5yPmhNSPwyNx
+        RI4uMx6+QIjNDZ66biMIaCidtAqZfPKUqkKh4lF0GtMHOP+kyCaRR9dP9Wd5b35iPMvFJ/15fq5q
+        z3ulraHFn7JSpVdSVE2HHFSTydCyZTpSVJlXyNVa3eRVvAaitOBBlBLwAq5tgf7OQ08cJyS0bvhZ
+        XABWxr4XTVOts7Q+imhPGqZONGZumYAzsmEEibk8RGk7jMbgrr9vS9x/ucbXP8e0XP+M63x21Tls
+        XwjhHxzqjsMb8Mb6uyhJHyCeIa+PfEDwxDyA6LsjAaJ5s3HWb/SkdtxDOkp7oDzYvje1ISKh0YFo
+        5fLzmxWcCmcvXOdq9x3KxKIPpsS6JWOar0J3DthK8LgXVLS0RHk+AJx/uGEhHXQhxiAqfYj6N9Hq
+        waejg2b74lJuNjGdoEVq2HcsgJS4tVs2G3LskXLqoKs1xZ/+jvkqwP4Nf/JJS9pj9ECCc01RdFmp
+        F98nLOd05HHRz471zXGKK0/9UOpfSSAC9Snk3ZgDFQhQi7sSv56Puv75RXunY3eKSt1tb2W+MppX
+        L9sfL9/HKa07WvbJPaZBfzsN/rsHyBmkmqK8p5qmOdOUT4p6LdyxGIfkk1GC++t2uDwH7rchXGHC
+        D9OYaik5q8qqArfc92IqCAZDElBY9+R4ar/Xk2CxQGGNECO2D9/Pn8tJAP+C6l8rV9bUhDkTQMfi
+        +CqezDXkiy3PJ85mLS8T1HdpiipqlLV3VvQOVm6enxsFWW37ArrljQp6an9rH+xdzbrnzdnR7Hh2
+        1iruX5we7J0fzS5nH2ZXcUUTIM3Z1cWsyc9FnHxTz2JO6LQPjktS++BojdZXjo2v8/hy+hr9g73T
+        WWN2VtxvgLbHs87sFIrRwd7ZrDfrFPebvNSdNYv7J/NSIy3Nufy+YfKIhVHPShIcG29Mrb5F3rnT
+        y8ofPfnoW2YfoesfPwXpL8lByzq/NJIOoPd+nFFEPvmYpJMkm3yMkwnkktkFnCRx87JOPzj96Nty
+        +E3U8QRyBgnkdNaNU8jp7Li4373gtaJ4JfLGRXG/x/lqioxyDE1nIqMkpUZayhL8ykP/0GQVL3E+
+        tDEDfNh2OpmE5tdWNB/aq6sZWM69yVJusVs1sGlg+WzKN98wHW+odSud8ZNXnvu/guhzsjDB5zDp
+        IgPbCRXWvSzZ8h4QK96BXtenFSP2f3NhNSg1YlywO2vG9cWvrQ2o4zAP06YtGnZ5DTyXPu77VRXe
+        IkTedJeC3BHmcBkw3RKlGhnMjthF5ON261AWm0l5grdISPgE83W3nHZqbzipuYmG+Twci8YdsVwi
+        cIIdUDBPzsymvYSU2oDcVo2kayARn0pZFz/zpEQAiQVwm/09Yvxhp2i4FTmV4l3fkgtqD4aPgwlx
+        7gm6NGinMOnwUerMYbtl0FgJlwZBhD2qWNLhLEX9EBXEA7jkgf66oMfQyov7J12pYds+iPodCV01
+        tbJarZfVslZSa7xchoO8KCpKSVX4v3IFpsyaURLS0QcC8xYqngC/3xb+SaPfQBjh1S/MoPKnhvwf
+        In+5lpcz6mp9ToYVV1ybA6uq3JAVtaK+52MNEOUQ5+Tw3Tk5RDk5fE9OgpCNBwG9o/wFBZyXjtRb
+        tG/DDrs76V//nKPzYrRY5ZP+O1sfe6jFq9/d+pc/PiKYOwhvgAV6j6X4E1e6vKGQ3O93aEGSf1fd
+        1RtpZnI3oSEJRCUm/7xxlxdQCxXyVlAZPf4wqyeRHDq9Iyw5dJjle4E3CqXDyHFoyNzt8kSnt/L4
+        f6UiJzN0eqYpm6YJcEWRa3XzHRk47/Vb2N1R1P9pFl1TPsBgGg2dpbfT1tXucqDUXQD5AjQnwUDD
+        iFHHXiPiyXjejwvaooBSwl/62O909lutNZPz4WWHZ42kRNPiOFyU5pWCMFH63u2SjbuIXYGXWkug
+        XdqKG5EJc8RLjLnCHwnIxvw6mEROyBZZdn6VC1j9HJNQOvUs/nQnec1TEpur/JYpXp7MSHXcla8+
+        bkRrGXSLDhlxN8L1DLznOcSHNfAmvJHBH1Hb88lGeCUDb/56IpFhFNC0sZpp/BVM7Hkbx6plRY16
+        7Y3gegbcONlMmZnBfmAuGCyQDqT1pD03iJLtQIcwrH/HX+lMmrMG63Uuu9LU98BtJnNA1kZHPqWH
+        vdZmD8ha6WoYuWG0GZ+1Us8h1i2f1mzukrVUh78ZTW6/0iNrvgs68UIqjZhDJWJZ8QpZoLJWa4KR
+        z3ubR80a7uiym1YjNkodXlmS3IILfCVC1KUQcRkgvZEwIhOPAuI327OjssAqpw1LERP3kWwaUivJ
+        XgJkLF1CbNBLVy57yO7PCyAeIOB+H3u9FLMUJwQyju95IUz9OeUi8QhUluiLbjOtrqPOfRVQX5oQ
+        l4zphIrHCgJsLkckJEYnzRNZltNN1HkSyTLapdSXLz2Z/5eOuEP0biCtuOkL9nqW2eZJr3meNmSZ
+        PWI+vSeOM79EltFD8Gjb8+YRp2dZ7DUbrUbakKWudZYyqme5Aioc8FcpiG05HzNLXFd8HiEtHh2l
+        IHPVNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Ukpfr54AsY/zTjHiNIpqWOXPHwPlSjjWWUsFZJw0o
+        I0vZ2UnKjFFdTQPsbnOGN7Jc9jsi0bR7myPQyHJ76Ec8c3g+xBHMG0gGlmX3X5Hrbb41VZY4thj4
+        Nf96QDplbvSwuWfWAh1vyJ22RbPeUMma4NwnFiC2GDdrncaEfIH53xa9sibrEseTGk64+dZYyVrz
+        OCL3lG3GZ818VEm/9/kKv7U1DvqdzT2ydj5xLWaDTaQLGkw9N0hduJK1cp/5YeR9+bJZ3aqyFBD3
+        Pf4RitT8tXe6uZv6/HoL2k0zwm2XOXvK7JMK0/l4Tq+Uqs/Fvc+fg59kfthbbSr+slcSDS/slbN8
+        +sj/SuIoi+PKSkpRlLdY/cc1yKc9uWx2MtC/xvIpZ1sk4WNHt0S8KJxG2K5UIvZ52v6tgof0ISx5
+        4Q3c4njxfTY1EnfdZqkfq/lXXusnZAklcwm6jFu32ox0eDYXQ/HZ1KtsR8L8qswPmIBx9bb7U09q
+        qfK8yLyLujRRfw2Vk5jrSqkOyVeuK3XlBTk5fWOTW/uFdPhe6Fmeg1GyaNpu99iawllk8yOzJtPX
+        MFn2VoGIeEEtEoTSP/jSik5xAyKSxmjxoD8eAYpv914Kn5DAQhMRP2n502yNBpQOiBN4qKoUprKi
+        adduXhueX258dJm3wQez3RHX89Tjr7F0qM0i/uH2MRtz6ZowHuOZ7U0cLvCcKCdWeoumXdpkzQr/
+        6HrTgGEPE3uLph0VPnKDaMpTavzmyx11bfH29aomVwscf/eln+J+yAO6EFZyt8wdl0fMD8LByItc
+        bGmz/MHmEcfCMovirvSnmN/MiRG/RbAdL6fkT0/LutvfTf1y3jcsy/R0feaJdfkF4Ttg0l6/e1F8
+        0X0v/ZzlB369w6HbLAhWVP/LrAvmccN/ZePrxPTCXDbWk98Z5ffTI/YgJm4NK2R3VMzggsgfEet1
+        5nAhGZd7rd8ksBYdez46KVhu/oYnf3yEO+JEVDOhVZRWarO7mfPqOgquo2C1ioHVKgrWVQysq/jI
+        FXTkCj6ygY5s4AqiYA0H6ygbOs6GjrKh42xoNVSMGj4yCtZxsIbyrOE8o/rlqKegQii4EChYw8Go
+        f+LuiSFRIGoL3BSoQ+D+oKKGUHFDGDo6sI4TpqGEabgYKLsqzq6OhpKOh5KBjmzgIxuozAYus4aK
+        oeFi4GTgXKAsqzkso26h5YQoOrKGj2ygUWfgUYcOjI+rot6p5qQrfOCckdGwU/G401GL6DkmQblQ
+        cS5Qt8C9Ag0+PPZUVF4Vl1dHmdBxJlQ0ZULt+qOfgIbyjfgRpaTkeuHLJgl2fVQfDatUrqkjSzYs
+        xZRNS9Nka2iY1KZ2xTAqyORhy27fMKkQP1UoNB6YtWyuWGl4GzJUkyg1RTbsmgZaVTV5aIx02VY1
+        q65TYtgila+TsVW37yOjXtFwMnjDW5DBL4Eom1R/ozIrKryJ4IqlWYSSqkwVZSgbwxGR62RYlRVr
+        WKlVjKo1sqqIYlt2+z4rVqs5VuQNb0GGOqqrRtWugC4mD1RdkYlR1WXLokZVU0emUcXie8tu30qG
+        +InPWHH7ERqYtcoKgngLeiy7TkkdFNMrVdBT1aqySfiPAtJaTVOJpqiGidCzZbfvTH9mTvYzX4mK
+        a/4jsGH6m48+nQDpYnUPNU/Pz/8Hj2GcyV9WAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:48:18 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 88975b2b88da8d45500adca8c330fc84
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEUPCmU+byywhfSi4yDQqcwYS9pKSVp9GQF8shdcnQoQG1Ip+F
+        j2XLmwCeOGHK+ACkXBh6ajEZBpejqeORZfsPQBIfNFArNUOvqKpuwHXZBHybTKbzas2sgb4kuB3O
+        O8MZicCrQp8wZ82lklG5mZ4By0BN/1GYPikLPwE6qrqpVRMjDRKiLZ+SECw4sMHjl0VzCATdxLPZ
+        iFkIRsj5MktkCcetEkeiL6ycQ3HqDty7oXgXOaAOGTKHhYwmlWCjaQbDTx1GXIvG5yPmhNSPwyNx
+        RI4uMx6+QIjNDZ66biMIaCidtAqZfPKUqkKh4lF0GtMHOP+kyCaRR9dP9Wd5b35iPMvFJ/15fq5q
+        z3ulraHFn7JSpVdSVE2HHFSTydCyZTpSVJlXyNVa3eRVvAaitOBBlBLwAq5tgf7OQ08cJyS0bvhZ
+        XABWxr4XTVOts7Q+imhPGqZONGZumYAzsmEEibk8RGk7jMbgrr9vS9x/ucbXP8e0XP+M63x21Tls
+        XwjhHxzqjsMb8Mb6uyhJHyCeIa+PfEDwxDyA6LsjAaJ5s3HWb/SkdtxDOkp7oDzYvje1ISKh0YFo
+        5fLzmxWcCmcvXOdq9x3KxKIPpsS6JWOar0J3DthK8LgXVLS0RHk+AJx/uGEhHXQhxiAqfYj6N9Hq
+        waejg2b74lJuNjGdoEVq2HcsgJS4tVs2G3LskXLqoKs1xZ/+jvkqwP4Nf/JJS9pj9ECCc01RdFmp
+        F98nLOd05HHRz471zXGKK0/9UOpfSSAC9Snk3ZgDFQhQi7sSv56Puv75RXunY3eKSt1tb2W+MppX
+        L9sfL9/HKa07WvbJPaZBfzsN/rsHyBmkmqK8p5qmOdOUT4p6LdyxGIfkk1GC++t2uDwH7rchXGHC
+        D9OYaik5q8qqArfc92IqCAZDElBY9+R4ar/Xk2CxQGGNECO2D9/Pn8tJAP+C6l8rV9bUhDkTQMfi
+        +CqezDXkiy3PJ85mLS8T1HdpiipqlLV3VvQOVm6enxsFWW37ArrljQp6an9rH+xdzbrnzdnR7Hh2
+        1iruX5we7J0fzS5nH2ZXcUUTIM3Z1cWsyc9FnHxTz2JO6LQPjktS++BojdZXjo2v8/hy+hr9g73T
+        WWN2VtxvgLbHs87sFIrRwd7ZrDfrFPebvNSdNYv7J/NSIy3Nufy+YfKIhVHPShIcG29Mrb5F3rnT
+        y8ofPfnoW2YfoesfPwXpL8lByzq/NJIOoPd+nFFEPvmYpJMkm3yMkwnkktkFnCRx87JOPzj96Nty
+        +E3U8QRyBgnkdNaNU8jp7Li4373gtaJ4JfLGRXG/x/lqioxyDE1nIqMkpUZayhL8ykP/0GQVL3E+
+        tDEDfNh2OpmE5tdWNB/aq6sZWM69yVJusVs1sGlg+WzKN98wHW+odSud8ZNXnvu/guhzsjDB5zDp
+        IgPbCRXWvSzZ8h4QK96BXtenFSP2f3NhNSg1YlywO2vG9cWvrQ2o4zAP06YtGnZ5DTyXPu77VRXe
+        IkTedJeC3BHmcBkw3RKlGhnMjthF5ON261AWm0l5grdISPgE83W3nHZqbzipuYmG+Twci8YdsVwi
+        cIIdUDBPzsymvYSU2oDcVo2kayARn0pZFz/zpEQAiQVwm/09Yvxhp2i4FTmV4l3fkgtqD4aPgwlx
+        7gm6NGinMOnwUerMYbtl0FgJlwZBhD2qWNLhLEX9EBXEA7jkgf66oMfQyov7J12pYds+iPodCV01
+        tbJarZfVslZSa7xchoO8KCpKSVX4v3IFpsyaURLS0QcC8xYqngC/3xb+SaPfQBjh1S/MoPKnhvwf
+        In+5lpcz6mp9ToYVV1ybA6uq3JAVtaK+52MNEOUQ5+Tw3Tk5RDk5fE9OgpCNBwG9o/wFBZyXjtRb
+        tG/DDrs76V//nKPzYrRY5ZP+O1sfe6jFq9/d+pc/PiKYOwhvgAV6j6X4E1e6vKGQ3O93aEGSf1fd
+        1RtpZnI3oSEJRCUm/7xxlxdQCxXyVlAZPf4wqyeRHDq9Iyw5dJjle4E3CqXDyHFoyNzt8kSnt/L4
+        f6UiJzN0eqYpm6YJcEWRa3XzHRk47/Vb2N1R1P9pFl1TPsBgGg2dpbfT1tXucqDUXQD5AjQnwUDD
+        iFHHXiPiyXjejwvaooBSwl/62O909lutNZPz4WWHZ42kRNPiOFyU5pWCMFH63u2SjbuIXYGXWkug
+        XdqKG5EJc8RLjLnCHwnIxvw6mEROyBZZdn6VC1j9HJNQOvUs/nQnec1TEpur/JYpXp7MSHXcla8+
+        bkRrGXSLDhlxN8L1DLznOcSHNfAmvJHBH1Hb88lGeCUDb/56IpFhFNC0sZpp/BVM7Hkbx6plRY16
+        7Y3gegbcONlMmZnBfmAuGCyQDqT1pD03iJLtQIcwrH/HX+lMmrMG63Uuu9LU98BtJnNA1kZHPqWH
+        vdZmD8ha6WoYuWG0GZ+1Us8h1i2f1mzukrVUh78ZTW6/0iNrvgs68UIqjZhDJWJZ8QpZoLJWa4KR
+        z3ubR80a7uiym1YjNkodXlmS3IILfCVC1KUQcRkgvZEwIhOPAuI327OjssAqpw1LERP3kWwaUivJ
+        XgJkLF1CbNBLVy57yO7PCyAeIOB+H3u9FLMUJwQyju95IUz9OeUi8QhUluiLbjOtrqPOfRVQX5oQ
+        l4zphIrHCgJsLkckJEYnzRNZltNN1HkSyTLapdSXLz2Z/5eOuEP0biCtuOkL9nqW2eZJr3meNmSZ
+        PWI+vSeOM79EltFD8Gjb8+YRp2dZ7DUbrUbakKWudZYyqme5Aioc8FcpiG05HzNLXFd8HiEtHh2l
+        IHPVNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Ukpfr54AsY/zTjHiNIpqWOXPHwPlSjjWWUsFZJw0o
+        I0vZ2UnKjFFdTQPsbnOGN7Jc9jsi0bR7myPQyHJ76Ec8c3g+xBHMG0gGlmX3X5Hrbb41VZY4thj4
+        Nf96QDplbvSwuWfWAh1vyJ22RbPeUMma4NwnFiC2GDdrncaEfIH53xa9sibrEseTGk64+dZYyVrz
+        OCL3lG3GZ818VEm/9/kKv7U1DvqdzT2ydj5xLWaDTaQLGkw9N0hduJK1cp/5YeR9+bJZ3aqyFBD3
+        Pf4RitT8tXe6uZv6/HoL2k0zwm2XOXvK7JMK0/l4Tq+Uqs/Fvc+fg59kfthbbSr+slcSDS/slbN8
+        +sj/SuIoi+PKSkpRlLdY/cc1yKc9uWx2MtC/xvIpZ1sk4WNHt0S8KJxG2K5UIvZ52v6tgof0ISx5
+        4Q3c4njxfTY1EnfdZqkfq/lXXusnZAklcwm6jFu32ox0eDYXQ/HZ1KtsR8L8qswPmIBx9bb7U09q
+        qfK8yLyLujRRfw2Vk5jrSqkOyVeuK3XlBTk5fWOTW/uFdPhe6Fmeg1GyaNpu99iawllk8yOzJtPX
+        MFn2VoGIeEEtEoTSP/jSik5xAyKSxmjxoD8eAYpv914Kn5DAQhMRP2n502yNBpQOiBN4qKoUprKi
+        adduXhueX258dJm3wQez3RHX89Tjr7F0qM0i/uH2MRtz6ZowHuOZ7U0cLvCcKCdWeoumXdpkzQr/
+        6HrTgGEPE3uLph0VPnKDaMpTavzmyx11bfH29aomVwscf/eln+J+yAO6EFZyt8wdl0fMD8LByItc
+        bGmz/MHmEcfCMovirvSnmN/MiRG/RbAdL6fkT0/LutvfTf1y3jcsy/R0feaJdfkF4Ttg0l6/e1F8
+        0X0v/ZzlB369w6HbLAhWVP/LrAvmccN/ZePrxPTCXDbWk98Z5ffTI/YgJm4NK2R3VMzggsgfEet1
+        5nAhGZd7rd8ksBYdez46KVhu/oYnf3yEO+JEVDOhVZRWarO7mfPqOgquo2C1ioHVKgrWVQysq/jI
+        FXTkCj6ygY5s4AqiYA0H6ygbOs6GjrKh42xoNVSMGj4yCtZxsIbyrOE8o/rlqKegQii4EChYw8Go
+        f+LuiSFRIGoL3BSoQ+D+oKKGUHFDGDo6sI4TpqGEabgYKLsqzq6OhpKOh5KBjmzgIxuozAYus4aK
+        oeFi4GTgXKAsqzkso26h5YQoOrKGj2ygUWfgUYcOjI+rot6p5qQrfOCckdGwU/G401GL6DkmQblQ
+        cS5Qt8C9Ag0+PPZUVF4Vl1dHmdBxJlQ0ZULt+qOfgIbyjfgRpaTkeuHLJgl2fVQfDatUrqkjSzYs
+        xZRNS9Nka2iY1KZ2xTAqyORhy27fMKkQP1UoNB6YtWyuWGl4GzJUkyg1RTbsmgZaVTV5aIx02VY1
+        q65TYtgila+TsVW37yOjXtFwMnjDW5DBL4Eom1R/ozIrKryJ4IqlWYSSqkwVZSgbwxGR62RYlRVr
+        WKlVjKo1sqqIYlt2+z4rVqs5VuQNb0GGOqqrRtWugC4mD1RdkYlR1WXLokZVU0emUcXie8tu30qG
+        +InPWHH7ERqYtcoKgngLeiy7TkkdFNMrVdBT1aqySfiPAtJaTVOJpqiGidCzZbfvTH9mTvYzX4mK
+        a/4jsGH6m48+nQDpYnUPNU/Pz/8Hj2GcyV9WAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:48:29 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 4e5870dcaf3a6c6c94abe841e5562201
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vc+1fiSBb+V3LYPXtkhmBePOIvswg4uiPKEaV7t9vlFEmBtYaEycNHi//73qok
+        EOCGxm61mRl/iJWqryr3fveRqkrCU4G5I69w8FTw7l3qFw4KxLV9ev/PwL4te/64UCq4ZEKhPqRB
+        OAgs4g5G7CGMfMqbvEFI/DENCwcj4gS0VBh5jk39AbMLB27kOKWC5bmh7zmFg9CPoD0KoHVK/QkL
+        Aua5QeFA1eqlQmDdUDty6CCKeFe42GTqkJDKdl2pKDZRZZtoqlwz1Yqs1kxDNnTdrBmVqm1RhVTN
+        UU0d1ahSrRHbskEwarNwQBzHu6f2XDYuPOg4SBS66klNx4tsqRfXQ7ep5zDrEdoOScAs6YyG955/
+        KwDQGtwQn84V84b/o1YoNNU0tVQIyTghI0ghxHKg/OmpsKSwUkq5jlE2C0DXx0SsuC5bXnAZPk65
+        4DYdkcgJC8+llZEFlcnY6urAuYZdqxcqza/GLVZ4vi4VbrwgtLzIDYUKiaFGmlapGlUiD3VFkw1N
+        s2SzXjPhVFNrdVVVRorFqQtJGIGEUPCmU+byywhfSi4yDQqcwYS9pKSVp9GQF8shdcnQoQG1Ip+F
+        j2XLmwCeOGHK+ACkXBh6ajEZBpejqeORZfsPQBIfNFArNUOvqKpuwHXZBHybTKbzas2sgb4kuB3O
+        O8MZicCrQp8wZ82lklG5mZ4By0BN/1GYPikLPwE6qrqpVRMjDRKiLZ+SECw4sMHjl0VzCATdxLPZ
+        iFkIRsj5MktkCcetEkeiL6ycQ3HqDty7oXgXOaAOGTKHhYwmlWCjaQbDTx1GXIvG5yPmhNSPwyNx
+        RI4uMx6+QIjNDZ66biMIaCidtAqZfPKUqkKh4lF0GtMHOP+kyCaRR9dP9Wd5b35iPMvFJ/15fq5q
+        z3ulraHFn7JSpVdSVE2HHFSTydCyZTpSVJlXyNVa3eRVvAaitOBBlBLwAq5tgf7OQ08cJyS0bvhZ
+        XABWxr4XTVOts7Q+imhPGqZONGZumYAzsmEEibk8RGk7jMbgrr9vS9x/ucbXP8e0XP+M63x21Tls
+        XwjhHxzqjsMb8Mb6uyhJHyCeIa+PfEDwxDyA6LsjAaJ5s3HWb/SkdtxDOkp7oDzYvje1ISKh0YFo
+        5fLzmxWcCmcvXOdq9x3KxKIPpsS6JWOar0J3DthK8LgXVLS0RHk+AJx/uGEhHXQhxiAqfYj6N9Hq
+        waejg2b74lJuNjGdoEVq2HcsgJS4tVs2G3LskXLqoKs1xZ/+jvkqwP4Nf/JJS9pj9ECCc01RdFmp
+        F98nLOd05HHRz471zXGKK0/9UOpfSSAC9Snk3ZgDFQhQi7sSv56Puv75RXunY3eKSt1tb2W+MppX
+        L9sfL9/HKa07WvbJPaZBfzsN/rsHyBmkmqK8p5qmOdOUT4p6LdyxGIfkk1GC++t2uDwH7rchXGHC
+        D9OYaik5q8qqArfc92IqCAZDElBY9+R4ar/Xk2CxQGGNECO2D9/Pn8tJAP+C6l8rV9bUhDkTQMfi
+        +CqezDXkiy3PJ85mLS8T1HdpiipqlLV3VvQOVm6enxsFWW37ArrljQp6an9rH+xdzbrnzdnR7Hh2
+        1iruX5we7J0fzS5nH2ZXcUUTIM3Z1cWsyc9FnHxTz2JO6LQPjktS++BojdZXjo2v8/hy+hr9g73T
+        WWN2VtxvgLbHs87sFIrRwd7ZrDfrFPebvNSdNYv7J/NSIy3Nufy+YfKIhVHPShIcG29Mrb5F3rnT
+        y8ofPfnoW2YfoesfPwXpL8lByzq/NJIOoPd+nFFEPvmYpJMkm3yMkwnkktkFnCRx87JOPzj96Nty
+        +E3U8QRyBgnkdNaNU8jp7Li4373gtaJ4JfLGRXG/x/lqioxyDE1nIqMkpUZayhL8ykP/0GQVL3E+
+        tDEDfNh2OpmE5tdWNB/aq6sZWM69yVJusVs1sGlg+WzKN98wHW+odSud8ZNXnvu/guhzsjDB5zDp
+        IgPbCRXWvSzZ8h4QK96BXtenFSP2f3NhNSg1YlywO2vG9cWvrQ2o4zAP06YtGnZ5DTyXPu77VRXe
+        IkTedJeC3BHmcBkw3RKlGhnMjthF5ON261AWm0l5grdISPgE83W3nHZqbzipuYmG+Twci8YdsVwi
+        cIIdUDBPzsymvYSU2oDcVo2kayARn0pZFz/zpEQAiQVwm/09Yvxhp2i4FTmV4l3fkgtqD4aPgwlx
+        7gm6NGinMOnwUerMYbtl0FgJlwZBhD2qWNLhLEX9EBXEA7jkgf66oMfQyov7J12pYds+iPodCV01
+        tbJarZfVslZSa7xchoO8KCpKSVX4v3IFpsyaURLS0QcC8xYqngC/3xb+SaPfQBjh1S/MoPKnhvwf
+        In+5lpcz6mp9ToYVV1ybA6uq3JAVtaK+52MNEOUQ5+Tw3Tk5RDk5fE9OgpCNBwG9o/wFBZyXjtRb
+        tG/DDrs76V//nKPzYrRY5ZP+O1sfe6jFq9/d+pc/PiKYOwhvgAV6j6X4E1e6vKGQ3O93aEGSf1fd
+        1RtpZnI3oSEJRCUm/7xxlxdQCxXyVlAZPf4wqyeRHDq9Iyw5dJjle4E3CqXDyHFoyNzt8kSnt/L4
+        f6UiJzN0eqYpm6YJcEWRa3XzHRk47/Vb2N1R1P9pFl1TPsBgGg2dpbfT1tXucqDUXQD5AjQnwUDD
+        iFHHXiPiyXjejwvaooBSwl/62O909lutNZPz4WWHZ42kRNPiOFyU5pWCMFH63u2SjbuIXYGXWkug
+        XdqKG5EJc8RLjLnCHwnIxvw6mEROyBZZdn6VC1j9HJNQOvUs/nQnec1TEpur/JYpXp7MSHXcla8+
+        bkRrGXSLDhlxN8L1DLznOcSHNfAmvJHBH1Hb88lGeCUDb/56IpFhFNC0sZpp/BVM7Hkbx6plRY16
+        7Y3gegbcONlMmZnBfmAuGCyQDqT1pD03iJLtQIcwrH/HX+lMmrMG63Uuu9LU98BtJnNA1kZHPqWH
+        vdZmD8ha6WoYuWG0GZ+1Us8h1i2f1mzukrVUh78ZTW6/0iNrvgs68UIqjZhDJWJZ8QpZoLJWa4KR
+        z3ubR80a7uiym1YjNkodXlmS3IILfCVC1KUQcRkgvZEwIhOPAuI327OjssAqpw1LERP3kWwaUivJ
+        XgJkLF1CbNBLVy57yO7PCyAeIOB+H3u9FLMUJwQyju95IUz9OeUi8QhUluiLbjOtrqPOfRVQX5oQ
+        l4zphIrHCgJsLkckJEYnzRNZltNN1HkSyTLapdSXLz2Z/5eOuEP0biCtuOkL9nqW2eZJr3meNmSZ
+        PWI+vSeOM79EltFD8Gjb8+YRp2dZ7DUbrUbakKWudZYyqme5Aioc8FcpiG05HzNLXFd8HiEtHh2l
+        IHPVNEQKbqjjrFrHUJa8JoRsMp6n1CX2PD+Ukpfr54AsY/zTjHiNIpqWOXPHwPlSjjWWUsFZJw0o
+        I0vZ2UnKjFFdTQPsbnOGN7Jc9jsi0bR7myPQyHJ76Ec8c3g+xBHMG0gGlmX3X5Hrbb41VZY4thj4
+        Nf96QDplbvSwuWfWAh1vyJ22RbPeUMma4NwnFiC2GDdrncaEfIH53xa9sibrEseTGk64+dZYyVrz
+        OCL3lG3GZ818VEm/9/kKv7U1DvqdzT2ydj5xLWaDTaQLGkw9N0hduJK1cp/5YeR9+bJZ3aqyFBD3
+        Pf4RitT8tXe6uZv6/HoL2k0zwm2XOXvK7JMK0/l4Tq+Uqs/Fvc+fg59kfthbbSr+slcSDS/slbN8
+        +sj/SuIoi+PKSkpRlLdY/cc1yKc9uWx2MtC/xvIpZ1sk4WNHt0S8KJxG2K5UIvZ52v6tgof0ISx5
+        4Q3c4njxfTY1EnfdZqkfq/lXXusnZAklcwm6jFu32ox0eDYXQ/HZ1KtsR8L8qswPmIBx9bb7U09q
+        qfK8yLyLujRRfw2Vk5jrSqkOyVeuK3XlBTk5fWOTW/uFdPhe6Fmeg1GyaNpu99iawllk8yOzJtPX
+        MFn2VoGIeEEtEoTSP/jSik5xAyKSxmjxoD8eAYpv914Kn5DAQhMRP2n502yNBpQOiBN4qKoUprKi
+        adduXhueX258dJm3wQez3RHX89Tjr7F0qM0i/uH2MRtz6ZowHuOZ7U0cLvCcKCdWeoumXdpkzQr/
+        6HrTgGEPE3uLph0VPnKDaMpTavzmyx11bfH29aomVwscf/eln+J+yAO6EFZyt8wdl0fMD8LByItc
+        bGmz/MHmEcfCMovirvSnmN/MiRG/RbAdL6fkT0/LutvfTf1y3jcsy/R0feaJdfkF4Ttg0l6/e1F8
+        0X0v/ZzlB369w6HbLAhWVP/LrAvmccN/ZePrxPTCXDbWk98Z5ffTI/YgJm4NK2R3VMzggsgfEet1
+        5nAhGZd7rd8ksBYdez46KVhu/oYnf3yEO+JEVDOhVZRWarO7mfPqOgquo2C1ioHVKgrWVQysq/jI
+        FXTkCj6ygY5s4AqiYA0H6ygbOs6GjrKh42xoNVSMGj4yCtZxsIbyrOE8o/rlqKegQii4EChYw8Go
+        f+LuiSFRIGoL3BSoQ+D+oKKGUHFDGDo6sI4TpqGEabgYKLsqzq6OhpKOh5KBjmzgIxuozAYus4aK
+        oeFi4GTgXKAsqzkso26h5YQoOrKGj2ygUWfgUYcOjI+rot6p5qQrfOCckdGwU/G401GL6DkmQblQ
+        cS5Qt8C9Ag0+PPZUVF4Vl1dHmdBxJlQ0ZULt+qOfgIbyjfgRpaTkeuHLJgl2fVQfDatUrqkjSzYs
+        xZRNS9Nka2iY1KZ2xTAqyORhy27fMKkQP1UoNB6YtWyuWGl4GzJUkyg1RTbsmgZaVTV5aIx02VY1
+        q65TYtgila+TsVW37yOjXtFwMnjDW5DBL4Eom1R/ozIrKryJ4IqlWYSSqkwVZSgbwxGR62RYlRVr
+        WKlVjKo1sqqIYlt2+z4rVqs5VuQNb0GGOqqrRtWugC4mD1RdkYlR1WXLokZVU0emUcXie8tu30qG
+        +InPWHH7ERqYtcoKgngLeiy7TkkdFNMrVdBT1aqySfiPAtJaTVOJpqiGidCzZbfvTH9mTvYzX4mK
+        a/4jsGH6m48+nQDpYnUPNU/Pz/8Hj2GcyV9WAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:48:39 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 9382908493174d9566b4d21c759ab4a5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+VcaXfiOBb9Kz7MnDmhGxNvLM6XHgKkk+mQcEJC1UxVhiNsQTQxNu0lS4X893mS
+        bTDwTJGqJEV35wORpSv5vfsWS/LyVGDuyCscPBW8e5f6hYMCcW2f3v8zsG/Lnj8ulAoumVCoD2kQ
+        DgKLuIMRewgjn/ImbxASf0zDwsGIOAEtFUaeY1N/wOzCgRs5TqlgeW7oe07hIPQjaI8CaJ1Sf8KC
+        gHluUDhQtXqpEFg31I4cOogi3hVONpk6JKSyXVcqik1U2SaaKtdMtSKrNdOQDV03a0alaltUIVVz
+        VFNHNapUa8S2bBCM2iwcEMfx7qk9l40LDzoOEoWuelLT8SJb6sX10G3qOcx6hLZDEjBLOqPhveff
+        CgC0BjfEp3PFvOH/qBUKTTVNLRVCMk7ICFIIsRwof3oqLCmslFKuY5TNAtD1MRErrsuWF1yGj1Mu
+        uE1HJHLCwnNpZWRBZTK2ujpwrmHX6oVK87NxixWer0uFGy8ILS9yQ6FCYqiRplWqRpXIQ13RZEPT
+        LNms10w41NRaXVWVkWJx6kISRiAhFLzplLn8NMKXkpNMgwJnMGEvKWnlaTTkxXJIXTJ0aECtyGfh
+        Y9nyJoAnTpgyPgApF4aeWkyGweVo6nhk2f4DkMQHDdRKzdArqqobcF42Ad8mk+m8WjNroC8Jboep
+        38IBicCpQp+wuTOnDpWMyY30DFAGSvqPwvBJWXgJkFHVTa2amGiQ0Gz5lIRgv4EN/r4smEMg5Cae
+        zUbMQjBCypfZIUs3bpM4Dn1h4xyCU2fgvg3Fu8gBdciQOSxkNKkEC00zGH7oMOJaND4eMSekfhwc
+        iRtydJnx4AVCbG7u1HEbQUBD6aRVyGSTp1QVChWPotOYPsDxJ0U2iTy6fqo/y3vzA+NZLj7pz/Nj
+        VXveK20NLf6UlSo9k6JqOmSgmkyGli3TkaLKvEKu1uomr+I1EKMFD2KUgBdwbQv0dx544ndCQuuG
+        H8UFYGXse9E01TpL66OI9aRh6kRj5pYJ+CIbRpCWy0OUtsNoDN76+7bE/ZdrfP1zTMv1z7jOZ1ed
+        w/aFEP7Boe44vAFvrL+LkvQBohmy+sgHBE/LA4i+OxIgmjcbZ/1GT2rHPaSjtAfKg+17UxsiEhod
+        iFYuP49uOBTOXrjO1e47lIlFH0yJdUvGNF+F7hywleBxL6hoaYnyfAA4/nDDQjroQoxBVPoQ9W+i
+        1YNPRwfN9sWl3GxiOkGL1LDvWAApcWu3bDbk2CPl1EFXa4o//R3zVYD9G/7kk5a0x+iBBMeaouiy
+        Ui++T1jO6cjjop8d65vjFFee+qHUv5JABOpTyLsxByoQoBZ3JX49H3X984v2TsfuFJW6297KfGU0
+        r162P16+j1Nad7Tsk3tMg/52Gvx3D5AzSDVFeU81TXOmKZ8U9Vq4YzEOySejBNfX7XB5DtxvQ7jC
+        dB+mMdVSclSVVQUuue/FVBAMhiSgsOrJ8dR+ryfBUoHCCiFGbB++nz+XkwD+BdW/Vq6sqQlzJoCO
+        xe+reDLXkC+1PJ84m7W8TFDfpSmqqFHW3lnRO1i3eX5uFGS17Qvolhcq6Kn9rX2wdzXrnjdnR7Pj
+        2VmruH9xerB3fjS7nH2YXcUVTYA0Z1cXsyY/FnHyTT2LOaHTPjguSe2DozVaXzk2vs7jy+lr9A/2
+        TmeN2VlxvwHaHs86s1MoRgd7Z7PerFPcb/JSd9Ys7p/MS420NOfy+4bJIxZGPStJ8Nt4Y2r1LfLO
+        nV5W/ujJR98y+whd//gpSH9JDlrW+aWRdAC99+OMIvLJxySdJNnkY5xMIJfMLuAgiZuXdfrB6Uff
+        lsNvoo4nkDNIIKezbpxCTmfHxf3uBa8VxSuRNy6K+z3OV1NklGNoOhMZJSk10lKW4Fce+ocmq3iJ
+        86GNGeDDttPJJDS/tqL50F5dzcBy7k2WcovdqoFNA8tnU775hul4Q61b6YwfvPLc/xVEn5OFCT6H
+        SRcZ2E6osO5lyYb3gFjx/vO6Pq0Ysf+bC6tBqRHjgt1ZM64vfm1tQB2HeZg2bdGwy2vgufRx36+q
+        8BYh8qa7FOSOMIfLgOmWKNXIYHbELiIft1uHsthMyhO8RULCJ5ivu+W0U3vDSc1NNMzn4Vg07ojl
+        EoET7ICCeXJmNu0lpNQG5LZqJF0DifhUyrr4mSclAkgsgMvs7xHjtzpFw63IqRTv+pZcUHswfBxM
+        iHNP0KVBO4VJh49SZw7bLYPGSrg0CCLsVsWSDmcp6oeoIG7AJbfz1wU9hlZe3D/pSg3b9kHU70jo
+        qqmV1Wq9rJa1klrj5TL8yIuiopRUhf8rV2DKrBklIR19IDBvoeL+7/tt4Z80+g2EEV79wgwqf2rI
+        /yHyl2t5OaOu1udkWHHGtTmwqsoNWVEr6nve1gBRDnFODt+dk0OUk8P35CQI2XgQ0DvKH0/AeelI
+        vUX7Nuywu5P+9c85Oi9Gi1U+6b+z9bGbWrz63a1/+eMjgrmD8AZYoPdYij9xpcsbCsn9focWJPlX
+        1V29kGYmdxMakkBUYvLPG3d5AbVQIW8FldHjD7N6Esmh0zvCkkOHWb4XeKNQOowch4bM3S5PdHor
+        t/9XKnIyQ6dnmrJpmgBXFLlWN9+RgfNev4VdHUX9n2bRNeUDDKbR0Fl6Om1d7S4HSt0FkC9AcxIM
+        NIwYdew1Ip6M5/24oC0KKCX8oY/9Tme/1VozOR9ednjWSEo0LY7DRWleKQgTpe/dLtm4i9gVeKm1
+        BNqlrbgRmTBHPMSYK/yRgGzMr4NJ5IRskWXnZ7mA1c8xCaVTz+J3d5KHPCWxucovmeLhyYxUx135
+        6uNGtJZBt+iQEXcjXM/Ae55DfFgDb8IbGfwRtT2fbIRXMvDmrycSGUYBTRurmcZfwcSet3GsWlbU
+        qNfeCK5nwI2TzZSZGewH5oLBAulAWk/ac4Mo2Q50CMP6d/yRzqQ5a7Be57IrTX0P3GYyB2RtdORT
+        ethrbfaArJWuhpEbRpvxWSv1HGLd8mnN5i5ZS3X4c9Hk9is9sua7oBMvpNKIOVQilhWvkAUqa7Um
+        GPm8t3nUrOGOLrtpNWKj1OGVJcktOMFXIkRdChGXAdIbCSMycSsgfq49OyoLrHLasBQxcR/JpiG1
+        kuwlQMbSKcQGvXTlsofs/rwA4gEC7vex10sxS3FCIOP4nhfC1J9TLhKPQGWJvug20+o66txXAfWl
+        CXHJmE6ouK0gwOZyREJidNI8kWU53USdJ5Eso11KffnSk/l/6Yg7RO8G0oqbPl6vZ5ltnvSa52lD
+        ltkj5tN74jjzU2QZPQSPtj1vHnF6lsVes9FqpA1Z6lpnKaN6liugwgF/lYLYlvMxs8R1xcsR0uLW
+        UQoyV01DpOCGOs6qdQxlyWtCyCbjeUpdYs/zQyl5uH4OyDLGX8yI1yiiaZkzdwycL+VYYykVnHXS
+        gDKylJ2dpMwY1dU0wO42Z3gjy2W/IxJNu7c5Ao0st4d+xDOH50McwbyBZGBZdv8Vud7mS1NliWOL
+        gV/ztwekU+ZGD5t7Zi3Q8YbcaVs06w2VrAnOfWIBYotxs9ZpTMgXmP9t0Strsi5xPKnhhJsvjZWs
+        NY8jck/ZZnzWzEeV9G2fr/BbW+Og39ncI2vnE9diNthEuqDB1HOD1IUrWSv3mR9G3pcvm9WtKksB
+        cd/jL6FIzV97p5u7qc+vt6DdNCPcdpmzp8w+qTCdj+f0Sqn6XNz7/Dn4SeY/e6tNxV/2SqLhhb1y
+        lk8f+V9J/Mrid2UlpSjKW6z+4xrk1Z5cNjsZ6F9j+ZSzLZLwsaNbIl4UTiNsVyoR+zxt/1bBQ/oQ
+        lrzwBi5xvPg+mxqJu26z1I/V/Cuv9ROyhJK5BF3GrVttRjo8m4uh+GzqVbYjYX5V5j+YgHH1tvtT
+        T2qp8rzIvIu6NFF/DZWTmOtKqQ7JV64rdeUFOTl9YpNb+4V0+F7oWZ6DUbJo2m732JrCUWTzX2ZN
+        pq9hsuylAhHxglokCKV/8KUVneIGRCSN0eJGfzwCFN/uuRQ+IYGFJiJ+0vKn2RoNKB0QJ/BQVSlM
+        ZUXTrl28Nty/3HjrMm+DD2a7I67nqccfY+lQm0X8te1jNubSNWE8xjPbmzhc4DlRTqz0Fk27tMma
+        Ff7R9aYBw24m9hZNOyp85AbRlKfU+MmXO+ra4unrVU2uFjj+7Es/xf2QG3QhrORumTsuj5gfhIOR
+        F7nY0mb5hc0jjoVlFsVd6U8xv5kTI75FsB0vp+RPT8u6299N/XLeOyzL9HR95ol1+QXhO2DSXr97
+        UXzRdS99neUHvr3DodssCFZU/8usC+Zxw7+y8XViemEuG+vJ74zy6+kRexATt4YVsjsqZnBB5I+I
+        9TpzuJCMy73WbxJYi449H50ULDd/w50/PsIdcSKqmdAqSiu12d3MeXUdBddRsFrFwGoVBesqBtZV
+        fOQKOnIFH9lARzZwBVGwhoN1lA0dZ0NH2dBxNrQaKkYNHxkF6zhYQ3nWcJ5R/XLUU1AhFFwIFKzh
+        YNQ/cffEkCgQtQVuCtQhcH9QUUOouCEMHR1YxwnTUMI0XAyUXRVnV0dDScdDyUBHNvCRDVRmA5dZ
+        Q8XQcDFwMnAuUJbVHJZRt9ByQhQdWcNHNtCoM/CoQwfGx1VR71Rz0hU+cM7IaNipeNzpqEX0HJOg
+        XKg4F6hb4F6BBh8eeyoqr4rLq6NM6DgTKpoyoXb91k9AQ/lGfEQpKble+LJJgl0f1UfDKpVr6siS
+        DUsxZdPSNNkaGia1qV0xjAoyediy2zdMKsSHCoXGA7OWzRUrDW9DhmoSpabIhl3TQKuqJg+NkS7b
+        qmbVdUoMW6TydTK26vZ9ZNQrGk4Gb3gLMvgpEGWT6m9UZkWFNxFcsTSLUFKVqaIMZWM4InKdDKuy
+        Yg0rtYpRtUZWFVFsy27fZ8VqNceKvOEtyFBHddWo2hXQxeSBqisyMaq6bFnUqGrqyDSqWHxv2e1b
+        yRAf+IwVtx+hgVmrrCCIt6DHsuuU1EExvVIFPVWtKpuEfxSQ1mqaSjRFNUyEni27fWf6M3Oyn/lK
+        VFzzT8CG6TcffToB0sXqPuASu9FkYN3R+JOn/CD5IKQaH6Vwai+j2GRKLF6bwJXVkT9dPz//H+9G
+        7X24VgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:48:50 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - c3df2f16c15338be6006ee408c08f283
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+VcaXfiOBb9Kz7MnDmhGxNvLM6XHgKkk+mQcEJC1UxVhiNsQTQxNu0lS4X893mS
+        bTDwTJGqJEV35wORpSv5vfsWS/LyVGDuyCscPBW8e5f6hYMCcW2f3v8zsG/Lnj8ulAoumVCoD2kQ
+        DgKLuIMRewgjn/ImbxASf0zDwsGIOAEtFUaeY1N/wOzCgRs5TqlgeW7oe07hIPQjaI8CaJ1Sf8KC
+        gHluUDhQtXqpEFg31I4cOogi3hVONpk6JKSyXVcqik1U2SaaKtdMtSKrNdOQDV03a0alaltUIVVz
+        VFNHNapUa8S2bBCM2iwcEMfx7qk9l40LDzoOEoWuelLT8SJb6sX10G3qOcx6hLZDEjBLOqPhveff
+        CgC0BjfEp3PFvOH/qBUKTTVNLRVCMk7ICFIIsRwof3oqLCmslFKuY5TNAtD1MRErrsuWF1yGj1Mu
+        uE1HJHLCwnNpZWRBZTK2ujpwrmHX6oVK87NxixWer0uFGy8ILS9yQ6FCYqiRplWqRpXIQ13RZEPT
+        LNms10w41NRaXVWVkWJx6kISRiAhFLzplLn8NMKXkpNMgwJnMGEvKWnlaTTkxXJIXTJ0aECtyGfh
+        Y9nyJoAnTpgyPgApF4aeWkyGweVo6nhk2f4DkMQHDdRKzdArqqobcF42Ad8mk+m8WjNroC8Jboep
+        38IBicCpQp+wuTOnDpWMyY30DFAGSvqPwvBJWXgJkFHVTa2amGiQ0Gz5lIRgv4EN/r4smEMg5Cae
+        zUbMQjBCypfZIUs3bpM4Dn1h4xyCU2fgvg3Fu8gBdciQOSxkNKkEC00zGH7oMOJaND4eMSekfhwc
+        iRtydJnx4AVCbG7u1HEbQUBD6aRVyGSTp1QVChWPotOYPsDxJ0U2iTy6fqo/y3vzA+NZLj7pz/Nj
+        VXveK20NLf6UlSo9k6JqOmSgmkyGli3TkaLKvEKu1uomr+I1EKMFD2KUgBdwbQv0dx544ndCQuuG
+        H8UFYGXse9E01TpL66OI9aRh6kRj5pYJ+CIbRpCWy0OUtsNoDN76+7bE/ZdrfP1zTMv1z7jOZ1ed
+        w/aFEP7Boe44vAFvrL+LkvQBohmy+sgHBE/LA4i+OxIgmjcbZ/1GT2rHPaSjtAfKg+17UxsiEhod
+        iFYuP49uOBTOXrjO1e47lIlFH0yJdUvGNF+F7hywleBxL6hoaYnyfAA4/nDDQjroQoxBVPoQ9W+i
+        1YNPRwfN9sWl3GxiOkGL1LDvWAApcWu3bDbk2CPl1EFXa4o//R3zVYD9G/7kk5a0x+iBBMeaouiy
+        Ui++T1jO6cjjop8d65vjFFee+qHUv5JABOpTyLsxByoQoBZ3JX49H3X984v2TsfuFJW6297KfGU0
+        r162P16+j1Nad7Tsk3tMg/52Gvx3D5AzSDVFeU81TXOmKZ8U9Vq4YzEOySejBNfX7XB5DtxvQ7jC
+        dB+mMdVSclSVVQUuue/FVBAMhiSgsOrJ8dR+ryfBUoHCCiFGbB++nz+XkwD+BdW/Vq6sqQlzJoCO
+        xe+reDLXkC+1PJ84m7W8TFDfpSmqqFHW3lnRO1i3eX5uFGS17Qvolhcq6Kn9rX2wdzXrnjdnR7Pj
+        2VmruH9xerB3fjS7nH2YXcUVTYA0Z1cXsyY/FnHyTT2LOaHTPjguSe2DozVaXzk2vs7jy+lr9A/2
+        TmeN2VlxvwHaHs86s1MoRgd7Z7PerFPcb/JSd9Ys7p/MS420NOfy+4bJIxZGPStJ8Nt4Y2r1LfLO
+        nV5W/ujJR98y+whd//gpSH9JDlrW+aWRdAC99+OMIvLJxySdJNnkY5xMIJfMLuAgiZuXdfrB6Uff
+        lsNvoo4nkDNIIKezbpxCTmfHxf3uBa8VxSuRNy6K+z3OV1NklGNoOhMZJSk10lKW4Fce+ocmq3iJ
+        86GNGeDDttPJJDS/tqL50F5dzcBy7k2WcovdqoFNA8tnU775hul4Q61b6YwfvPLc/xVEn5OFCT6H
+        SRcZ2E6osO5lyYb3gFjx/vO6Pq0Ysf+bC6tBqRHjgt1ZM64vfm1tQB2HeZg2bdGwy2vgufRx36+q
+        8BYh8qa7FOSOMIfLgOmWKNXIYHbELiIft1uHsthMyhO8RULCJ5ivu+W0U3vDSc1NNMzn4Vg07ojl
+        EoET7ICCeXJmNu0lpNQG5LZqJF0DifhUyrr4mSclAkgsgMvs7xHjtzpFw63IqRTv+pZcUHswfBxM
+        iHNP0KVBO4VJh49SZw7bLYPGSrg0CCLsVsWSDmcp6oeoIG7AJbfz1wU9hlZe3D/pSg3b9kHU70jo
+        qqmV1Wq9rJa1klrj5TL8yIuiopRUhf8rV2DKrBklIR19IDBvoeL+7/tt4Z80+g2EEV79wgwqf2rI
+        /yHyl2t5OaOu1udkWHHGtTmwqsoNWVEr6nve1gBRDnFODt+dk0OUk8P35CQI2XgQ0DvKH0/AeelI
+        vUX7Nuywu5P+9c85Oi9Gi1U+6b+z9bGbWrz63a1/+eMjgrmD8AZYoPdYij9xpcsbCsn9focWJPlX
+        1V29kGYmdxMakkBUYvLPG3d5AbVQIW8FldHjD7N6Esmh0zvCkkOHWb4XeKNQOowch4bM3S5PdHor
+        t/9XKnIyQ6dnmrJpmgBXFLlWN9+RgfNev4VdHUX9n2bRNeUDDKbR0Fl6Om1d7S4HSt0FkC9AcxIM
+        NIwYdew1Ip6M5/24oC0KKCX8oY/9Tme/1VozOR9ednjWSEo0LY7DRWleKQgTpe/dLtm4i9gVeKm1
+        BNqlrbgRmTBHPMSYK/yRgGzMr4NJ5IRskWXnZ7mA1c8xCaVTz+J3d5KHPCWxucovmeLhyYxUx135
+        6uNGtJZBt+iQEXcjXM/Ae55DfFgDb8IbGfwRtT2fbIRXMvDmrycSGUYBTRurmcZfwcSet3GsWlbU
+        qNfeCK5nwI2TzZSZGewH5oLBAulAWk/ac4Mo2Q50CMP6d/yRzqQ5a7Be57IrTX0P3GYyB2RtdORT
+        ethrbfaArJWuhpEbRpvxWSv1HGLd8mnN5i5ZS3X4c9Hk9is9sua7oBMvpNKIOVQilhWvkAUqa7Um
+        GPm8t3nUrOGOLrtpNWKj1OGVJcktOMFXIkRdChGXAdIbCSMycSsgfq49OyoLrHLasBQxcR/JpiG1
+        kuwlQMbSKcQGvXTlsofs/rwA4gEC7vex10sxS3FCIOP4nhfC1J9TLhKPQGWJvug20+o66txXAfWl
+        CXHJmE6ouK0gwOZyREJidNI8kWU53USdJ5Eso11KffnSk/l/6Yg7RO8G0oqbPl6vZ5ltnvSa52lD
+        ltkj5tN74jjzU2QZPQSPtj1vHnF6lsVes9FqpA1Z6lpnKaN6liugwgF/lYLYlvMxs8R1xcsR0uLW
+        UQoyV01DpOCGOs6qdQxlyWtCyCbjeUpdYs/zQyl5uH4OyDLGX8yI1yiiaZkzdwycL+VYYykVnHXS
+        gDKylJ2dpMwY1dU0wO42Z3gjy2W/IxJNu7c5Ao0st4d+xDOH50McwbyBZGBZdv8Vud7mS1NliWOL
+        gV/ztwekU+ZGD5t7Zi3Q8YbcaVs06w2VrAnOfWIBYotxs9ZpTMgXmP9t0Strsi5xPKnhhJsvjZWs
+        NY8jck/ZZnzWzEeV9G2fr/BbW+Og39ncI2vnE9diNthEuqDB1HOD1IUrWSv3mR9G3pcvm9WtKksB
+        cd/jL6FIzV97p5u7qc+vt6DdNCPcdpmzp8w+qTCdj+f0Sqn6XNz7/Dn4SeY/e6tNxV/2SqLhhb1y
+        lk8f+V9J/Mrid2UlpSjKW6z+4xrk1Z5cNjsZ6F9j+ZSzLZLwsaNbIl4UTiNsVyoR+zxt/1bBQ/oQ
+        lrzwBi5xvPg+mxqJu26z1I/V/Cuv9ROyhJK5BF3GrVttRjo8m4uh+GzqVbYjYX5V5j+YgHH1tvtT
+        T2qp8rzIvIu6NFF/DZWTmOtKqQ7JV64rdeUFOTl9YpNb+4V0+F7oWZ6DUbJo2m732JrCUWTzX2ZN
+        pq9hsuylAhHxglokCKV/8KUVneIGRCSN0eJGfzwCFN/uuRQ+IYGFJiJ+0vKn2RoNKB0QJ/BQVSlM
+        ZUXTrl28Nty/3HjrMm+DD2a7I67nqccfY+lQm0X8te1jNubSNWE8xjPbmzhc4DlRTqz0Fk27tMma
+        Ff7R9aYBw24m9hZNOyp85AbRlKfU+MmXO+ra4unrVU2uFjj+7Es/xf2QG3QhrORumTsuj5gfhIOR
+        F7nY0mb5hc0jjoVlFsVd6U8xv5kTI75FsB0vp+RPT8u6299N/XLeOyzL9HR95ol1+QXhO2DSXr97
+        UXzRdS99neUHvr3DodssCFZU/8usC+Zxw7+y8XViemEuG+vJ74zy6+kRexATt4YVsjsqZnBB5I+I
+        9TpzuJCMy73WbxJYi449H50ULDd/w50/PsIdcSKqmdAqSiu12d3MeXUdBddRsFrFwGoVBesqBtZV
+        fOQKOnIFH9lARzZwBVGwhoN1lA0dZ0NH2dBxNrQaKkYNHxkF6zhYQ3nWcJ5R/XLUU1AhFFwIFKzh
+        YNQ/cffEkCgQtQVuCtQhcH9QUUOouCEMHR1YxwnTUMI0XAyUXRVnV0dDScdDyUBHNvCRDVRmA5dZ
+        Q8XQcDFwMnAuUJbVHJZRt9ByQhQdWcNHNtCoM/CoQwfGx1VR71Rz0hU+cM7IaNipeNzpqEX0HJOg
+        XKg4F6hb4F6BBh8eeyoqr4rLq6NM6DgTKpoyoXb91k9AQ/lGfEQpKble+LJJgl0f1UfDKpVr6siS
+        DUsxZdPSNNkaGia1qV0xjAoyediy2zdMKsSHCoXGA7OWzRUrDW9DhmoSpabIhl3TQKuqJg+NkS7b
+        qmbVdUoMW6TydTK26vZ9ZNQrGk4Gb3gLMvgpEGWT6m9UZkWFNxFcsTSLUFKVqaIMZWM4InKdDKuy
+        Yg0rtYpRtUZWFVFsy27fZ8VqNceKvOEtyFBHddWo2hXQxeSBqisyMaq6bFnUqGrqyDSqWHxv2e1b
+        yRAf+IwVtx+hgVmrrCCIt6DHsuuU1EExvVIFPVWtKpuEfxSQ1mqaSjRFNUyEni27fWf6M3Oyn/lK
+        VFzzT8CG6TcffToB0sXqPuASu9FkYN3R+JOn/CD5IKQaH6Vwai+j2GRKLF6bwJXVkT9dPz//H+9G
+        7X24VgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:49:00 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 915f5747c577546d00e117919fb3eb07
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+VceXPiSLL/Kgr2xQt7BmFdCOR/djHgsd8aN2Fsund7vEQhFVhrITE6fIzxd39Z
+        JQkKSNHYbbuZmY5oXKrMKmX+8qhL0lPJ9UdB6fCpFNz7NCwdlojvhPT+H5FzWwnCcalc8smEQn1M
+        o3gQ2cQfjNyHOAkpIwWDmIRjGpcOR8SLaLk0CjyHhgPXKR36ieeVS3bgx2HglQ7jMAF6EgF1SsOJ
+        G0Vu4EelQ1Wrl0uRfUOdxKODJGFN4WaTqUdiKjt1pao4RJUdoqlyzVKrslqzDNnQdatmVE3Hpgox
+        rVFNHdWoYtaIYzsgGHXceEA8L7inzlw2JjzoOMgUuupJTS9IHKmX1kOzaeC59iPQjkjk2tI5je+D
+        8JYzADW6ISGdKxYM/0vtmGuqaWq5FJNxBkaUsxDbg/LXp9KSwko5xzrlctwIdH3MxErrxPICy/hx
+        ygR36IgkXlx6Lq/0zKHM+lZXOy407Fo9V2l+N2ax0vN1uXQTRLEdJH7MO88MNdK0qmmYRB7qiiYb
+        mmbLVr1mwaWm1uqqqowUm0EXkzgBCaEQTKeuz27DfSm7yTQqMQQz9LKSVpkmQ1asxNQnQ49G1E5C
+        N36s2MEE+IkX54gPQMqFoae2K0PncjL1ArJs/wFIEjINqjVDr6qqbsB93Qn4NplM59WaVQN9SXQ7
+        zP0WLkgCThWHxJ07c+5QWZ/MSM/A6oKS4SM3fFbmXgJgmLqlmZmJBhnMdkhJDPYbOODvy4J5BEJu
+        EjjuyLURHi7ly+wgwo3bJI3DkLtpAcC5M6S+TaKIxrkyrDovZ5JpTs3Sa5Ymm6bmyEa9RuWhpoxk
+        qhMbpDZUR1NLacs802xl/WkYjEMaMQVURZHh/4EGf+F/5ls5A7QKKfdaRVmmxEFMvKzeTyagu30b
+        QcKKXMhhTF1O4VwFtIjeUSZTFhdPJRcyF4clq9EXPB78hbspLGwzqrJGVTdStY1UfSPVeL5+XlSm
+        ktkBpHFWSgcBKEDG5I0nkEGTCS/euOMbXrChITiil9ZyS/sOfWAqgUfcJR54NRm6HnDRSAQBnGHq
+        JWPXz7KlZRrzmszmPRreuTaVWjSGrAquXhJlVebsIzJxvUehgSM0YCLkMqlMJvCUae6p2aXnEt+m
+        6fXI9WIapqJmcjDuisuGEAhLh7ldLmGD+bl02ioJY9pTHlDgXxDxrNGY3bz0VZEtIo+un+rP8t78
+        wniW95/05/m1qj3vlbdm3f9JlCq/k6JqOoyDNZkMbUemI0WVWYVs1uoWq2I1MFKUAhgpCOQipm2J
+        /sbSP/+dkNi+YVdpAVAZh0EyzbUWrfrIR5yMkNqjQiAjusMEJgeVIQrbUTKGnPnbtsD9h2l8/XMK
+        y/XPuM7nV52j9gUX/sGj/jgG/1TrH6IkfYAxBeYWoxA42ORgAPnkjkSI5s3Geb/Rk9ppC+k4b4Hi
+        4ITB1IFxAYgejBlMfjbGwCVPuaXrQu2+Q5lU9MGU2LdkTItV6M4ZthI8bQUVLS1TnnUA159vID0O
+        uhBjEJUhjD3votVDSEeHzfbFpdxsYjoBRWo4d24EA/PWbtlsyKlHyrmDrtbs//Q/mK8C27/gn3za
+        kvZceijBNQxRuqzU9z8mLOdwFGHRF/t6dZziytMwlvpXEogAgybk3RQDGDp1dX9X4jcIUdf/dNHe
+        6didolJ321uZr4Lm1cv2l8uPcUr7jlZCco9p0N9Og//sAecMUs2+vKdaljXTlK+Kes3dcT8NySej
+        DOPrdnxFDtxvQ7jCohMm02Y5uzJhsglD7kchFUWDIYnoICry1H6vJ8GClcI6NeXYPnx//bWSBfDf
+        Uf1rleqamjBnAtYx/30TT2YasgV/EBJvs5aXGdd3aYoqalS0D1b0DqatQVgYBaK2fc665UAFLbW/
+        tQ/3rmbdT83Z8exkdt7aP7g4O9z7dDy7nH2eXaUVTWBpzq4uZk12zePkVS33C0KnfXhSltqHx2uw
+        vnFsfBvHl8PX6B/unc0as/P9gwZoezLrzM6gmBzunc96s87+QZOVurPm/sHpvNTIS3Msv6+bImCh
+        1/OyBL+Nd4ZW3yLv3OkV5Y+efPQtsw/X9Y+fgvSX5KBlnV8aSYfQ+iDNKDyffMnSSZZNvqTJBHLJ
+        7AIusrh5WaMfnH70bTF8FXQsgZxDAjmbddMUcjY72T/oXrBaXrzieeNi/6DH8GryjHICpHOeUbJS
+        Iy+JAL9x1z80WaVLnM9tzACft51OZqH5rRXN5/bqagaWc++ylFvsVg0cGtmhO822udZ0ZHuT0jm7
+        eOO5/xuIPgcLE3zOJl0IbDuhwrqXZccuA2Kn25rr+rRSjoN/+rAalBopX7Q7a8b1xa+jDajnuQGm
+        TZsTdnkNPJc+bftNFd4jRN51l4LcEddjMmC6ZUo1BJ4dsQvPx+3Wkcw3k4oEb5GYsAnm22457dTe
+        cFZzkwyLcTjhxB2xXCZwxjugYJ6CmU17iVNqA+e2amRNI4mEVBJd/DyQMgEkN4Jh9rfEZUdtnHDL
+        cyrFm74nFtQZDB8HE+LdE3Rp0M7ZpKNHqTNn2y2Dpkr4NIoS7KhiSYfznOuHqMAP4LKHStYFPclO
+        iQ9Ou1LDcfj57+sTumppFdWsV9SKVlZrrFyBH3lRVJSyqrA/lSpMmTWjzKWjDwTmLZSfQ3/cFv5p
+        o99AEGHVL8yg8teG/G8i/34tL2fU1fqCDMvvuDYHVlW5IStqVf3IYw0Q5QjH5OjDMTlCMTn6SEyi
+        2B0P5qfmKC4dqbegb4OOe3fav/65QOdFb6nKp/0Ptj52qMWqP9z6lz8+Ilx/EN8ACvQeS/GnvnR5
+        QyG53+/QgqR4VN3VgVSY3E1oTCJeick/J+7yAmqhQtEKStDjD7N64smh0zvGkkPHtcMgCkaxdJR4
+        Ho1df7s80emtHP+vVBRkhk7PsmTLsoBdUeRa3fpABD71+i1sdOT1f5pF15R1MJgmQ2/pGcl1tbuM
+        UeouGNkCtCDBAGHkUs9ZA+LJeD5IC9qigELCHvo46HQOWq01k7PuZY9ljaxE8+I4XpTmlRwwXvre
+        7ZKNu4hdzi+1lph2aSsuffRvgD5llgl/nD4duCm/DiaJF7uLLDu/ywWsfk5ILJ0FNjvdyR42lfjm
+        Khsy+SO8glQnXfnqy0ZuTeBu0aFL/I3susDeCzwSwhp4E78h8B9TJwjJRvaqwN785VQiwySiOdEU
+        iL+AiYNgY181UdSk197IXBeYG6ebIbME3s+uDwaLpENpPWnPDaKIDehQYo+Fskc6M7JosF7nsitN
+        wwDcZjJnEG10HFJ61Gtt9gDRSlfDxI+TzfyilXoesW/ZtGZzE9FSHfZ0Prn9RgvRfBd0EsRUGrke
+        lYhtpytkziVarQlG/tTb3KtouOPLbl6N2Ch3eGVJchtu8I0IUZdCxHeBMxhJ2bO9OZNoo44b2ZWc
+        sBQxyPPAnMlYugXfoJeufPdB3J/njHiAgPt96fVynqU4IZBxwiCIYerPIOeJh3OJQF90m3l1HXXu
+        q4iG0oT4ZEwnlB8rcGZrOSIhMXp5nhBRzjdR50lERLRLaShfBjL7Kx0zh+jdQFrx85c8dBHZ5mmv
+        +SkniMgeuyG9J543v4WI6BF4tBME84jTRRR7zUarkRNE6FrnOaK6iBVA4YG/SlFqy3mfInBd/oqO
+        tDg6ypmsVdMQKbqhnrdqHUNZ8poYssl4nlKX0AvCWMpe8ZgziIix14PSNQonLWPmjwHzpRxrLKWC
+        804eUIYI2flpjoxhrqYB925zhjdELPsdnmjavc0RaIjYHoUJyxxBCHEE8wYisIno/l/iB5uHpuoS
+        xrYLfs3eYZHOXD952NxStEAnGDKnbVHRG6qiCT6FxAaOLfoVrdOYkN9h/rdFK9FkXeIFUsOLNw+N
+        VdGaJwm5p+5mftHMx9X8nbNv4Ftbw6Df2dxCtPOpb7sO2ES6oNE08KPchauilftuGCfB779vVtdU
+        lgLivsdehZKav/TONjdTn99uQbtpRrjtMmdPmX1VYTqfzumVsvm8v/frr9FPMvvZWyXt/32vzAkv
+        bFWwfPrC/pX5r8x/V1ZSiqK8x+o/e6Vm/QWzQjQ7AutfY/lUsC2S4bGjWyJBEk8TbFcqE/tTTn+t
+        4DF9iMtBfANDHCt+zKZG5q7bLPVTNf/Ka/0MLK5kIUCXKXWrzUiPZXPeFZtNvcl2JMyvKuwHEzCt
+        3nZ/6kktV58XmXdRlyfqb3EVJOa6Uq5D8pXrSl15QU7On9hk1n4hHGEQB3bgYZAsSNvtHttTuEoc
+        9uvak+lbmEwcKhARL6hNolj6X7a0olPcgIikKTc/6E97gOL7PZfCJiSw0ETEzyh/mq3RiNIB8aIA
+        VZXCVJaTdm3w2nB+ufHosmiDD2a7I6bnWcAeY+mk7zWXSyfsreZyqZm/0/wuDhcFXlIQK70FaZc2
+        WUXhH/1gGrnYYWJvQdpR4RM/SqYspaZPvtxR3+FPX69qcrXgY8++9HO+H3JAF8NK7tb1x5WRG0bx
+        YBQkPra0WX5h85jxwjKL4q70p5jfzIHhX8TYDpcz8qeHZd3t76ZhpegdlmV4uqEb8HX5BWE7YNJe
+        v3ux/6JxL3+d5Qe+vcM/+LDFgmBF9b/MumAeN+xbL98GphcXorGe/M4pG0+P3Qc+cWvYsXtH+Qwu
+        SsIRsd9mDheTcaXX+qcE1qLjIEQnBcvkV5z8sR7uiJdQzQIqL63UiruZ8+o6ylxHmVUTY1ZNlFlX
+        MWZdxXuuoj1X8Z4NtGcDVxBl1nBmHUVDx9HQUTR0HA2thopRw3tGmXWcWUNx1nCcUf0K1FNQIRRc
+        CJRZw5lR/8TdE+NEGVFb4KZAHQL3BxU1hIobwtDRjnUcMA0FTMPFQNFVcXR1NJR0PJQMtGcD79lA
+        ZTZwmTVUDA0XAwcDxwJFWS1AGXULrSBE0Z41vGcDjToDjzq0Y7xfFfVOtSBd4R0X9IyGnYrHnY5a
+        RC8wCYqFimOBugXuFWjw4bGnovKquLw6ioSOI6GiKRNq149+IhrLN/wjSlnJD+KXTRKc+qg+GppU
+        rqkjWzZsxZItW9Nke2hY1KFO1TCqyORhy2avmFTwz2VyjQdWTcwVK4T3AUO1iFJTZMOpaaCVqclD
+        Y6TLjqrZdZ0Sw+GpfB2MrZp9Hxj1qoaDwQjvAQa7BaJsVv1KZVZUeBfBFVuzCSWmTBVlKBvDEZHr
+        ZGjKij2s1qqGaY9sE1Fsy2bfZ0XTLLAiI7wHGOqorhqmUwVdLBaouiITw9Rl26aGqakjyzCx+N6y
+        2WvB4J+ZTRV3HoHg2quoIBzvAY/t1Cmpg2J61QQ9Vc2ULcI+CkhrNU0lmqIaFgLPls2+M/1ZBdnP
+        eiMortmHiGOafeQxpOzblXx1HzGJ/WQysO9o+uFddpF9EFJNr3J26ixzuZMpsVltxq6s9vz1+vn5
+        /wGv285IPlkAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:49:11 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - dac43f126f0856cc6a2ba7b5fb46e2c1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8s0eATHIbGCokzOzNZClhC+KLsVk/8piQ734t
+        2QYBMiGZJMPuTtUQWWpJ3b9+6Gk/FBxv5BcOHgr+rUeCwkEBe3ZAbv8d2tdlPxgXSgUPTwjkRySM
+        BqGFvcHIuYvigNAifxDhYEyiwsEIuyEpFUa+a5Ng4NiFAy923VLB8r0o8N3CQRTEUB6HUDolwcQJ
+        Q8f3wsIBUmulQmhdETt2ySCOaVXobDJ1cURku6ZUFBsj2cYqkqsmqsioauqyrmlmVa8YtkUUbJij
+        KhpViWJUsW3ZwBixnWiAXde/JfacN8o8yDhIBbroSQ3Xj22pl+RDtanvOtY9lB3i0LGkDolu/eCa
+        EUBpeIUDMhfMH/6PWBGTVFVRqRDhcQpGmJFgy4X0l4fCksBKKcM6obKdEGS9T9lK8vj0AsvofkoZ
+        t8kIx25UeCyttMygTNtGqw3nKnYtn4k0741qrPB4WSpc+WFk+bEXscZTRY1UtWLoBpaHmqLKuqpa
+        slmrmvCoomoNIWWkWBS6CEcxcAgJfzp1PNoNs6W0k2lYoAim6KUptTyNhzRZjoiHhy4JiRUHTnRf
+        tvwJ0GM3yhAfAJcLRU8tR4bG5Xjq+nhZ/wPgJKASVKq6VkFI06FfZwK2jSfTebZqVkFeHF4PM7uF
+        BxyDUUUBdubGnBlU2iZV0iOQOiBkcM8Un6aZlQAYhmaqRqqiQQqzFRAcgf4GNtj7MmMuBpeb+LYz
+        ciwBDePyeXrg4RbrJPHDgJlpDsCZMSS2jcOQRJkwNDtLp5ypdtXUqqYqG4Zqy3qtSuShqoxkomEL
+        uNaRraJCUjOLNFtpfxr444CEVACkKDL831fhL/xPbSsjgFoBYVarKMslkR9hN8334gnIbl2HELBC
+        B2IYFZeVMKqcspDcEMpT6hcPBQciF4MlzTEWNC78hd4U6rZpqbJWijaWqhtLtY2l+uPl4yIz4czy
+        IYzTVDIIQAIiJqs8gQgaT1jyyhlfsYQFFcEQ3SSXadqzyR0VCSziJnbBqvHQcYGKhDwIEC6mbjx2
+        vNQPVGTOc1Kdd0AdcSj1futI4TwcL5hV5vQjPHFcGqK7fhBltNScaf8ZQzyKy52rqmnoq533SHDj
+        WERqkghCOvjZU31nFWyuAt+/mt9/RVWV1f7PG939k650nsUhwCGeTkE+Yj/FyQdCQXdX+tdy+9c1
+        hNBq/8fn512pTaIr3w6lejJqSnswtEi2E4CAEMGKTzHyiQwlCsu6MnRqHeCz0yxmpI+ugz2LJM8j
+        x41oTWo0KVOUuuxQACBA2jQAZOzWacSRTpoFbnbxkIU28HSIvbTSmHZe+KLIJpZHlw+1R3lv/qA/
+        ysUH7XH+jNTHvdLWpMWfeK6ynhSkajAjqcp4aNkyGSlIphmyUa2ZNIvmwJhd8AFYDJhSaQvkDzoQ
+        s98Jjqwr+pQkAJVx4MfTTGrev+7Z2J8WJJooYxibnGEM07TyUAjbYTyG0euPbYH7nUp8+XMCy+XP
+        Ypk7F+3D1hlj/s4l3jiCSIFq7yIkuYPRHWZ5owAo6DRtALHgBocCyRv1Tr/ek1pJDekoqyHEwQ78
+        qQ0jNBS6MHpT/uloD49s8Ctc5kr3HcIkrA+m2LrGY5IvQndOsBXjSS3IaKqp8LQBeP50BQPVoAs+
+        Bl4ZwCzgTaS6C8jooNE6O5cbDZFMUCLV7RsnhACztVk26nJikXJmoKs5xZ/+KbJVIPsN/sknTWnP
+        IQcSPMNkQZOVWvF93HIORx4Wfb6tF/upWHgCo2X/QgIWYPoCcTfBACYxGiruiv/6gdD0P561dtp3
+        p0Kuu62t1FcWxtXz1ufz9zFK64aUA3wrkqC/nQS/7wHlDEJNUd5DpmnOVOWLgi6ZORYTl3zQSzC+
+        bkeXZ8D9FrgrLP9hWWOU0icDpv0w5L4XUmE4GOKQDMI8S+33etIhUEi9lGJ79/36tZw68C9C+avl
+        ypqYMGcC0jH7fRVLphLSrRcfppSbpTxPqb5LUqGgell9Z0Fv2BQ31wt4afuMdMuBCmqq/2gd7F3M
+        uh8bs6PZ8azTLO6fnR7sfTyanc8+zS6SjAaQNGYXZ7MGfWZ+8qKaxRzXaR0cl6TWwdEarK/sG0/j
+        +Hz46v2DvdNZfdYp7tdB2uNZe3YKyfhgrzPrzdrF/QZNdWeN4v7JPFXPUnMsv6+ZPGCh1U5Jgt/6
+        G0OrbRF3brSy8mcPPtqW0YfJ+ucPQdpzYtCyzM/1pAOovZ9EFBZPPqfhJI0mn5NgArFkdgYPqd88
+        r9IPDj/athi+CDoaQDoQQE5n3SSEnM6Oi/vdM5rLkhcsbpwV93sUrwaLKMdQ1GERJU3VsxQP8Cs3
+        /UODVbLE+dQSKeDTttPJ1DWfWtF8aq2uZmA59yZLucVu1cAmoRU403TPb01GukssdejDK8/9X4H1
+        OVgixudk0hlHthMirFtZegA2wFayx7kuTzOh2P/Vg9WgVE/owt1ZM64vfm11QFzX8UXStFjBLq+B
+        59wndZ8U4S1c5E13KfANdlzKg0i2VKg6R7MjemHxuNU8lNlmUh7jTRxhOsF83S2nndobTnOu4mE+
+        DsescEc0lzKc0g4IqCdnZtNaopRaQLmtGGnVUMIBkXgT7/hSyoDkhDDM/hE7ATuMgoJrFlOJuOpb
+        YkHswfB+MMHuLRYuDVoZmXR4L7XnZLul0EQIjx13PiVDJ6P6ISKwA7j0es86o8fpeT09uKzbNjuJ
+        f3lAR6ZaRkatjMpqCVVpugw/8iKpKCWk0D/lCkyZVb3EuCN3GOYthN0IeL8t/JN6vy5AhGY/M4LK
+        X+ryf7H87VJejqir+TkRlvW4NgdGSK7LCqqg9zzWAFYOxZgcvjsmh0JMDt8TkzByxoP5ebkQl7bU
+        W5Rvg45zc9K//DlH5kVricgn/XfWvuhQi2a/u/bPf7xHON4gugIUyK0oxJ940vkVgeB+u0MLkvxR
+        dVcHUm5yNyERDlmmiP954S4voBYi5K2gODn+NKsnFhzavSNRcGg7VuCH/iiSDmPXJZHjbRcn2r2V
+        4/+VjJzI0O6ZpmyaJpArilytme+IwMdevykaHVn+X2bRNaUNDKbx0F26rboudpcSSt0FIV2A5gQY
+        KBg5xLXXgHjQH/eThLpICCGhlz722+39ZnNN5bR52aVRI02RLDmOFql5JgOMpb53u2TjLmKX0UvN
+        JaJd2opLLv0NhLfMUuaPknuBm+LrYBK7kbOIsvNezmD1c4wj6dS36OlOeu1XYpurdMhkl0g5ro67
+        8sXnjdQqR90kQwd7G8k1jrznuziANfAmep2jPyK2H+CN5BWOvPHhRMLDOCRZocEVfgAV+/7Gtqo8
+        q3GvtZG4xhHXTzZDZnK0nxwPFBZKB9J60J4rROErLF0GTS798oy2z7vSNPDBbCZzAl5HRwEhh73m
+        ZgvgtXQxjL0o3kzPa6nnYuuaTms2V+E11abvSeDrJ2rw6jsjEz8i0shxiYQtK1khMypeaw1Q8sfe
+        5lZ5xR2dd7NsgY4yg1eWOLeggyc8BC25iOcApT+S0ovOGRGvo7YTWuWsYMljBJejGZG+1AXboJcu
+        POeO359P7kgLHQTM73Ovl9Es+QmGiBP4fgRTfwo5CzyMigf6rNvIsmtC474ISSBNsIfHZELYsQIj
+        Npc9Mr1uzeIEj3K2iToPIjyiXUIC+dyX6V/piBpE7wrCipe9bqPxyDZOeo2PWQGP7JETkFvsuvMu
+        eEQPwaJt3597nMaj2GvUm/WsgIeu2ckQ1XisAAoX7FUKE13O2+SB67KXpaTF0VFGZK6qBkvhFXHd
+        Ve3oypLVRBBNxvOQuoTeylV/RsAjRl/UStYoyR33Jcy8MWC+FGP1pVDQaWcOpfOQdU4yZHRjNQw4
+        N5sjvM5j2W+zQNPqbfZAncf2MIhp5PAD8COYN2COjEf3P7Hnbx6aKksYWw7YNX2bSDp1vPhuc01e
+        A21/SI22SXhrqPAq+BhgCyi2aJfXTn2Cv8H8b4tavMq62PWluhttHhorvDaPY3xLnM30vJqPKtnb
+        f0/gW13DoN/eXIPX84lnOTboRDoj4dT3wsyEK7yW+04Qxf63b5vFNZQlh7jt0ZfSpMaH3unmaujx
+        9Ra0m2aE2y5z9pTZFwTT+WROr5SMx+Le16/hTzL92VstKv6yV2IFz6yVs3z6TP+V2K/MfldWUoqi
+        vMXqP32ZZv1Vv1w02xzp32P5lLMtkuKxo1sifhxNY9GuVMr2x6z8pYxH5C4q+dEVDHE0+T6bGqm5
+        brPUT8T8O6/1U7CYkLkAnSelW21GujSas6bobOpVtiNhflWmPyIGk+xt96ceUKnyuIi8i7wsUD9F
+        lROYa0qpBsFXrik15RkxObuxSbX9TDgCP/It3xVBsijabvfYmsJTbNNfx5pMX0Nl/FAhYPGMWDiM
+        pH/RpRWZihUo4DShZgf9SQuQfLt7KXRCAgtNAftpyV9mazQkZIDd0BeKSmAqy4p2bfDacH658egy
+        b4MPZrsjKuepT6+xtJM3zEuFY/p+eanQyN4ufxODC303zvGV3qJolzZZeebvPX8aOqLDxN6iaEeZ
+        j70we5md3ny5IZ7Nbl+vSnKxoKN3X/oZ3Q85oItgJXfteOPyyAnCaDDyY0+0tFl+YfOI0sIyi4hN
+        6S8xv5kDw75Nsh0up/gvD8u62d9Mg3LeOyzL8HQDx2fr8jNMd8CkvX73rPiscS97neUHvr3DPviw
+        xYJgRfS/zbpg7jf0qztPA9OLctFYD34dQsfTI+eOTdzqVuTcEDaDC+NghK3XmcNFeFzuNX+VQFtk
+        7AfCScFy8QtO/mgLN9iNiWpCKUut5PK7mfPsmpC4JiRGhogYGUJiDYmINSRuuSJsuSJuWRe2rIsF
+        FBKrYmJNiIYmRkMToqGJ0VCrQjaq4paFxJqYWBXirIpxFsqXI54iZEIRMyEkVsXEQvsUm6eIUkgo
+        1IVYFUKDENsDEioCiRWha8KGNTFgqhAwVcyGEF0kRlcTupImdiVd2LIublkX8qyLeVaFbKhiNsRg
+        iLEQooxyUBaahZrjosKWVXHLutDrdLHXCRsWt4uE1olywpW44ZyWhW6HxH6nCTWi5ahEiAUSYyE0
+        C7FVCJ1P7HtIyC8S86sJkdDESCBhyITc9aOfkETyFfuIUpry/Oh5kwS7NqqNhgaRq2hkybqlmLJp
+        qapsDXWT2MSu6HpFMHnYstoLJhXsw6VM4oFZ5WPFSsHbgIFMrFQVWberKkhlqPJQH2myjVSrphGs
+        2yyUr4OxVbXvA6NWUcVg0IK3AIN2IRA2zX6hMCsivAnjiqVamGBDJooylPXhCMs1PDRkxRpWqhXd
+        sEaWIRBsy2rfp0XDyNEiLXgLMNCohnTDroAsJnVUTZGxbmiyZRHdUNHI1A2Rf29Z7aVgsA/+JoLb
+        91DgWKuoCCjeAh7LrhFcA8G0igFyItWQTUw/CkiqVRVhVUG6KYBny2rfGf7MnOhnvhIUl/ST0BFJ
+        P/IYEPoVUba6DynHXjwZWDck+QQyfUg/CImSp4yc2MtUzmSKLZqbkiurLX+5fHz8P9fdrDvIWgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:49:21 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 61a9af48c43db75219a3acb1a725908c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8s0eATHIbGCokzOzNZClhC+KLsVk/8piQ734t
+        2QYBMiGZJMPuTtUQWWpJ3b9+6Gk/FBxv5BcOHgr+rUeCwkEBe3ZAbv8d2tdlPxgXSgUPTwjkRySM
+        BqGFvcHIuYvigNAifxDhYEyiwsEIuyEpFUa+a5Ng4NiFAy923VLB8r0o8N3CQRTEUB6HUDolwcQJ
+        Q8f3wsIBUmulQmhdETt2ySCOaVXobDJ1cURku6ZUFBsj2cYqkqsmqsioauqyrmlmVa8YtkUUbJij
+        KhpViWJUsW3ZwBixnWiAXde/JfacN8o8yDhIBbroSQ3Xj22pl+RDtanvOtY9lB3i0LGkDolu/eCa
+        EUBpeIUDMhfMH/6PWBGTVFVRqRDhcQpGmJFgy4X0l4fCksBKKcM6obKdEGS9T9lK8vj0AsvofkoZ
+        t8kIx25UeCyttMygTNtGqw3nKnYtn4k0741qrPB4WSpc+WFk+bEXscZTRY1UtWLoBpaHmqLKuqpa
+        slmrmvCoomoNIWWkWBS6CEcxcAgJfzp1PNoNs6W0k2lYoAim6KUptTyNhzRZjoiHhy4JiRUHTnRf
+        tvwJ0GM3yhAfAJcLRU8tR4bG5Xjq+nhZ/wPgJKASVKq6VkFI06FfZwK2jSfTebZqVkFeHF4PM7uF
+        BxyDUUUBdubGnBlU2iZV0iOQOiBkcM8Un6aZlQAYhmaqRqqiQQqzFRAcgf4GNtj7MmMuBpeb+LYz
+        ciwBDePyeXrg4RbrJPHDgJlpDsCZMSS2jcOQRJkwNDtLp5ypdtXUqqYqG4Zqy3qtSuShqoxkomEL
+        uNaRraJCUjOLNFtpfxr444CEVACkKDL831fhL/xPbSsjgFoBYVarKMslkR9hN8334gnIbl2HELBC
+        B2IYFZeVMKqcspDcEMpT6hcPBQciF4MlzakuaFz4C70p1G3TUmWtFG0sVTeWahtL9cfLx0Vmwpnl
+        QxinqWQQgARETFZ5AhE0nrDklTO+YgkLKoIhukku07RnkzsqEljETeyCVeOh4wIVCXkQwBimbjx2
+        vNQPVGTOc1Kdd0AdcSj1futI4TwcL5hV5vQjPHFcGqK7fhBltNScaf8ZQzyKy52rqmnoq533SHDj
+        WERqkghCOvjZU31nFWyuAt8/rye03H9FVZXV/s8b3f2TrnSexSHAIZ5OQT5iP8XJB0JBd1f613L7
+        1zWE0Gr/x+fnXalNoivfDqV6MmpKezC0SLYTgIAQwYpPMfKJDCUKy7oydGod4LPTLGakj66DPYsk
+        zyPHjWhNajQpU5S67FAAIEDaNABk7NZpxJFOmgVudvGQhTbwdIi9tNKYdl74osgmlkeXD7VHeW/+
+        oD/KxQftcf6M1Me90takxZ94rrKeFKRqMCOpynho2TIZKUimGbJRrZk0i+bAmF3wAVgMmFJpC+QP
+        OhCz3wmOrCv6lCQAlXHgx9NMat6/7tnYnxYkmihjGJucYQzTtPJQCNthPIbR649tgfudSnz5cwLL
+        5c9imTsX7cPWGWP+ziXeOIJIgWrvIiS5g9EdZnmjACjoNG0AseAGhwLJG/VOv96TWkkN6SirIcTB
+        DvypDSM0FLowelP+6WgPj2zwK1zmSvcdwiSsD6bYusZjki9Cd06wFeNJLchoqqnwtAF4/nQFA9Wg
+        Cz4GXhnALOBNpLoLyOig0To7lxsNkUxQItXtGyeEALO1WTbqcmKRcmagqznFn/4pslUg+w3+ySdN
+        ac8hBxI8w2RBk5Va8X3ccg5HHhZ9vq0X+6lYeAKjZf9CAhZg+gJxN8EAJjEaKu6K//qB0PQ/nrV2
+        2nenQq67ra3UVxbG1fPW5/P3MUrrhpQDfCuSoL+dBL/vAeUMQk1R3kOmac5U5YuCLpk5FhOXfNBL
+        ML5uR5dnwP0WuCss/2FZY5TSJwOm/TDkvhdSYTgY4pAMwjxL7fd60iFQSL2UYnv3/fq1nDrwL0L5
+        q+XKmpgwZwLSMft9FUumEtKtFx+mlJulPE+pvktSoaB6WX1nQW/YFDfXC3hp+4x0y4EKaqr/aB3s
+        Xcy6Hxuzo9nxrNMs7p+dHux9PJqdzz7NLpKMBpA0ZhdnswZ9Zn7yoprFHNdpHRyXpNbB0Rqsr+wb
+        T+P4fPjq/YO901l91inu10Ha41l7dgrJ+GCvM+vN2sX9Bk11Z43i/sk8Vc9Scyy/r5k8YKHVTkmC
+        3/obQ6ttEXdutLLyZw8+2pbRh8n65w9B2nNi0LLMz/WkA6i9n0QUFk8+p+EkjSafk2ACsWR2Bg+p
+        3zyv0g8OP9q2GL4IOhpAOhBATmfdJISczo6L+90zmsuSFyxunBX3exSvBosox1DUYRElTdWzFA/w
+        Kzf9Q4NVssT51BIp4NO208nUNZ9a0Xxqra5mYDn3Jku5xW7VwCahFTjTdM9vTUa6Syx16MMrz/1f
+        gfU5WCLG52TSGUe2EyKsW1l6ADbAVrLHuS5PM6HY/9WD1aBUT+jC3Vkzri9+bXVAXNfxRdK0WMEu
+        r4Hn3Cd1nxThLVzkTXcp8A12XMqDSLZUqDpHsyN6YfG41TyU2WZSHuNNHGE6wXzdLaed2htOc67i
+        YT4Ox6xwRzSXMpzSDgioJ2dm01qilFpAua0YadVQwgGReBPv+FLKgOSEMMz+ETsBO4yCgmsWU4m4
+        6ltiQezB8H4wwe4tFi4NWhmZdHgvtedku6XQRAiPHXc+JUMno/ohIrADuPR6zzqjx+l5PT24rNs2
+        O4l/eUBHplpGRq2MymoJVWm6DD/yIqkoJaTQP+UKTJlVvcS4I3cY5i2E3Qh4vy38k3q/LkCEZj8z
+        gspf6vJ/sfztUl6OqKv5ORGW9bg2B0ZIrssKqqD3PNYAVg7FmBy+OyaHQkwO3xOTMHLGg/l5uRCX
+        ttRblG+DjnNz0r/8OUfmRWuJyCf9d9a+6FCLZr+79s9/vEc43iC6AhTIrSjEn3jS+RWB4H67QwuS
+        /FF1VwdSbnI3IREOWaaI/3nhLi+gFiLkraA4Of40qycWHNq9I1FwaDtW4If+KJIOY9clkeNtFyfa
+        vZXj/5WMnMjQ7pmmbJomkCuKXK2Z74jAx16/KRodWf5fZtE1pQ0MpvHQXbqtui52lxJK3QUhXYDm
+        BBgoGDnEtdeAeNAf95OEukgIIaGXPvbb7f1mc03ltHnZpVEjTZEsOY4WqXkmA4ylvne7ZOMuYpfR
+        S80lol3aiksu/Q2Et8xS5o+Se4Gb4utgEruRs4iy817OYPVzjCPp1Lfo6U567Vdim6t0yGSXSDmu
+        jrvyxeeN1CpH3SRDB3sbyTWOvOe7OIA18CZ6naM/IrYf4I3kFY688eFEwsM4JFmhwRV+ABX7/sa2
+        qjyrca+1kbjGEddPNkNmcrSfHA8UFkoH0nrQnitE4SssXQZNLv3yjLbPu9I08MFsJnMCXkdHASGH
+        veZmC+C1dDGMvSjeTM9rqedi65pOazZX4TXVpu9J4OsnavDqOyMTPyLSyHGJhC0rWSEzKl5rDVDy
+        x97mVnnFHZ13s2yBjjKDV5Y4t6CDJzwELbmI5wClP5LSi84ZEa+jthNa5axgyWMEl6MZkb7UBdug
+        ly48547fn0/uSAsdBMzvc6+X0Sz5CYaIE/h+BFN/CjkLPIyKB/qs28iya0LjvghJIE2wh8dkQtix
+        AiM2lz0yvW7N4gSPcraJOg8iPKJdQgL53JfpX+mIGkTvCsKKl71uo/HINk56jY9ZAY/skROQW+y6
+        8y54RA/Bom3fn3ucxqPYa9Sb9ayAh67ZyRDVeKwAChfsVQoTXc7b5IHrspelpMXRUUZkrqoGS+EV
+        cd1V7ejKktVEEE3G85C6hN7KVX9GwCNGX9RK1ijJHfclzLwxYL4UY/WlUNBpZw6l85B1TjJkdGM1
+        DDg3myO8zmPZb7NA0+pt9kCdx/YwiGnk8APwI5g3YI6MR/c/sedvHpoqSxhbDtg1fZtIOnW8+G5z
+        TV4DbX9IjbZJeGuo8Cr4GGALKLZol9dOfYK/wfxvi1q8yrrY9aW6G20eGiu8No9jfEuczfS8mo8q
+        2dt/T+BbXcOg395cg9fziWc5NuhEOiPh1PfCzIQrvJb7ThDF/rdvm8U1lCWHuO3Rl9Kkxofe6eZq
+        6PH1FrSbZoTbLnP2lNkXBNP5ZE6vlIzH4t7Xr+FPMv3ZWy0q/rJXYgXPrJWzfPpM/5XYr8x+V1ZS
+        iqK8xeo/fZlm/VW/XDTbHOnfY/mUsy2S4rGjWyJ+HE1j0a5UyvbHrPyljEfkLir50RUMcTT5Ppsa
+        qblus9RPxPw7r/VTsJiQuQCdJ6VbbUa6NJqzpuhs6lW2I2F+VaY/IgaT7G33px5QqfK4iLyLvCxQ
+        P0WVE5hrSqkGwVeuKTXlGTE5u7FJtf1MOAI/8i3fFUGyKNpu99iawlNs01/HmkxfQ2X8UCFg8YxY
+        OIykf9GlFZmKFSjgNKFmB/1JC5B8u3spdEICC00B+2nJX2ZrNCRkgN3QF4pKYCrLinZt8Npwfrnx
+        6DJvgw9muyMq56lPr7G0kzfMS4Vj+n55qdDI3i5/E4MLfTfO8ZXeomiXNll55u89fxo6osPE3qJo
+        R5mPvTB7mZ3efLkhns1uX69KcrGgo3df+hndDzmgi2Ald+144/LICcJoMPJjT7S0WX5h84jSwjKL
+        iE3pLzG/mQPDvk2yHS6n+C8Py7rZ30yDct47LMvwdAPHZ+vyM0x3wKS9fves+KxxL3ud5Qe+vcM+
+        +LDFgmBF9L/NumDuN/SrO08D04ty0VgPfh1Cx9Mj545N3OpW5NwQNoML42CErdeZw0V4XO41f5VA
+        W2TsB8JJwXLxC07+aAs32I2JakIpS63k8ruZ8+yakLgmJEaGiBgZQmINiYg1JG65Imy5Im5ZF7as
+        iwUUEqtiYk2IhiZGQxOioYnRUKtCNqriloXEmphYFeKsinEWypcjniJkQhEzISRWxcRC+xSbp4hS
+        SCjUhVgVQoMQ2wMSKgKJFaFrwoY1MWCqEDBVzIYQXSRGVxO6kiZ2JV3Ysi5uWRfyrIt5VoVsqGI2
+        xGCIsRCijHJQFpqFmuOiwpZVccu60Ot0sdcJGxa3i4TWiXLClbjhnJaFbofEfqcJNaLlqESIBRJj
+        ITQLsVUInU/se0jILxLzqwmR0MRIIGHIhNz1o5+QRPIV+4hSmvL86HmTBLs2qo2GBpGraGTJuqWY
+        smmpqmwNdZPYxK7oekUwediy2gsmFezDpUzigVnlY8VKwduAgUysVBVZt6sqSGWo8lAfabKNVKum
+        EazbLJSvg7FVte8Do1ZRxWDQgrcAg3YhEDbNfqEwKyK8CeOKpVqYYEMmijKU9eEIyzU8NGTFGlaq
+        Fd2wRpYhEGzLat+nRcPI0SIteAsw0KiGdMOugCwmdVRNkbFuaLJlEd1Q0cjUDZF/b1ntpWCwD/4m
+        gtv3UOBYq6gIKN4CHsuuEVwDwbSKAXIi1ZBNTD8KSKpVFWFVQbopgGfLat8Z/syc6Ge+EhSX9JPQ
+        EUk/8hgQ+hVRtroPKcdePBlYNyT5BDJ9SD8IiZKnjJzYy1TOZIotmpuSK6stf7l8fPw/Ua4Ch8ha
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:49:32 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 4363765ae140b6f17693112db168b620
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8s0eAbHIbGDYkzOzNZClhC+KLsVk/8piQ734t
+        2QYBMiGZJMPuTtUQWWrJ3b9+qCXLfig43sgvHDwU/FuPBIWDAvbsgNz+O7Svy34wLpQKHp4QqI9I
+        GA1CC3uDkXMXxQGhTf4gwsGYRIWDEXZDUiqMfNcmwcCxCwde7LqlguV7UeC7hYMoiKE9DqF1SoKJ
+        E4aO74WFA6TWSoXQuiJ27JJBHNOucLPJ1MURke2aUlFsjGQbq0iumqgio6qpy7qmmVW9YtgWUbBh
+        jqpoVCWKUcW2ZQNjxHaiAXZd/5bYc94o8yDjIBXooic1XD+2pV5SD92mvutY99B2iEPHkjokuvWD
+        a0YAreEVDshcMH/4P2JFTFJVRaVChMcpGGFGgi0Xyp8fCksCK6UM64TKdkKQ9T5lK6njywsso/sp
+        ZdwmIxy7UeGxtDIygzIdG60OnKvYtXom0vxuVGOFx8tS4coPI8uPvYgNnipqpKoVQzewPNQUVdZV
+        1ZLNWtWESxVVawgpI8Wi0EU4ioFDKPjTqePR2zBbSm8yDQsUwRS9tKSWp/GQFssR8fDQJSGx4sCJ
+        7suWPwF67EYZ4gPgcqHoqeXIMLgcT10fL+t/AJwEVIJKVdcqCGk63NeZgG3jyXRerZpVkBeH18PM
+        buECx2BUUYCduTFnBpWOSZX0CKQOCBncM8WnZWYlAIahmaqRqmiQwmwFBEegv4EN9r7MmIvB5Sa+
+        7YwcS0DDuHyeHni4xTpJ/DBgZpoDcGYMiW3jMCRRJgytzsopZ6pdNbWqqcqGodqyXqsSeagqI5lo
+        2AKudWSrqJD0zCLNVtqfBv44ICEVACmKDP/3VfgL/1PbygigV0CY1SrKckvkR9hN6714ArJb1yEE
+        rNCBGEbFZS2MKqctJDeE8pT6xUPBgcjFYElragsaF/7C3RTqtmmrstaKNraqG1u1ja364+XjojLh
+        zPIhjNNSMglAASIm6zyBCBpPWPHKGV+xggUdwRDdpJZp2rPJHRUJLOImdsGq8dBxgYqEPAhgDFM3
+        Hjte6gcqMuc1qc47oI44lHq/daRwHo4XzCpz+hGeOC4N0V0/iDJaas70/hlDPIrLN1dV09BXb94j
+        wY1jEalJIgjp4GdP3TvrYHMd+PvzekLLwisIrd3/pNHuSudZFJLOyB8xFOHvxI+AK0x/nNBy/TCZ
+        djfy9jOhanBXONLyOVKVirbK0TFoVzqCeHYv/RpjFwIQsaWmP8GOJ3WARNo7+rXZKQKLoe/G20Am
+        ZkvPZUutqKqyytZ5o7t/wkEFBhNPp2AIxH7Z/Su599c1hNAaLOfnXalNoivfDqV6kl5IezAHS7YT
+        gCVAqC8+xchHMpSo/axbrUHdCILbNAuu6aXrYM8iyfXIcSPak3pXyhSlLjsUAJhJbBopM3brNDRL
+        J80Cl4Y9ZHMAhESYpGinMb154bMim1geXT7UHuW9+YX+KBcftMf5NVIf90pbkxZ/4LnK7qQgVYPU
+        rSrjoWXLZKQgmVbIRrVm0ipaA8lNwQdgMWBKpS2QP2jGwn4nOLKu6FVSAFTGgR9PM6n5QHTPkqS0
+        IdFEGcMk7gxjyGfLQyFsh/EYpvk/tgXudyrx5Y8JLJc/imXuXLQPW2eM+TuXeOMIQiqqvYuQ5A7S
+        IEiHRwFQ0Hx2AEHzBocCyRv1Tr/ek1pJD+ko6yHEwQ78qQ2pDDS6kOZQ/mlaBJcsSyhc5kr3DcIk
+        rA+m2LrGY5IvQndOsBXjSS+oaKqp8HQAuP54BTP6oAs+Bl4ZQLr0JlLdBWR00GidncuNhkgmaJHq
+        9o0TQoDZ2iwbdTmxSDkz0NWa4g//FNkqkP0G/+STprTnkAMJriGr0mSlVnwft5zDkYdFnx/rxX4q
+        Fp5AWtG/kIAFyPMg7iYYQLanoeKu+K8fCE3/w1lrp313KuS629pKfWVhXD1vfTp/H6O0bkg5wLci
+        CfrbSfD7HlDOINQU5T1kmuZMVT4r6JKZYzFxyQe9BPPrdnR5BtxvgbuiCl3/GaX0yoD1EUy574VU
+        GA6GOCSDMM9S+72edAgUUi+l2N59v3wppw78k1D+armyJibkTEA6Zr+vYslUQrpH5UNKuVnK85Tq
+        myQVCqqX1XcW9IaluLlewEvbZ6RbTlTQU/1H62DvYtb90JgdzY5nnWZx/+z0YO/D0ex89nF2kVQ0
+        gKQxuzibNeg185MX9SzmuE7r4LgktQ6O1mB9Zd94Gsfnw1fvH+ydzuqzTnG/DtIez9qzUyjGB3ud
+        WW/WLu43aKk7axT3T+alelaaY/ltw+QBC6N2ShL81t8YWm2LuHOjlZU/e/DRtow+TNY/fwjSnhOD
+        lmV+ricdQO/9JKKwePIpDSdpNPmUBBOIJbMzuEj95nmdvnP40bbF8EXQ0QDSgQByOusmIeR0dlzc
+        757RWla8YHHjrLjfo3g1WEQ5hqYOiyhpqZ6VeIBfeejvGqySJc7HlkgBH7dNJ1PXfGpF87G1upqB
+        5dybLOUWu1UDm4RW4EzTrcE1Gel2OttJfO3c/xVYn4MlYnxOJp1xZDshwrqVpU8KB9hK9jjX5Wkm
+        FPu/eLAalOoJXbg7a8b1xa+tDojrOr5ImhZr2OU18Jz7pO+TIryFi7zpLgW+wY5LeRDJlgpV52h2
+        RC8sHreahzLbTMpjvIkjTBPM191y2qm94bTmKh7m43DMGndEcynDKe2AgHpyMpvWEqXUAsptxUi7
+        hhIOiMSbeMeXUgYkJ4Rp9o/YCdjDKGi4ZjGViLu+JRbEHgzvBxPs3mLh0qCVkUmH91J7TrZbCk2E
+        8Nhz4adk6GRU30UE9gAuPQe1zuhxerCBPris2zY7svDygI5MtYyMWhmV1RKq0nIZfuRFUVFKSKF/
+        yhVImVW9xLgjdxjyFsKOTrzfFv5JvV8XIEKrnxlB5c91+b9Y/nopL0fU1fqcCMvuuJYDIyTXZQVV
+        0Hs+1gBWDsWYHL47JodCTA7fE5MwcsaD+fNyIS5tqbdo3wYd5+akf/ljjsyL0RKRT/rvrH3RQy1a
+        /e7aP//+HuF4g+gKUCC3ohB/4knnVwSC++0OLUjyZ9VdnUi55G5CIhyyShH/88ZdXkAtRMhbQXFy
+        /GlWTyw4tHtHouDQdqzAD/1RJB3Grksix9suTrR7K4//VypyIkO7Z5qyaZpArihytWa+IwIfev2m
+        aHZk9X+ZRdeUDjCYxkN36VjvuthdSih1F4TsLKDYF6Fh5BDXXgPiQX/cTwrqoiCEhB762G+395vN
+        NZXT4WWXRo20RLLiOFqU5pUMMFb61u2SjbuIXUYvNZeIdmkrLjn0NxCeMkuZP0rOBW6Kr4NJ7EbO
+        IsrO73IGq59jHEmnvkWf7qTnoyW2uUqnTHa8k+PquCtffNpIrXLUTTJ0sLeRXOPIe76LA1gDb6LX
+        OfojYvsB3khe4cgbP59IeBiHJGs0uMafQcW+v3GsKs9q3GttJK5xxPWTzZCZHO1HxwOFhdKBtB60
+        5wpR+A5Lh0GT09E8o+3zrjQNfDCbyZyA19FRQMhhr7nZAngtXQxjL4o30/Na6rnYuqZpzeYuvKba
+        9IUSfP1ED1596UHnkeMSCVtWskJmVLzWGqDkD73No/KKOzrvZtUCHWUGryxxbsENnvAQtOQingOU
+        /khKT4RnRLyO2k5olbOGJY8RnCJnRPrSLdgGvXThOXf8/nxyRlroIGB+n3q9jGbJT+j57cD3I0j9
+        KeQs8DAqHuizbiOrrgmN+yIkgTTBHh6TCWGPFRixueyR6XFrFid4lLNN1HkQ4RHtEhLI575M/0pH
+        1CB6VxBWvOy9JI1HtnHSa3zIGnhkj5yA3GLXnd+CR/QQLNr2/bnHaTyKvUa9Wc8aeOianQxRjccK
+        oHDBXqUw0eV8TB64LnurTFo8OsqIzFXVYCm8Iq67qh1dWbKaCKLJeB5Sl9BbeSeCEfCI0TfakjVK
+        csZ9CTNvDJgvxVh9KRR02plD6TxknZMMGd1YDQPOzeYIr/NY9tss0LR6mz1Q57E9DGIaOfwA/Ajy
+        BsyR8ej+J/b8zVNTZQljywG7pq9dSaeOF99t7slroO0PqdE2CW8NFV4FHwJsAcUW4/LaqU/wV8j/
+        tujFq6yLXV+qu9HmqbHCa/M4xrfE2UzPq/mokr0m+QS+1TUM+u3NPXg9n3iWY4NO6BsnU98LMxOu
+        8FruO0EU+1+/bhbXUJYc4rZH396TGj/3Tjd3Q4+vt6DdlBFuu8zZU2afEaTzSU6vlIzH4t6XL+EP
+        Mv3ZW20q/rRXYg3P7JWzfPpE/5XYr8x+V1ZSiqK8xeo/fZlm/Z3IXDTbHOnfY/mUsy2S4rGjWyJ+
+        HE1j0a5UyvaHrP2ljEfkLir50RVMcbT4Ppsaqblus9RPxPw7r/VTsJiQuQCdJ61bbUa6NJqzoWg2
+        9SrbkZBflemPiMGketv9qQdUqjwuIu+iLgvUT1HlBOaaUqpB8JVrSk15RkzOTmxSbT8TjsCPfMt3
+        RZAsmrbbPbamcBXb9NexJtPXUBk/VQhYPCMWDiPpX3RpRaZiBQo4TajZg/5kBCi+3bkUmpDAQlPA
+        ftryl9kaDQkZYDf0haISSGVZ065NXhueX258dJm3wQfZ7ojKeerTYyzt5FX8UuGYvohfKjSy1/Df
+        xOC497nXZFk07dImK8/8vedPQ0f0MLG3aNpR5mMvzF5mpydfbohns9PXq5JcLOjo2Zd+RvddHtBF
+        sJK7drxxeeQEYTQY+bEnWtosv7B5RGlhmUXEpvSXyG/mwLCPuGyHyyn+y8OybvY306Cc9w7LMjzd
+        wPHZuvwM0x0waa/fPSs+a97LXmf5jm/vsA8+bLEgWBH9b7MumPsN/TzR08D0olw01oNfh9D59Mi5
+        Y4lb3YqcG8IyuDAORth6nRwuwuNyr/mLBNoiYz8QJgXLzS948kdHuMFuTFQTWllppZbfzZxX14TE
+        NSExMkTEyBASa0hErCHxyBXhyBXxyLpwZF0soJBYFRNrQjQ0MRqaEA1NjIZaFbJRFY8sJNbExKoQ
+        Z1WMs1C+HPEUIROKmAkhsSomFtqn2DxFlEJCoS7EqhAahNgekFARSKwIXRMOrIkBU4WAqWI2hOgi
+        Mbqa0JU0sSvpwpF18ci6kGddzLMqZEMVsyEGQ4yFEGWUg7LQLNQcFxWOrIpH1oVep4u9TjiweFwk
+        tE6UE67EA+eMLHQ7JPY7TagRLUclQiyQGAuhWYitQuh8Yt9DQn6RmF9NiIQmRgIJQybUrj/6CUkk
+        X7GPKKUlz4+elyTYtVFtNDSIXEUjS9YtxZRNS1Vla6ibxCZ2RdcrguRhy24vSCrYF16ZxAOzyseK
+        lYa3AQOZWKkqsm5XVZDKUOWhPtJkG6lWTSNYt1koXwdjq27fBkatoorBoA1vAQa9hUDYtPqFwqyI
+        8CaMK5ZqYYINmSjKUNaHIyzX8NCQFWtYqVZ0wxpZhkCwLbt9mxYNI0eLtOEtwECjGtINuwKymNRR
+        NUXGuqHJlkV0Q0UjUzdE/r1lt5eCwb6MnAhu30ODY62iIqB4C3gsu0ZwDQTTKgbIiVRDNjH9KCCp
+        VlWEVQXppgCeLbt9Y/gzc6Kf+UpQXNJvZ0ck/chjQOjnVtnqPqQce/FkYN2Q5FvR9CL9ICRKrjJy
+        Yi9TOZMptmhtSq6sjvz58vHx/1+kJ0jxWwAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:49:43 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - add4d06ae2861dd1f0cb2dae92d3c1a8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8s0eAbHIbGDYkzOzNZClhC+KLsVk/8piQ734t
+        2QYBMiGZJMPuTtUQWWrJ3b9+qCXLfig43sgvHDwU/FuPBIWDAvbsgNz+O7Svy34wLpQKHp4QqI9I
+        GA1CC3uDkXMXxQGhTf4gwsGYRIWDEXZDUiqMfNcmwcCxCwde7LqlguV7UeC7hYMoiKE9DqF1SoKJ
+        E4aO74WFA6TWSoXQuiJ27JJBHNOucLPJ1MURke2aUlFsjGQbq0iumqgio6qpy7qmmVW9YtgWUbBh
+        jqpoVCWKUcW2ZQNjxHaiAXZd/5bYc94o8yDjIBXooic1XD+2pV5SD92mvutY99B2iEPHkjokuvWD
+        a0YAreEVDshcMH/4P2JFTFJVRaVChMcpGGFGgi0Xyp8fCksCK6UM64TKdkKQ9T5lK6njywsso/sp
+        ZdwmIxy7UeGxtDIygzIdG60OnKvYtXom0vxuVGOFx8tS4coPI8uPvYgNnipqpKoVQzewPNQUVdZV
+        1ZLNWtWESxVVawgpI8Wi0EU4ioFDKPjTqePR2zBbSm8yDQsUwRS9tKSWp/GQFssR8fDQJSGx4sCJ
+        7suWPwF67EYZ4gPgcqHoqeXIMLgcT10fL+t/AJwEVIJKVdcqCGk63NeZgG3jyXRerZpVkBeH18PM
+        buECx2BUUYCduTFnBpWOSZX0CKQOCBncM8WnZWYlAIahmaqRqmiQwmwFBEegv4EN9r7MmIvB5Sa+
+        7YwcS0DDuHyeHni4xTpJ/DBgZpoDcGYMiW3jMCRRJgytzsopZ6pdNbWqqcqGodqyXqsSeagqI5lo
+        2AKudWSrqJD0zCLNVtqfBv44ICEVACmKDP/3VfgL/1PbygigV0CY1SrKckvkR9hN6714ArJb1yEE
+        rNCBGEbFZS2MKqctJDeE8pT6xUPBgcjFYElragsaF/7C3RTqtmmrstaKNraqG1u1ja364+XjojLh
+        zPIhjNNSMglAASIm6zyBCBpPWPHKGV+xggUdwRDdpJZp2rPJHRUJLOImdsGq8dBxgYqEPAhgDFM3
+        Hjte6gcqMuc1qc47oI44lHq/daRwHo4XzCpz+hGeOC4N0V0/iDJaas70/hlDPIrLN1dV09BXb94j
+        wY1jEalJIgjp4GdP3TvrYHMd+PvzekLLwisIrd3/pNHuSudZFJLOyB8xFOHvxI+AK0x/nNBy/TCZ
+        djfy9jOhanBXONLyOVKVirbK0TFoVzqCeHYv/RpjFwIQsaWmP8GOJ3WARNo7+rXZKQKLoe/G20Am
+        ZkvPZUutqKqyytZ5o7t/wkEFBhNPp2AIxH7Z/Su599c1hNAaLOfnXalNoivfDqV6kl5IezAHS7YT
+        gCVAqC8+xchHMpSo/axbrUHdCILbNAuu6aXrYM8iyfXIcSPak3pXyhSlLjsUAJhJbBopM3brNDRL
+        J80Cl4Y9ZHMAhESYpGinMb154bMim1geXT7UHuW9+YX+KBcftMf5NVIf90pbkxZ/4LnK7qQgVYPU
+        rSrjoWXLZKQgmVbIRrVm0ipaA8lNwQdgMWBKpS2QP2jGwn4nOLKu6FVSAFTGgR9PM6n5QHTPkqS0
+        IdFEGcMk7gxjyGfLQyFsh/EYpvk/tgXudyrx5Y8JLJc/imXuXLQPW2eM+TuXeOMIQiqqvYuQ5A7S
+        IEiHRwFQ0Hx2AEHzBocCyRv1Tr/ek1pJD+ko6yHEwQ78qQ2pDDS6kOZQ/mlaBJcsSyhc5kr3DcIk
+        rA+m2LrGY5IvQndOsBXjSS+oaKqp8HQAuP54BTP6oAs+Bl4ZQLr0JlLdBWR00GidncuNhkgmaJHq
+        9o0TQoDZ2iwbdTmxSDkz0NWa4g//FNkqkP0G/+STprTnkAMJriGr0mSlVnwft5zDkYdFnx/rxX4q
+        Fp5AWtG/kIAFyPMg7iYYQLanoeKu+K8fCE3/w1lrp313KuS629pKfWVhXD1vfTp/H6O0bkg5wLci
+        CfrbSfD7HlDOINQU5T1kmuZMVT4r6JKZYzFxyQe9BPPrdnR5BtxvgbuiCl3/GaX0yoD1EUy574VU
+        GA6GOCSDMM9S+72edAgUUi+l2N59v3wppw78k1D+armyJibkTEA6Zr+vYslUQrpH5UNKuVnK85Tq
+        myQVCqqX1XcW9IaluLlewEvbZ6RbTlTQU/1H62DvYtb90JgdzY5nnWZx/+z0YO/D0ex89nF2kVQ0
+        gKQxuzibNeg185MX9SzmuE7r4LgktQ6O1mB9Zd94Gsfnw1fvH+ydzuqzTnG/DtIez9qzUyjGB3ud
+        WW/WLu43aKk7axT3T+alelaaY/ltw+QBC6N2ShL81t8YWm2LuHOjlZU/e/DRtow+TNY/fwjSnhOD
+        lmV+ricdQO/9JKKwePIpDSdpNPmUBBOIJbMzuEj95nmdvnP40bbF8EXQ0QDSgQByOusmIeR0dlzc
+        757RWla8YHHjrLjfo3g1WEQ5hqYOiyhpqZ6VeIBfeejvGqySJc7HlkgBH7dNJ1PXfGpF87G1upqB
+        5dybLOUWu1UDm4RW4EzTrcE1Gel2OttJfO3c/xVYn4MlYnxOJp1xZDshwrqVpU8KB9hK9jjX5Wkm
+        FPu/eLAalOoJXbg7a8b1xa+tDojrOr5ImhZr2OU18Jz7pO+TIryFi7zpLgW+wY5LeRDJlgpV52h2
+        RC8sHreahzLbTMpjvIkjTBPM191y2qm94bTmKh7m43DMGndEcynDKe2AgHpyMpvWEqXUAsptxUi7
+        hhIOiMSbeMeXUgYkJ4Rp9o/YCdjDKGi4ZjGViLu+JRbEHgzvBxPs3mLh0qCVkUmH91J7TrZbCk2E
+        8Nhz4adk6GRU30UE9gAuPQe1zuhxerCBPris2zY7svDygI5MtYyMWhmV1RKq0nIZfuRFUVFKSKF/
+        yhVImVW9xLgjdxjyFsKOTrzfFv5JvV8XIEKrnxlB5c91+b9Y/nopL0fU1fqcCMvuuJYDIyTXZQVV
+        0Hs+1gBWDsWYHL47JodCTA7fE5MwcsaD+fNyIS5tqbdo3wYd5+akf/ljjsyL0RKRT/rvrH3RQy1a
+        /e7aP//+HuF4g+gKUCC3ohB/4knnVwSC++0OLUjyZ9VdnUi55G5CIhyyShH/88ZdXkAtRMhbQXFy
+        /GlWTyw4tHtHouDQdqzAD/1RJB3Grksix9suTrR7K4//VypyIkO7Z5qyaZpArihytWa+IwIfev2m
+        aHZk9X+ZRdeUDjCYxkN36VjvuthdSih1F4TsLKDYF6Fh5BDXXgPiQX/cTwrqoiCEhB762G+395vN
+        NZXT4WWXRo20RLLiOFqU5pUMMFb61u2SjbuIXUYvNZeIdmkrLjn0NxCeMkuZP0rOBW6Kr4NJ7EbO
+        IsrO73IGq59jHEmnvkWf7qTnoyW2uUqnTHa8k+PquCtffNpIrXLUTTJ0sLeRXOPIe76LA1gDb6LX
+        OfojYvsB3khe4cgbP59IeBiHJGs0uMafQcW+v3GsKs9q3GttJK5xxPWTzZCZHO1HxwOFhdKBtB60
+        5wpR+A5Lh0GT09E8o+3zrjQNfDCbyZyA19FRQMhhr7nZAngtXQxjL4o30/Na6rnYuqZpzeYuvKba
+        9IUSfP1ED1596UHnkeMSCVtWskJmVLzWGqDkD73No/KKOzrvZtUCHWUGryxxbsENnvAQtOQingOU
+        /khKT4RnRLyO2k5olbOGJY8RnCJnRPrSLdgGvXThOXf8/nxyRlroIGB+n3q9jGbJT+j57cD3I0j9
+        KeQs8DAqHuizbiOrrgmN+yIkgTTBHh6TCWGPFRixueyR6XFrFid4lLNN1HkQ4RHtEhLI575M/0pH
+        1CB6VxBWvOy9JI1HtnHSa3zIGnhkj5yA3GLXnd+CR/QQLNr2/bnHaTyKvUa9Wc8aeOianQxRjccK
+        oHDBXqUw0eV8TB64LnurTFo8OsqIzFXVYCm8Iq67qh1dWbKaCKLJeB5Sl9BbeSeCEfCI0TfakjVK
+        csZ9CTNvDJgvxVh9KRR02plD6TxknZMMGd1YDQPOzeYIr/NY9tss0LR6mz1Q57E9DGIaOfwA/Ajy
+        BsyR8ej+J/b8zVNTZQljywG7pq9dSaeOF99t7slroO0PqdE2CW8NFV4FHwJsAcUW4/LaqU/wV8j/
+        tujFq6yLXV+qu9HmqbHCa/M4xrfE2UzPq/mokr0m+QS+1TUM+u3NPXg9n3iWY4NO6BsnU98LMxOu
+        8FruO0EU+1+/bhbXUJYc4rZH396TGj/3Tjd3Q4+vt6DdlBFuu8zZU2afEaTzSU6vlIzH4t6XL+EP
+        Mv3ZW20q/rRXYg3P7JWzfPpE/5XYr8x+V1ZSiqK8xeo/fZlm/Z3IXDTbHOnfY/mUsy2S4rGjWyJ+
+        HE1j0a5UyvaHrP2ljEfkLir50RVMcbT4Ppsaqblus9RPxPw7r/VTsJiQuQCdJ61bbUa6NJqzoWg2
+        9SrbkZBflemPiMGketv9qQdUqjwuIu+iLgvUT1HlBOaaUqpB8JVrSk15RkzOTmxSbT8TjsCPfMt3
+        RZAsmrbbPbamcBXb9NexJtPXUBk/VQhYPCMWDiPpX3RpRaZiBQo4TajZg/5kBCi+3bkUmpDAQlPA
+        ftryl9kaDQkZYDf0haISSGVZ065NXhueX258dJm3wQfZ7ojKeerTYyzt5FX8UuGYvohfKjSy1/Df
+        xOC497nXZFk07dImK8/8vedPQ0f0MLG3aNpR5mMvzF5mpydfbohns9PXq5JcLOjo2Zd+RvddHtBF
+        sJK7drxxeeQEYTQY+bEnWtosv7B5RGlhmUXEpvSXyG/mwLCPuGyHyyn+y8OybvY306Cc9w7LMjzd
+        wPHZuvwM0x0waa/fPSs+a97LXmf5jm/vsA8+bLEgWBH9b7MumPsN/TzR08D0olw01oNfh9D59Mi5
+        Y4lb3YqcG8IyuDAORth6nRwuwuNyr/mLBNoiYz8QJgXLzS948kdHuMFuTFQTWllppZbfzZxX14TE
+        NSExMkTEyBASa0hErCHxyBXhyBXxyLpwZF0soJBYFRNrQjQ0MRqaEA1NjIZaFbJRFY8sJNbExKoQ
+        Z1WMs1C+HPEUIROKmAkhsSomFtqn2DxFlEJCoS7EqhAahNgekFARSKwIXRMOrIkBU4WAqWI2hOgi
+        Mbqa0JU0sSvpwpF18ci6kGddzLMqZEMVsyEGQ4yFEGWUg7LQLNQcFxWOrIpH1oVep4u9TjiweFwk
+        tE6UE67EA+eMLHQ7JPY7TagRLUclQiyQGAuhWYitQuh8Yt9DQn6RmF9NiIQmRgIJQybUrj/6CUkk
+        X7GPKKUlz4+elyTYtVFtNDSIXEUjS9YtxZRNS1Vla6ibxCZ2RdcrguRhy24vSCrYF16ZxAOzyseK
+        lYa3AQOZWKkqsm5XVZDKUOWhPtJkG6lWTSNYt1koXwdjq27fBkatoorBoA1vAQa9hUDYtPqFwqyI
+        8CaMK5ZqYYINmSjKUNaHIyzX8NCQFWtYqVZ0wxpZhkCwLbt9mxYNI0eLtOEtwECjGtINuwKymNRR
+        NUXGuqHJlkV0Q0UjUzdE/r1lt5eCwb6MnAhu30ODY62iIqB4C3gsu0ZwDQTTKgbIiVRDNjH9KCCp
+        VlWEVQXppgCeLbt9Y/gzc6Kf+UpQXNJvZ0ck/chjQOjnVtnqPqQce/FkYN2Q5FvR9CL9ICRKrjJy
+        Yi9TOZMptmhtSq6sjvz58vHx/1+kJ0jxWwAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:49:53 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - e6da000bf89cd53e938bbff9b1a1cd00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8s0eAbHIbGDYkzOzNZClhC+KLsVk/8piQ734t
+        2QYBMiGZJMPuTtUQWWrJ3b9+qCXLfig43sgvHDwU/FuPBIWDAvbsgNz+O7Svy34wLpQKHp4QqI9I
+        GA1CC3uDkXMXxQGhTf4gwsGYRIWDEXZDUiqMfNcmwcCxCwde7LqlguV7UeC7hYMoiKE9DqF1SoKJ
+        E4aO74WFA6TWSoXQuiJ27JJBHNOucLPJ1MURke2aUlFsjGQbq0iumqgio6qpy7qmmVW9YtgWUbBh
+        jqpoVCWKUcW2ZQNjxHaiAXZd/5bYc94o8yDjIBXooic1XD+2pV5SD92mvutY99B2iEPHkjokuvWD
+        a0YAreEVDshcMH/4P2JFTFJVRaVChMcpGGFGgi0Xyp8fCksCK6UM64TKdkKQ9T5lK6njywsso/sp
+        ZdwmIxy7UeGxtDIygzIdG60OnKvYtXom0vxuVGOFx8tS4coPI8uPvYgNnipqpKoVQzewPNQUVdZV
+        1ZLNWtWESxVVawgpI8Wi0EU4ioFDKPjTqePR2zBbSm8yDQsUwRS9tKSWp/GQFssR8fDQJSGx4sCJ
+        7suWPwF67EYZ4gPgcqHoqeXIMLgcT10fL+t/AJwEVIJKVdcqCGk63NeZgG3jyXRerZpVkBeH18PM
+        buECx2BUUYCduTFnBpWOSZX0CKQOCBncM8WnZWYlAIahmaqRqmiQwmwFBEegv4EN9r7MmIvB5Sa+
+        7YwcS0DDuHyeHni4xTpJ/DBgZpoDcGYMiW3jMCRRJgytzsopZ6pdNbWqqcqGodqyXqsSeagqI5lo
+        2AKudWSrqJD0zCLNVtqfBv44ICEVACmKDP/3VfgL/1PbygigV0CY1SrKckvkR9hN6714ArJb1yEE
+        rNCBGEbFZS2MKqctJDeE8pT6xUPBgcjFYElragsaF/7C3RTqtmmrstaKNraqG1u1ja364+XjojLh
+        zPIhjNNSMglAASIm6zyBCBpPWPHKGV+xggUdwRDdpJZp2rPJHRUJLOImdsGq8dBxgYqEPAhgDFM3
+        Hjte6gcqMuc1qc47oI44lHq/daRwHo4XzCpz+hGeOC4N0V0/iDJaas70/hlDPIrLN1dV09BXb94j
+        wY1jEalJIgjp4GdP3TvrYHMd+PvzekLLwisIrd3/pNHuSudZFJLOyB8xFOHvxI+AK0x/nNBy/TCZ
+        djfy9jOhanBXONLyOVKVirbK0TFoVzqCeHYv/RpjFwIQsaWmP8GOJ3WARNo7+rXZKQKLoe/G20Am
+        ZkvPZUutqKqyytZ5o7t/wkEFBhNPp2AIxH7Z/Su599c1hNAaLOfnXalNoivfDqV6kl5IezAHS7YT
+        gCVAqC8+xchHMpSo/axbrUHdCILbNAuu6aXrYM8iyfXIcSPak3pXyhSlLjsUAJhJbBopM3brNDRL
+        J80Cl4Y9ZHMAhESYpGinMb154bMim1geXT7UHuW9+YX+KBcftMf5NVIf90pbkxZ/4LnK7qQgVYPU
+        rSrjoWXLZKQgmVbIRrVm0ipaA8lNwQdgMWBKpS2QP2jGwn4nOLKu6FVSAFTGgR9PM6n5QHTPkqS0
+        IdFEGcMk7gxjyGfLQyFsh/EYpvk/tgXudyrx5Y8JLJc/imXuXLQPW2eM+TuXeOMIQiqqvYuQ5A7S
+        IEiHRwFQ0Hx2AEHzBocCyRv1Tr/ek1pJD+ko6yHEwQ78qQ2pDDS6kOZQ/mlaBJcsSyhc5kr3DcIk
+        rA+m2LrGY5IvQndOsBXjSS+oaKqp8HQAuP54BTP6oAs+Bl4ZQLr0JlLdBWR00GidncuNhkgmaJHq
+        9o0TQoDZ2iwbdTmxSDkz0NWa4g//FNkqkP0G/+STprTnkAMJriGr0mSlVnwft5zDkYdFnx/rxX4q
+        Fp5AWtG/kIAFyPMg7iYYQLanoeKu+K8fCE3/w1lrp313KuS629pKfWVhXD1vfTp/H6O0bkg5wLci
+        CfrbSfD7HlDOINQU5T1kmuZMVT4r6JKZYzFxyQe9BPPrdnR5BtxvgbuiCl3/GaX0yoD1EUy574VU
+        GA6GOCSDMM9S+72edAgUUi+l2N59v3wppw78k1D+armyJibkTEA6Zr+vYslUQrpH5UNKuVnK85Tq
+        myQVCqqX1XcW9IaluLlewEvbZ6RbTlTQU/1H62DvYtb90JgdzY5nnWZx/+z0YO/D0ex89nF2kVQ0
+        gKQxuzibNeg185MX9SzmuE7r4LgktQ6O1mB9Zd94Gsfnw1fvH+ydzuqzTnG/DtIez9qzUyjGB3ud
+        WW/WLu43aKk7axT3T+alelaaY/ltw+QBC6N2ShL81t8YWm2LuHOjlZU/e/DRtow+TNY/fwjSnhOD
+        lmV+ricdQO/9JKKwePIpDSdpNPmUBBOIJbMzuEj95nmdvnP40bbF8EXQ0QDSgQByOusmIeR0dlzc
+        757RWla8YHHjrLjfo3g1WEQ5hqYOiyhpqZ6VeIBfeejvGqySJc7HlkgBH7dNJ1PXfGpF87G1upqB
+        5dybLOUWu1UDm4RW4EzTrcE1Gel2OttJfO3c/xVYn4MlYnxOJp1xZDshwrqVpU8KB9hK9jjX5Wkm
+        FPu/eLAalOoJXbg7a8b1xa+tDojrOr5ImhZr2OU18Jz7pO+TIryFi7zpLgW+wY5LeRDJlgpV52h2
+        RC8sHreahzLbTMpjvIkjTBPM191y2qm94bTmKh7m43DMGndEcynDKe2AgHpyMpvWEqXUAsptxUi7
+        hhIOiMSbeMeXUgYkJ4Rp9o/YCdjDKGi4ZjGViLu+JRbEHgzvBxPs3mLh0qCVkUmH91J7TrZbCk2E
+        8Nhz4adk6GRU30UE9gAuPQe1zuhxerCBPris2zY7svDygI5MtYyMWhmV1RKq0nIZfuRFUVFKSKF/
+        yhVImVW9xLgjdxjyFsKOTrzfFv5JvV8XIEKrnxlB5c91+b9Y/nopL0fU1fqcCMvuuJYDIyTXZQVV
+        0Hs+1gBWDsWYHL47JodCTA7fE5MwcsaD+fNyIS5tqbdo3wYd5+akf/ljjsyL0RKRT/rvrH3RQy1a
+        /e7aP//+HuF4g+gKUCC3ohB/4knnVwSC++0OLUjyZ9VdnUi55G5CIhyyShH/88ZdXkAtRMhbQXFy
+        /GlWTyw4tHtHouDQdqzAD/1RJB3Grksix9suTrR7K4//VypyIkO7Z5qyaZpArihytWa+IwIfev2m
+        aHZk9X+ZRdeUDjCYxkN36VjvuthdSih1F4TsLKDYF6Fh5BDXXgPiQX/cTwrqoiCEhB762G+395vN
+        NZXT4WWXRo20RLLiOFqU5pUMMFb61u2SjbuIXUYvNZeIdmkrLjn0NxCeMkuZP0rOBW6Kr4NJ7EbO
+        IsrO73IGq59jHEmnvkWf7qTnoyW2uUqnTHa8k+PquCtffNpIrXLUTTJ0sLeRXOPIe76LA1gDb6LX
+        OfojYvsB3khe4cgbP59IeBiHJGs0uMafQcW+v3GsKs9q3GttJK5xxPWTzZCZHO1HxwOFhdKBtB60
+        5wpR+A5Lh0GT09E8o+3zrjQNfDCbyZyA19FRQMhhr7nZAngtXQxjL4o30/Na6rnYuqZpzeYuvKba
+        9IUSfP1ED1596UHnkeMSCVtWskJmVLzWGqDkD73No/KKOzrvZtUCHWUGryxxbsENnvAQtOQingOU
+        /khKT4RnRLyO2k5olbOGJY8RnCJnRPrSLdgGvXThOXf8/nxyRlroIGB+n3q9jGbJT+j57cD3I0j9
+        KeQs8DAqHuizbiOrrgmN+yIkgTTBHh6TCWGPFRixueyR6XFrFid4lLNN1HkQ4RHtEhLI575M/0pH
+        1CB6VxBWvOy9JI1HtnHSa3zIGnhkj5yA3GLXnd+CR/QQLNr2/bnHaTyKvUa9Wc8aeOianQxRjccK
+        oHDBXqUw0eV8TB64LnurTFo8OsqIzFXVYCm8Iq67qh1dWbKaCKLJeB5Sl9BbeSeCEfCI0TfakjVK
+        csZ9CTNvDJgvxVh9KRR02plD6TxknZMMGd1YDQPOzeYIr/NY9tss0LR6mz1Q57E9DGIaOfwA/Ajy
+        BsyR8ej+J/b8zVNTZQljywG7pq9dSaeOF99t7slroO0PqdE2CW8NFV4FHwJsAcUW4/LaqU/wV8j/
+        tujFq6yLXV+qu9HmqbHCa/M4xrfE2UzPq/mokr0m+QS+1TUM+u3NPXg9n3iWY4NO6BsnU98LMxOu
+        8FruO0EU+1+/bhbXUJYc4rZH396TGj/3Tjd3Q4+vt6DdlBFuu8zZU2afEaTzSU6vlIzH4t6XL+EP
+        Mv3ZW20q/rRXYg3P7JWzfPpE/5XYr8x+V1ZSiqK8xeo/fZlm/Z3IXDTbHOnfY/mUsy2S4rGjWyJ+
+        HE1j0a5UyvaHrP2ljEfkLir50RVMcbT4Ppsaqblus9RPxPw7r/VTsJiQuQCdJ61bbUa6NJqzoWg2
+        9SrbkZBflemPiMGketv9qQdUqjwuIu+iLgvUT1HlBOaaUqpB8JVrSk15RkzOTmxSbT8TjsCPfMt3
+        RZAsmrbbPbamcBXb9NexJtPXUBk/VQhYPCMWDiPpX3RpRaZiBQo4TajZg/5kBCi+3bkUmpDAQlPA
+        ftryl9kaDQkZYDf0haISSGVZ065NXhueX258dJm3wQfZ7ojKeerTYyzt5FX8UuGYvohfKjSy1/Df
+        xOC497nXZFk07dImK8/8vedPQ0f0MLG3aNpR5mMvzF5mpydfbohns9PXq5JcLOjo2Zd+RvddHtBF
+        sJK7drxxeeQEYTQY+bEnWtosv7B5RGlhmUXEpvSXyG/mwLCPuGyHyyn+y8OybvY306Cc9w7LMjzd
+        wPHZuvwM0x0waa/fPSs+a97LXmf5jm/vsA8+bLEgWBH9b7MumPsN/TzR08D0olw01oNfh9D59Mi5
+        Y4lb3YqcG8IyuDAORth6nRwuwuNyr/mLBNoiYz8QJgXLzS948kdHuMFuTFQTWllppZbfzZxX14TE
+        NSExMkTEyBASa0hErCHxyBXhyBXxyLpwZF0soJBYFRNrQjQ0MRqaEA1NjIZaFbJRFY8sJNbExKoQ
+        Z1WMs1C+HPEUIROKmAkhsSomFtqn2DxFlEJCoS7EqhAahNgekFARSKwIXRMOrIkBU4WAqWI2hOgi
+        Mbqa0JU0sSvpwpF18ci6kGddzLMqZEMVsyEGQ4yFEGWUg7LQLNQcFxWOrIpH1oVep4u9TjiweFwk
+        tE6UE67EA+eMLHQ7JPY7TagRLUclQiyQGAuhWYitQuh8Yt9DQn6RmF9NiIQmRgIJQybUrj/6CUkk
+        X7GPKKUlz4+elyTYtVFtNDSIXEUjS9YtxZRNS1Vla6ibxCZ2RdcrguRhy24vSCrYF16ZxAOzyseK
+        lYa3AQOZWKkqsm5XVZDKUOWhPtJkG6lWTSNYt1koXwdjq27fBkatoorBoA1vAQa9hUDYtPqFwqyI
+        8CaMK5ZqYYINmSjKUNaHIyzX8NCQFWtYqVZ0wxpZhkCwLbt9mxYNI0eLtOEtwECjGtINuwKymNRR
+        NUXGuqHJlkV0Q0UjUzdE/r1lt5eCwb6MnAhu30ODY62iIqB4C3gsu0ZwDQTTKgbIiVRDNjH9KCCp
+        VlWEVQXppgCeLbt9Y/gzc6Kf+UpQXNJvZ0ck/chjQOjnVtnqPqQce/FkYN2Q5FvR9CL9ICRKrjJy
+        Yi9TOZMptmhtSq6sjvz58vHx/1+kJ0jxWwAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:50:04 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 6ed8d7b6ceeb1ec81a6e2e513d0f1d41
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8s0eAbHIbGDYkzOzNZClhC+KLsVk/8piQ734t
+        2QYBMiGZJMPuTtUQWWrJ3b9+qCXLfig43sgvHDwU/FuPBIWDAvbsgNz+O7Svy34wLpQKHp4QqI9I
+        GA1CC3uDkXMXxQGhTf4gwsGYRIWDEXZDUiqMfNcmwcCxCwde7LqlguV7UeC7hYMoiKE9DqF1SoKJ
+        E4aO74WFA6TWSoXQuiJ27JJBHNOucLPJ1MURke2aUlFsjGQbq0iumqgio6qpy7qmmVW9YtgWUbBh
+        jqpoVCWKUcW2ZQNjxHaiAXZd/5bYc94o8yDjIBXooic1XD+2pV5SD92mvutY99B2iEPHkjokuvWD
+        a0YAreEVDshcMH/4P2JFTFJVRaVChMcpGGFGgi0Xyp8fCksCK6UM64TKdkKQ9T5lK6njywsso/sp
+        ZdwmIxy7UeGxtDIygzIdG60OnKvYtXom0vxuVGOFx8tS4coPI8uPvYgNnipqpKoVQzewPNQUVdZV
+        1ZLNWtWESxVVawgpI8Wi0EU4ioFDKPjTqePR2zBbSm8yDQsUwRS9tKSWp/GQFssR8fDQJSGx4sCJ
+        7suWPwF67EYZ4gPgcqHoqeXIMLgcT10fL+t/AJwEVIJKVdcqCGk63NeZgG3jyXRerZpVkBeH18PM
+        buECx2BUUYCduTFnBpWOSZX0CKQOCBncM8WnZWYlAIahmaqRqmiQwmwFBEegv4EN9r7MmIvB5Sa+
+        7YwcS0DDuHyeHni4xTpJ/DBgZpoDcGYMiW3jMCRRJgytzsopZ6pdNbWqqcqGodqyXqsSeagqI5lo
+        2AKudWSrqJD0zCLNVtqfBv44ICEVACmKDP/3VfgL/1PbygigV0CY1SrKckvkR9hN6714ArJb1yEE
+        rNCBGEbFZS2MKqctJDeE8pT6xUPBgcjFYElragsaF/7C3RTqtmmrstaKNraqG1u1ja364+XjojLh
+        zPIhjNNSMglAASIm6zyBCBpPWPHKGV+xggUdwRDdpJZp2rPJHRUJLOImdsGq8dBxgYqEPAhgDFM3
+        Hjte6gcqMuc1qc47oI44lHq/daRwHo4XzCpz+hGeOC4N0V0/iDJaas70/hlDPIrLN1dV09BXb94j
+        wY1jEalJIgjp4GdP3TvrYHMd+PvzekLLwisIrd3/pNHuSudZFJLOyB8xFOHvxI+AK0x/nNBy/TCZ
+        djfy9jOhanBXONLyOVKVirbK0TFoVzqCeHYv/RpjFwIQsaWmP8GOJ3WARNo7+rXZKQKLoe/G20Am
+        ZkvPZUutqKqyytZ5o7t/wkEFBhNPp2AIxH7Z/Su599c1hNAaLOfnXalNoivfDqV6kl5IezAHS7YT
+        gCVAqC8+xchHMpSo/axbrUHdCILbNAuu6aXrYM8iyfXIcSPak3pXyhSlLjsUAJhJbBopM3brNDRL
+        J80Cl4Y9ZHMAhESYpGinMb154bMim1geXT7UHuW9+YX+KBcftMf5NVIf90pbkxZ/4LnK7qQgVYPU
+        rSrjoWXLZKQgmVbIRrVm0ipaA8lNwQdgMWBKpS2QP2jGwn4nOLKu6FVSAFTGgR9PM6n5QHTPkqS0
+        IdFEGcMk7gxjyGfLQyFsh/EYpvk/tgXudyrx5Y8JLJc/imXuXLQPW2eM+TuXeOMIQiqqvYuQ5A7S
+        IEiHRwFQ0Hx2AEHzBocCyRv1Tr/ek1pJD+ko6yHEwQ78qQ2pDDS6kOZQ/mlaBJcsSyhc5kr3DcIk
+        rA+m2LrGY5IvQndOsBXjSS+oaKqp8HQAuP54BTP6oAs+Bl4ZQLr0JlLdBWR00GidncuNhkgmaJHq
+        9o0TQoDZ2iwbdTmxSDkz0NWa4g//FNkqkP0G/+STprTnkAMJriGr0mSlVnwft5zDkYdFnx/rxX4q
+        Fp5AWtG/kIAFyPMg7iYYQLanoeKu+K8fCE3/w1lrp313KuS629pKfWVhXD1vfTp/H6O0bkg5wLci
+        CfrbSfD7HlDOINQU5T1kmuZMVT4r6JKZYzFxyQe9BPPrdnR5BtxvgbuiCl3/GaX0yoD1EUy574VU
+        GA6GOCSDMM9S+72edAgUUi+l2N59v3wppw78k1D+armyJibkTEA6Zr+vYslUQrpH5UNKuVnK85Tq
+        myQVCqqX1XcW9IaluLlewEvbZ6RbTlTQU/1H62DvYtb90JgdzY5nnWZx/+z0YO/D0ex89nF2kVQ0
+        gKQxuzibNeg185MX9SzmuE7r4LgktQ6O1mB9Zd94Gsfnw1fvH+ydzuqzTnG/DtIez9qzUyjGB3ud
+        WW/WLu43aKk7axT3T+alelaaY/ltw+QBC6N2ShL81t8YWm2LuHOjlZU/e/DRtow+TNY/fwjSnhOD
+        lmV+ricdQO/9JKKwePIpDSdpNPmUBBOIJbMzuEj95nmdvnP40bbF8EXQ0QDSgQByOusmIeR0dlzc
+        757RWla8YHHjrLjfo3g1WEQ5hqYOiyhpqZ6VeIBfeejvGqySJc7HlkgBH7dNJ1PXfGpF87G1upqB
+        5dybLOUWu1UDm4RW4EzTrcE1Gel2OttJfO3c/xVYn4MlYnxOJp1xZDshwrqVpU8KB9hK9jjX5Wkm
+        FPu/eLAalOoJXbg7a8b1xa+tDojrOr5ImhZr2OU18Jz7pO+TIryFi7zpLgW+wY5LeRDJlgpV52h2
+        RC8sHreahzLbTMpjvIkjTBPM191y2qm94bTmKh7m43DMGndEcynDKe2AgHpyMpvWEqXUAsptxUi7
+        hhIOiMSbeMeXUgYkJ4Rp9o/YCdjDKGi4ZjGViLu+JRbEHgzvBxPs3mLh0qCVkUmH91J7TrZbCk2E
+        8Nhz4adk6GRU30UE9gAuPQe1zuhxerCBPris2zY7svDygI5MtYyMWhmV1RKq0nIZfuRFUVFKSKF/
+        yhVImVW9xLgjdxjyFsKOTrzfFv5JvV8XIEKrnxlB5c91+b9Y/nopL0fU1fqcCMvuuJYDIyTXZQVV
+        0Hs+1gBWDsWYHL47JodCTA7fE5MwcsaD+fNyIS5tqbdo3wYd5+akf/ljjsyL0RKRT/rvrH3RQy1a
+        /e7aP//+HuF4g+gKUCC3ohB/4knnVwSC++0OLUjyZ9VdnUi55G5CIhyyShH/88ZdXkAtRMhbQXFy
+        /GlWTyw4tHtHouDQdqzAD/1RJB3Grksix9suTrR7K4//VypyIkO7Z5qyaZpArihytWa+IwIfev2m
+        aHZk9X+ZRdeUDjCYxkN36VjvuthdSih1F4TsLKDYF6Fh5BDXXgPiQX/cTwrqoiCEhB762G+395vN
+        NZXT4WWXRo20RLLiOFqU5pUMMFb61u2SjbuIXUYvNZeIdmkrLjn0NxCeMkuZP0rOBW6Kr4NJ7EbO
+        IsrO73IGq59jHEmnvkWf7qTnoyW2uUqnTHa8k+PquCtffNpIrXLUTTJ0sLeRXOPIe76LA1gDb6LX
+        OfojYvsB3khe4cgbP59IeBiHJGs0uMafQcW+v3GsKs9q3GttJK5xxPWTzZCZHO1HxwOFhdKBtB60
+        5wpR+A5Lh0GT09E8o+3zrjQNfDCbyZyA19FRQMhhr7nZAngtXQxjL4o30/Na6rnYuqZpzeYuvKba
+        9IUSfP1ED1596UHnkeMSCVtWskJmVLzWGqDkD73No/KKOzrvZtUCHWUGryxxbsENnvAQtOQingOU
+        /khKT4RnRLyO2k5olbOGJY8RnCJnRPrSLdgGvXThOXf8/nxyRlroIGB+n3q9jGbJT+j57cD3I0j9
+        KeQs8DAqHuizbiOrrgmN+yIkgTTBHh6TCWGPFRixueyR6XFrFid4lLNN1HkQ4RHtEhLI575M/0pH
+        1CB6VxBWvOy9JI1HtnHSa3zIGnhkj5yA3GLXnd+CR/QQLNr2/bnHaTyKvUa9Wc8aeOianQxRjccK
+        oHDBXqUw0eV8TB64LnurTFo8OsqIzFXVYCm8Iq67qh1dWbKaCKLJeB5Sl9BbeSeCEfCI0TfakjVK
+        csZ9CTNvDJgvxVh9KRR02plD6TxknZMMGd1YDQPOzeYIr/NY9tss0LR6mz1Q57E9DGIaOfwA/Ajy
+        BsyR8ej+J/b8zVNTZQljywG7pq9dSaeOF99t7slroO0PqdE2CW8NFV4FHwJsAcUW4/LaqU/wV8j/
+        tujFq6yLXV+qu9HmqbHCa/M4xrfE2UzPq/mokr0m+QS+1TUM+u3NPXg9n3iWY4NO6BsnU98LMxOu
+        8FruO0EU+1+/bhbXUJYc4rZH396TGj/3Tjd3Q4+vt6DdlBFuu8zZU2afEaTzSU6vlIzH4t6XL+EP
+        Mv3ZW20q/rRXYg3P7JWzfPpE/5XYr8x+V1ZSiqK8xeo/fZlm/Z3IXDTbHOnfY/mUsy2S4rGjWyJ+
+        HE1j0a5UyvaHrP2ljEfkLir50RVMcbT4Ppsaqblus9RPxPw7r/VTsJiQuQCdJ61bbUa6NJqzoWg2
+        9SrbkZBflemPiMGketv9qQdUqjwuIu+iLgvUT1HlBOaaUqpB8JVrSk15RkzOTmxSbT8TjsCPfMt3
+        RZAsmrbbPbamcBXb9NexJtPXUBk/VQhYPCMWDiPpX3RpRaZiBQo4TajZg/5kBCi+3bkUmpDAQlPA
+        ftryl9kaDQkZYDf0haISSGVZ065NXhueX258dJm3wQfZ7ojKeerTYyzt5FX8UuGYvohfKjSy1/Df
+        xOC497nXZFk07dImK8/8vedPQ0f0MLG3aNpR5mMvzF5mpydfbohns9PXq5JcLOjo2Zd+RvddHtBF
+        sJK7drxxeeQEYTQY+bEnWtosv7B5RGlhmUXEpvSXyG/mwLCPuGyHyyn+y8OybvY306Cc9w7LMjzd
+        wPHZuvwM0x0waa/fPSs+a97LXmf5jm/vsA8+bLEgWBH9b7MumPsN/TzR08D0olw01oNfh9D59Mi5
+        Y4lb3YqcG8IyuDAORth6nRwuwuNyr/mLBNoiYz8QJgXLzS948kdHuMFuTFQTWllppZbfzZxX14TE
+        NSExMkTEyBASa0hErCHxyBXhyBXxyLpwZF0soJBYFRNrQjQ0MRqaEA1NjIZaFbJRFY8sJNbExKoQ
+        Z1WMs1C+HPEUIROKmAkhsSomFtqn2DxFlEJCoS7EqhAahNgekFARSKwIXRMOrIkBU4WAqWI2hOgi
+        Mbqa0JU0sSvpwpF18ci6kGddzLMqZEMVsyEGQ4yFEGWUg7LQLNQcFxWOrIpH1oVep4u9TjiweFwk
+        tE6UE67EA+eMLHQ7JPY7TagRLUclQiyQGAuhWYitQuh8Yt9DQn6RmF9NiIQmRgIJQybUrj/6CUkk
+        X7GPKKUlz4+elyTYtVFtNDSIXEUjS9YtxZRNS1Vla6ibxCZ2RdcrguRhy24vSCrYF16ZxAOzyseK
+        lYa3AQOZWKkqsm5XVZDKUOWhPtJkG6lWTSNYt1koXwdjq27fBkatoorBoA1vAQa9hUDYtPqFwqyI
+        8CaMK5ZqYYINmSjKUNaHIyzX8NCQFWtYqVZ0wxpZhkCwLbt9mxYNI0eLtOEtwECjGtINuwKymNRR
+        NUXGuqHJlkV0Q0UjUzdE/r1lt5eCwb6MnAhu30ODY62iIqB4C3gsu0ZwDQTTKgbIiVRDNjH9KCCp
+        VlWEVQXppgCeLbt9Y/gzc6Kf+UpQXNJvZ0ck/chjQOjnVtnqPqQce/FkYN2Q5FvR9CL9ICRKrjJy
+        Yi9TOZMptmhtSq6sjvz58vHx/1+kJ0jxWwAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:50:14 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - c852eed2302ac1eb6a0b9d93e030f564
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8s0eAbHIbGDYkzOzNZClhC+KLsVk/8piQ734t
+        2QYBMiGZJMPuTtUQWWrJ3b9+qCXLfig43sgvHDwU/FuPBIWDAvbsgNz+O7Svy34wLpQKHp4QqI9I
+        GA1CC3uDkXMXxQGhTf4gwsGYRIWDEXZDUiqMfNcmwcCxCwde7LqlguV7UeC7hYMoiKE9DqF1SoKJ
+        E4aO74WFA6TWSoXQuiJ27JJBHNOucLPJ1MURke2aUlFsjGQbq0iumqgio6qpy7qmmVW9YtgWUbBh
+        jqpoVCWKUcW2ZQNjxHaiAXZd/5bYc94o8yDjIBXooic1XD+2pV5SD92mvutY99B2iEPHkjokuvWD
+        a0YAreEVDshcMH/4P2JFTFJVRaVChMcpGGFGgi0Xyp8fCksCK6UM64TKdkKQ9T5lK6njywsso/sp
+        ZdwmIxy7UeGxtDIygzIdG60OnKvYtXom0vxuVGOFx8tS4coPI8uPvYgNnipqpKoVQzewPNQUVdZV
+        1ZLNWtWESxVVawgpI8Wi0EU4ioFDKPjTqePR2zBbSm8yDQsUwRS9tKSWp/GQFssR8fDQJSGx4sCJ
+        7suWPwF67EYZ4gPgcqHoqeXIMLgcT10fL+t/AJwEVIJKVdcqCGk63NeZgG3jyXRerZpVkBeH18PM
+        buECx2BUUYCduTFnBpWOSZX0CKQOCBncM8WnZWYlAIahmaqRqmiQwmwFBEegv4EN9r7MmIvB5Sa+
+        7YwcS0DDuHyeHni4xTpJ/DBgZpoDcGYMiW3jMCRRJgytzsopZ6pdNbWqqcqGodqyXqsSeagqI5lo
+        2AKudWSrqJD0zCLNVtqfBv44ICEVACmKDP/3VfgL/1PbygigV0CY1SrKckvkR9hN6714ArJb1yEE
+        rNCBGEbFZS2MKqctJDeE8pT6xUPBgcjFYElragsaF/7C3RTqtmmrstaKNraqG1u1ja364+XjojLh
+        zPIhjNNSMglAASIm6zyBCBpPWPHKGV+xggUdwRDdpJZp2rPJHRUJLOImdsGq8dBxgYqEPAhgDFM3
+        Hjte6gcqMuc1qc47oI44lHq/daRwHo4XzCpz+hGeOC4N0V0/iDJaas70/hlDPIrLN1dV09BXb94j
+        wY1jEalJIgjp4GdP3TvrYHMd+PvzekLLwisIrd3/pNHuSudZFJLOyB8xFOHvxI+AK0x/nNBy/TCZ
+        djfy9jOhanBXONLyOVKVirbK0TFoVzqCeHYv/RpjFwIQsaWmP8GOJ3WARNo7+rXZKQKLoe/G20Am
+        ZkvPZUutqKqyytZ5o7t/wkEFBhNPp2AIxH7Z/Su599c1hNAaLOfnXalNoivfDqV6kl5IezAHS7YT
+        gCVAqC8+xchHMpSo/axbrUHdCILbNAuu6aXrYM8iyfXIcSPak3pXyhSlLjsUAJhJbBopM3brNDRL
+        J80Cl4Y9ZHMAhESYpGinMb154bMim1geXT7UHuW9+YX+KBcftMf5NVIf90pbkxZ/4LnK7qQgVYPU
+        rSrjoWXLZKQgmVbIRrVm0ipaA8lNwQdgMWBKpS2QP2jGwn4nOLKu6FVSAFTGgR9PM6n5QHTPkqS0
+        IdFEGcMk7gxjyGfLQyFsh/EYpvk/tgXudyrx5Y8JLJc/imXuXLQPW2eM+TuXeOMIQiqqvYuQ5A7S
+        IEiHRwFQ0Hx2AEHzBocCyRv1Tr/ek1pJD+ko6yHEwQ78qQ2pDDS6kOZQ/mlaBJcsSyhc5kr3DcIk
+        rA+m2LrGY5IvQndOsBXjSS+oaKqp8HQAuP54BTP6oAs+Bl4ZQLr0JlLdBWR00GidncuNhkgmaJHq
+        9o0TQoDZ2iwbdTmxSDkz0NWa4g//FNkqkP0G/+STprTnkAMJriGr0mSlVnwft5zDkYdFnx/rxX4q
+        Fp5AWtG/kIAFyPMg7iYYQLanoeKu+K8fCE3/w1lrp313KuS629pKfWVhXD1vfTp/H6O0bkg5wLci
+        CfrbSfD7HlDOINQU5T1kmuZMVT4r6JKZYzFxyQe9BPPrdnR5BtxvgbuiCl3/GaX0yoD1EUy574VU
+        GA6GOCSDMM9S+72edAgUUi+l2N59v3wppw78k1D+armyJibkTEA6Zr+vYslUQrpH5UNKuVnK85Tq
+        myQVCqqX1XcW9IaluLlewEvbZ6RbTlTQU/1H62DvYtb90JgdzY5nnWZx/+z0YO/D0ex89nF2kVQ0
+        gKQxuzibNeg185MX9SzmuE7r4LgktQ6O1mB9Zd94Gsfnw1fvH+ydzuqzTnG/DtIez9qzUyjGB3ud
+        WW/WLu43aKk7axT3T+alelaaY/ltw+QBC6N2ShL81t8YWm2LuHOjlZU/e/DRtow+TNY/fwjSnhOD
+        lmV+ricdQO/9JKKwePIpDSdpNPmUBBOIJbMzuEj95nmdvnP40bbF8EXQ0QDSgQByOusmIeR0dlzc
+        757RWla8YHHjrLjfo3g1WEQ5hqYOiyhpqZ6VeIBfeejvGqySJc7HlkgBH7dNJ1PXfGpF87G1upqB
+        5dybLOUWu1UDm4RW4EzTrcE1Gel2OttJfO3c/xVYn4MlYnxOJp1xZDshwrqVpU8KB9hK9jjX5Wkm
+        FPu/eLAalOoJXbg7a8b1xa+tDojrOr5ImhZr2OU18Jz7pO+TIryFi7zpLgW+wY5LeRDJlgpV52h2
+        RC8sHreahzLbTMpjvIkjTBPM191y2qm94bTmKh7m43DMGndEcynDKe2AgHpyMpvWEqXUAsptxUi7
+        hhIOiMSbeMeXUgYkJ4Rp9o/YCdjDKGi4ZjGViLu+JRbEHgzvBxPs3mLh0qCVkUmH91J7TrZbCk2E
+        8Nhz4adk6GRU30UE9gAuPQe1zuhxerCBPris2zY7svDygI5MtYyMWhmV1RKq0nIZfuRFUVFKSKF/
+        yhVImVW9xLgjdxjyFsKOTrzfFv5JvV8XIEKrnxlB5c91+b9Y/nopL0fU1fqcCMvuuJYDIyTXZQVV
+        0Hs+1gBWDsWYHL47JodCTA7fE5MwcsaD+fNyIS5tqbdo3wYd5+akf/ljjsyL0RKRT/rvrH3RQy1a
+        /e7aP//+HuF4g+gKUCC3ohB/4knnVwSC++0OLUjyZ9VdnUi55G5CIhyyShH/88ZdXkAtRMhbQXFy
+        /GlWTyw4tHtHouDQdqzAD/1RJB3Grksix9suTrR7K4//VypyIkO7Z5qyaZpArihytWa+IwIfev2m
+        aHZk9X+ZRdeUDjCYxkN36VjvuthdSih1F4TsLKDYF6Fh5BDXXgPiQX/cTwrqoiCEhB762G+395vN
+        NZXT4WWXRo20RLLiOFqU5pUMMFb61u2SjbuIXUYvNZeIdmkrLjn0NxCeMkuZP0rOBW6Kr4NJ7EbO
+        IsrO73IGq59jHEmnvkWf7qTnoyW2uUqnTHa8k+PquCtffNpIrXLUTTJ0sLeRXOPIe76LA1gDb6LX
+        OfojYvsB3khe4cgbP59IeBiHJGs0uMafQcW+v3GsKs9q3GttJK5xxPWTzZCZHO1HxwOFhdKBtB60
+        5wpR+A5Lh0GT09E8o+3zrjQNfDCbyZyA19FRQMhhr7nZAngtXQxjL4o30/Na6rnYuqZpzeYuvKba
+        9IUSfP1ED1596UHnkeMSCVtWskJmVLzWGqDkD73No/KKOzrvZtUCHWUGryxxbsENnvAQtOQingOU
+        /khKT4RnRLyO2k5olbOGJY8RnCJnRPrSLdgGvXThOXf8/nxyRlroIGB+n3q9jGbJT+j57cD3I0j9
+        KeQs8DAqHuizbiOrrgmN+yIkgTTBHh6TCWGPFRixueyR6XFrFid4lLNN1HkQ4RHtEhLI575M/0pH
+        1CB6VxBWvOy9JI1HtnHSa3zIGnhkj5yA3GLXnd+CR/QQLNr2/bnHaTyKvUa9Wc8aeOianQxRjccK
+        oHDBXqUw0eV8TB64LnurTFo8OsqIzFXVYCm8Iq67qh1dWbKaCKLJeB5Sl9BbeSeCEfCI0TfakjVK
+        csZ9CTNvDJgvxVh9KRR02plD6TxknZMMGd1YDQPOzeYIr/NY9tss0LR6mz1Q57E9DGIaOfwA/Ajy
+        BsyR8ej+J/b8zVNTZQljywG7pq9dSaeOF99t7slroO0PqdE2CW8NFV4FHwJsAcUW4/LaqU/wV8j/
+        tujFq6yLXV+qu9HmqbHCa/M4xrfE2UzPq/mokr0m+QS+1TUM+u3NPXg9n3iWY4NO6BsnU98LMxOu
+        8FruO0EU+1+/bhbXUJYc4rZH396TGj/3Tjd3Q4+vt6DdlBFuu8zZU2afEaTzSU6vlIzH4t6XL+EP
+        Mv3ZW20q/rRXYg3P7JWzfPpE/5XYr8x+V1ZSiqK8xeo/fZlm/Z3IXDTbHOnfY/mUsy2S4rGjWyJ+
+        HE1j0a5UyvaHrP2ljEfkLir50RVMcbT4Ppsaqblus9RPxPw7r/VTsJiQuQCdJ61bbUa6NJqzoWg2
+        9SrbkZBflemPiMGketv9qQdUqjwuIu+iLgvUT1HlBOaaUqpB8JVrSk15RkzOTmxSbT8TjsCPfMt3
+        RZAsmrbbPbamcBXb9NexJtPXUBk/VQhYPCMWDiPpX3RpRaZiBQo4TajZg/5kBCi+3bkUmpDAQlPA
+        ftryl9kaDQkZYDf0haISSGVZ065NXhueX258dJm3wQfZ7ojKeerTYyzt5FX8UuGYvohfKjSy1/Df
+        xOC497nXZFk07dImK8/8vedPQ0f0MLG3aNpR5mMvzF5mpydfbohns9PXq5JcLOjo2Zd+RvddHtBF
+        sJK7drxxeeQEYTQY+bEnWtosv7B5RGlhmUXEpvSXyG/mwLCPuGyHyyn+y8OybvY306Cc9w7LMjzd
+        wPHZuvwM0x0waa/fPSs+a97LXmf5jm/vsA8+bLEgWBH9b7MumPsN/TzR08D0olw01oNfh9D59Mi5
+        Y4lb3YqcG8IyuDAORth6nRwuwuNyr/mLBNoiYz8QJgXLzS948kdHuMFuTFQTWllppZbfzZxX14TE
+        NSExMkTEyBASa0hErCHxyBXhyBXxyLpwZF0soJBYFRNrQjQ0MRqaEA1NjIZaFbJRFY8sJNbExKoQ
+        Z1WMs1C+HPEUIROKmAkhsSomFtqn2DxFlEJCoS7EqhAahNgekFARSKwIXRMOrIkBU4WAqWI2hOgi
+        Mbqa0JU0sSvpwpF18ci6kGddzLMqZEMVsyEGQ4yFEGWUg7LQLNQcFxWOrIpH1oVep4u9TjiweFwk
+        tE6UE67EA+eMLHQ7JPY7TagRLUclQiyQGAuhWYitQuh8Yt9DQn6RmF9NiIQmRgIJQybUrj/6CUkk
+        X7GPKKUlz4+elyTYtVFtNDSIXEUjS9YtxZRNS1Vla6ibxCZ2RdcrguRhy24vSCrYF16ZxAOzyseK
+        lYa3AQOZWKkqsm5XVZDKUOWhPtJkG6lWTSNYt1koXwdjq27fBkatoorBoA1vAQa9hUDYtPqFwqyI
+        8CaMK5ZqYYINmSjKUNaHIyzX8NCQFWtYqVZ0wxpZhkCwLbt9mxYNI0eLtOEtwECjGtINuwKymNRR
+        NUXGuqHJlkV0Q0UjUzdE/r1lt5eCwb6MnAhu30ODY62iIqB4C3gsu0ZwDQTTKgbIiVRDNjH9KCCp
+        VlWEVQXppgCeLbt9Y/gzc6Kf+UpQXNJvZ0ck/chjQOjnVtnqPqQce/FkYN2Q5FvR9CL9ICRKrjJy
+        Yi9TOZMptmhtSq6sjvz58vHx/1+kJ0jxWwAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:50:25 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 4d9cd4b19f8e323e655434e4b58b6dc1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8s0eAbHIbGDYkzOzNZClhC+KLsVk/8piQ734t
+        2QYBMiGZJMPuTtUQWWrJ3b9+qCXLfig43sgvHDwU/FuPBIWDAvbsgNz+O7Svy34wLpQKHp4QqI9I
+        GA1CC3uDkXMXxQGhTf4gwsGYRIWDEXZDUiqMfNcmwcCxCwde7LqlguV7UeC7hYMoiKE9DqF1SoKJ
+        E4aO74WFA6TWSoXQuiJ27JJBHNOucLPJ1MURke2aUlFsjGQbq0iumqgio6qpy7qmmVW9YtgWUbBh
+        jqpoVCWKUcW2ZQNjxHaiAXZd/5bYc94o8yDjIBXooic1XD+2pV5SD92mvutY99B2iEPHkjokuvWD
+        a0YAreEVDshcMH/4P2JFTFJVRaVChMcpGGFGgi0Xyp8fCksCK6UM64TKdkKQ9T5lK6njywsso/sp
+        ZdwmIxy7UeGxtDIygzIdG60OnKvYtXom0vxuVGOFx8tS4coPI8uPvYgNnipqpKoVQzewPNQUVdZV
+        1ZLNWtWESxVVawgpI8Wi0EU4ioFDKPjTqePR2zBbSm8yDQsUwRS9tKSWp/GQFssR8fDQJSGx4sCJ
+        7suWPwF67EYZ4gPgcqHoqeXIMLgcT10fL+t/AJwEVIJKVdcqCGk63NeZgG3jyXRerZpVkBeH18PM
+        buECx2BUUYCduTFnBpWOSZX0CKQOCBncM8WnZWYlAIahmaqRqmiQwmwFBEegv4EN9r7MmIvB5Sa+
+        7YwcS0DDuHyeHni4xTpJ/DBgZpoDcGYMiW3jMCRRJgytzsopZ6pdNbWqqcqGodqyXqsSeagqI5lo
+        2AKudWSrqJD0zCLNVtqfBv44ICEVACmKDP/3VfgL/1PbygigV0CY1SrKckvkR9hN6714ArJb1yEE
+        rNCBGEbFZS2MKqctJDeE8pT6xUPBgcjFYElragsaF/7C3RTqtmmrstaKNraqG1u1ja364+XjojLh
+        zPIhjNNSMglAASIm6zyBCBpPWPHKGV+xggUdwRDdpJZp2rPJHRUJLOImdsGq8dBxgYqEPAhgDFM3
+        Hjte6gcqMuc1qc47oI44lHq/daRwHo4XzCpz+hGeOC4N0V0/iDJaas70/hlDPIrLN1dV09BXb94j
+        wY1jEalJIgjp4GdP3TvrYHMd+PvzekLLwisIrd3/pNHuSudZFJLOyB8xFOHvxI+AK0x/nNBy/TCZ
+        djfy9jOhanBXONLyOVKVirbK0TFoVzqCeHYv/RpjFwIQsaWmP8GOJ3WARNo7+rXZKQKLoe/G20Am
+        ZkvPZUutqKqyytZ5o7t/wkEFBhNPp2AIxH7Z/Su599c1hNAaLOfnXalNoivfDqV6kl5IezAHS7YT
+        gCVAqC8+xchHMpSo/axbrUHdCILbNAuu6aXrYM8iyfXIcSPak3pXyhSlLjsUAJhJbBopM3brNDRL
+        J80Cl4Y9ZHMAhESYpGinMb154bMim1geXT7UHuW9+YX+KBcftMf5NVIf90pbkxZ/4LnK7qQgVYPU
+        rSrjoWXLZKQgmVbIRrVm0ipaA8lNwQdgMWBKpS2QP2jGwn4nOLKu6FVSAFTGgR9PM6n5QHTPkqS0
+        IdFEGcMk7gxjyGfLQyFsh/EYpvk/tgXudyrx5Y8JLJc/imXuXLQPW2eM+TuXeOMIQiqqvYuQ5A7S
+        IEiHRwFQ0Hx2AEHzBocCyRv1Tr/ek1pJD+ko6yHEwQ78qQ2pDDS6kOZQ/mlaBJcsSyhc5kr3DcIk
+        rA+m2LrGY5IvQndOsBXjSS+oaKqp8HQAuP54BTP6oAs+Bl4ZQLr0JlLdBWR00GidncuNhkgmaJHq
+        9o0TQoDZ2iwbdTmxSDkz0NWa4g//FNkqkP0G/+STprTnkAMJriGr0mSlVnwft5zDkYdFnx/rxX4q
+        Fp5AWtG/kIAFyPMg7iYYQLanoeKu+K8fCE3/w1lrp313KuS629pKfWVhXD1vfTp/H6O0bkg5wLci
+        CfrbSfD7HlDOINQU5T1kmuZMVT4r6JKZYzFxyQe9BPPrdnR5BtxvgbuiCl3/GaX0yoD1EUy574VU
+        GA6GOCSDMM9S+72edAgUUi+l2N59v3wppw78k1D+armyJibkTEA6Zr+vYslUQrpH5UNKuVnK85Tq
+        myQVCqqX1XcW9IaluLlewEvbZ6RbTlTQU/1H62DvYtb90JgdzY5nnWZx/+z0YO/D0ex89nF2kVQ0
+        gKQxuzibNeg185MX9SzmuE7r4LgktQ6O1mB9Zd94Gsfnw1fvH+ydzuqzTnG/DtIez9qzUyjGB3ud
+        WW/WLu43aKk7axT3T+alelaaY/ltw+QBC6N2ShL81t8YWm2LuHOjlZU/e/DRtow+TNY/fwjSnhOD
+        lmV+ricdQO/9JKKwePIpDSdpNPmUBBOIJbMzuEj95nmdvnP40bbF8EXQ0QDSgQByOusmIeR0dlzc
+        757RWla8YHHjrLjfo3g1WEQ5hqYOiyhpqZ6VeIBfeejvGqySJc7HlkgBH7dNJ1PXfGpF87G1upqB
+        5dybLOUWu1UDm4RW4EzTrcE1Gel2OttJfO3c/xVYn4MlYnxOJp1xZDshwrqVpU8KB9hK9jjX5Wkm
+        FPu/eLAalOoJXbg7a8b1xa+tDojrOr5ImhZr2OU18Jz7pO+TIryFi7zpLgW+wY5LeRDJlgpV52h2
+        RC8sHreahzLbTMpjvIkjTBPM191y2qm94bTmKh7m43DMGndEcynDKe2AgHpyMpvWEqXUAsptxUi7
+        hhIOiMSbeMeXUgYkJ4Rp9o/YCdjDKGi4ZjGViLu+JRbEHgzvBxPs3mLh0qCVkUmH91J7TrZbCk2E
+        8Nhz4adk6GRU30UE9gAuPQe1zuhxerCBPris2zY7svDygI5MtYyMWhmV1RKq0nIZfuRFUVFKSKF/
+        yhVImVW9xLgjdxjyFsKOTrzfFv5JvV8XIEKrnxlB5c91+b9Y/nopL0fU1fqcCMvuuJYDIyTXZQVV
+        0Hs+1gBWDsWYHL47JodCTA7fE5MwcsaD+fNyIS5tqbdo3wYd5+akf/ljjsyL0RKRT/rvrH3RQy1a
+        /e7aP//+HuF4g+gKUCC3ohB/4knnVwSC++0OLUjyZ9VdnUi55G5CIhyyShH/88ZdXkAtRMhbQXFy
+        /GlWTyw4tHtHouDQdqzAD/1RJB3Grksix9suTrR7K4//VypyIkO7Z5qyaZpArihytWa+IwIfev2m
+        aHZk9X+ZRdeUDjCYxkN36VjvuthdSih1F4TsLKDYF6Fh5BDXXgPiQX/cTwrqoiCEhB762G+395vN
+        NZXT4WWXRo20RLLiOFqU5pUMMFb61u2SjbuIXUYvNZeIdmkrLjn0NxCeMkuZP0rOBW6Kr4NJ7EbO
+        IsrO73IGq59jHEmnvkWf7qTnoyW2uUqnTHa8k+PquCtffNpIrXLUTTJ0sLeRXOPIe76LA1gDb6LX
+        OfojYvsB3khe4cgbP59IeBiHJGs0uMafQcW+v3GsKs9q3GttJK5xxPWTzZCZHO1HxwOFhdKBtB60
+        5wpR+A5Lh0GT09E8o+3zrjQNfDCbyZyA19FRQMhhr7nZAngtXQxjL4o30/Na6rnYuqZpzeYuvKba
+        9IUSfP1ED1596UHnkeMSCVtWskJmVLzWGqDkD73No/KKOzrvZtUCHWUGryxxbsENnvAQtOQingOU
+        /khKT4RnRLyO2k5olbOGJY8RnCJnRPrSLdgGvXThOXf8/nxyRlroIGB+n3q9jGbJT+j57cD3I0j9
+        KeQs8DAqHuizbiOrrgmN+yIkgTTBHh6TCWGPFRixueyR6XFrFid4lLNN1HkQ4RHtEhLI575M/0pH
+        1CB6VxBWvOy9JI1HtnHSa3zIGnhkj5yA3GLXnd+CR/QQLNr2/bnHaTyKvUa9Wc8aeOianQxRjccK
+        oHDBXqUw0eV8TB64LnurTFo8OsqIzFXVYCm8Iq67qh1dWbKaCKLJeB5Sl9BbeSeCEfCI0TfakjVK
+        csZ9CTNvDJgvxVh9KRR02plD6TxknZMMGd1YDQPOzeYIr/NY9tss0LR6mz1Q57E9DGIaOfwA/Ajy
+        BsyR8ej+J/b8zVNTZQljywG7pq9dSaeOF99t7slroO0PqdE2CW8NFV4FHwJsAcUW4/LaqU/wV8j/
+        tujFq6yLXV+qu9HmqbHCa/M4xrfE2UzPq/mokr0m+QS+1TUM+u3NPXg9n3iWY4NO6BsnU98LMxOu
+        8FruO0EU+1+/bhbXUJYc4rZH396TGj/3Tjd3Q4+vt6DdlBFuu8zZU2afEaTzSU6vlIzH4t6XL+EP
+        Mv3ZW20q/rRXYg3P7JWzfPpE/5XYr8x+V1ZSiqK8xeo/fZlm/Z3IXDTbHOnfY/mUsy2S4rGjWyJ+
+        HE1j0a5UyvaHrP2ljEfkLir50RVMcbT4Ppsaqblus9RPxPw7r/VTsJiQuQCdJ61bbUa6NJqzoWg2
+        9SrbkZBflemPiMGketv9qQdUqjwuIu+iLgvUT1HlBOaaUqpB8JVrSk15RkzOTmxSbT8TjsCPfMt3
+        RZAsmrbbPbamcBXb9NexJtPXUBk/VQhYPCMWDiPpX3RpRaZiBQo4TajZg/5kBCi+3bkUmpDAQlPA
+        ftryl9kaDQkZYDf0haISSGVZ065NXhueX258dJm3wQfZ7ojKeerTYyzt5FX8UuGYvohfKjSy1/Df
+        xOC497nXZFk07dImK8/8vedPQ0f0MLG3aNpR5mMvzF5mpydfbohns9PXq5JcLOjo2Zd+RvddHtBF
+        sJK7drxxeeQEYTQY+bEnWtosv7B5RGlhmUXEpvSXyG/mwLCPuGyHyyn+y8OybvY306Cc9w7LMjzd
+        wPHZuvwM0x0waa/fPSs+a97LXmf5jm/vsA8+bLEgWBH9b7MumPsN/TzR08D0olw01oNfh9D59Mi5
+        Y4lb3YqcG8IyuDAORth6nRwuwuNyr/mLBNoiYz8QJgXLzS948kdHuMFuTFQTWllppZbfzZxX14TE
+        NSExMkTEyBASa0hErCHxyBXhyBXxyLpwZF0soJBYFRNrQjQ0MRqaEA1NjIZaFbJRFY8sJNbExKoQ
+        Z1WMs1C+HPEUIROKmAkhsSomFtqn2DxFlEJCoS7EqhAahNgekFARSKwIXRMOrIkBU4WAqWI2hOgi
+        Mbqa0JU0sSvpwpF18ci6kGddzLMqZEMVsyEGQ4yFEGWUg7LQLNQcFxWOrIpH1oVep4u9TjiweFwk
+        tE6UE67EA+eMLHQ7JPY7TagRLUclQiyQGAuhWYitQuh8Yt9DQn6RmF9NiIQmRgIJQybUrj/6CUkk
+        X7GPKKUlz4+elyTYtVFtNDSIXEUjS9YtxZRNS1Vla6ibxCZ2RdcrguRhy24vSCrYF16ZxAOzyseK
+        lYa3AQOZWKkqsm5XVZDKUOWhPtJkG6lWTSNYt1koXwdjq27fBkatoorBoA1vAQa9hUDYtPqFwqyI
+        8CaMK5ZqYYINmSjKUNaHIyzX8NCQFWtYqVZ0wxpZhkCwLbt9mxYNI0eLtOEtwECjGtINuwKymNRR
+        NUXGuqHJlkV0Q0UjUzdE/r1lt5eCwb6MnAhu30ODY62iIqB4C3gsu0ZwDQTTKgbIiVRDNjH9KCCp
+        VlWEVQXppgCeLbt9Y/gzc6Kf+UpQXNJvZ0ck/chjQOjnVtnqPqQce/FkYN2Q5FvR9CL9ICRKrjJy
+        Yi9TOZMptmhtSq6sjvz58vHx/1+kJ0jxWwAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:50:35 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 013196d4c94ce3d49042f459f66fa559
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYmLZxuD8s0eAbHIbGDYkzOzNZClhC+KLsVk/8piQ734t
+        2QYBMiGZJMPuTtUQWWrJ3b9+qCXLfig43sgvHDwU/FuPBIWDAvbsgNz+O7Svy34wLpQKHp4QqI9I
+        GA1CC3uDkXMXxQGhTf4gwsGYRIWDEXZDUiqMfNcmwcCxCwde7LqlguV7UeC7hYMoiKE9DqF1SoKJ
+        E4aO74WFA6TWSoXQuiJ27JJBHNOucLPJ1MURke2aUlFsjGQbq0iumqgio6qpy7qmmVW9YtgWUbBh
+        jqpoVCWKUcW2ZQNjxHaiAXZd/5bYc94o8yDjIBXooic1XD+2pV5SD92mvutY99B2iEPHkjokuvWD
+        a0YAreEVDshcMH/4P2JFTFJVRaVChMcpGGFGgi0Xyp8fCksCK6UM64TKdkKQ9T5lK6njywsso/sp
+        ZdwmIxy7UeGxtDIygzIdG60OnKvYtXom0vxuVGOFx8tS4coPI8uPvYgNnipqpKoVQzewPNQUVdZV
+        1ZLNWtWESxVVawgpI8Wi0EU4ioHDAiBpEZdQHTFbSm8yDQsUwRS9tKSWp/GQFssR8fDQJSGx4sCJ
+        7suWPwF67EYZ4gPgcqHoqeXIMLgcT10fL+t/AJwEVIJKVdcqCGk63NeZgG3jyXRerWu1lJx49nLt
+        FQ6vh5k1wwWOwdSiADtzE8/MLL1Torqsko1Hqx6htxNGfnDPLCQtM3MC1AzNVI1Ul4NUH1ZAcASK
+        HtjgGMsSuBh8c+LbzsixBDSM8ecpjNeLWHmJwwbMnnM0kVlN4gQ4DEmUCUOrs3LKmWpXTa1qqrJh
+        qLas16pEHqrKSCYatoBrHdkqKiQ9s5C0lZlMA38ckJAKgBRFhv/7KvyF/6kRZgTQKyDMvBVluSXy
+        I+ym9V48Admt6xAiW+hAsKPishZGldMWkhtCeUod6KHgQIhjsKQ1tQWNC3/hbgr177RVWWtFG1vV
+        ja3axlb98fJxUZlwZvkQ72kpmS2gAKGVdZ5AqI0nrHjljK9YwYKOYIhuUss07dnkjooEFnETu2DV
+        eOi4QEVCHgQwhqkbjx0v9QMVmfOaVOcdUEccSr3fOlI4j9sLZpU5/QhPHJfG8q4fRBktNWd6/4wh
+        HsXlm6uqaeirN++R4MaxiNQkEcR+8LOn7p11sLkO/P15PaFl4RWE1u5/0mh3pfMsXEln5I8YivB3
+        4kfAFaY/Tmi5fpjMzxt5+5lQNbgrHGn5HKlKRVvl6Bi0Kx1BPLuXfo2xCwGI2FLTn2DHkzpAIu0d
+        /drsFIHF0HfjbSATs6XnsqVWVFVZZeu80d0/4aACg4mnUzCEJHg9//6V3PvrGkJoDZbz867UJtGV
+        b4dSPclDpD2YrCXbCcASINQXn2LkIxlK1H7WrdagbgTBbZoF1/TSdWiATq5HjhvRntS7UqYoddmh
+        AMBMYtNImbFbp6FZOmkWuHztIZsDICTCJEU7jenNC58V2cTy6PKh9ijvzS/0R7n4oD3Or5H6uFfa
+        mrT4A89VdicFqRrkeFUZDy1bJiMFybRCNqo1k1bRGsiCCj4AiwFTKm2B/EFTG/Y7wZF1Ra+SAqAy
+        Dvx4mknNB6J7lk2lDYkmyhjmdWcYQ+JbHgphO4zHMPP/sS1wv1OJL39MYLn8USxz56J92DpjzN+5
+        xBtHEFJR7V2EJHeQL0HePAqAgia+AwiaNzgUSN6od/r1ntRKekhHWQ8hDnbgT21IZaDRhTSH8k8z
+        JbhkWULhMle6bxAmYX0wxdY1HpN8Ebpzgq0YT3pBRVNNhacDwPXHK5jRB13wMfDKANKlN5HqLiCj
+        g0br7FxuNEQyQYtUt2+cEALM1mbZqMuJRcqZga7WFH/4p8hWgew3+CefNKU9hxxIcA1ZlSYrteL7
+        uOUcjjws+vxYL/ZTsfAE0or+hQQsQJ4HcTfBALI9DRV3xX/9QGj6H85aO+27UyHX3dZW6isL4+p5
+        69P5+xildUPKAb4VSdDfToLf94ByBqGmKO8h0zRnqvJZQZfMHIuJSz7oJZhft6PLM+B+C9wVVej6
+        zyilVwasj2DKfS+kwnAwxCEZhHmW2u/1pEOgkHopxfbu++VLOXXgn4TyV8uVNTEhZwLSMft9FUum
+        EtLNLB9Sys1SnqdU3ySpUFC9rL6zoDcsxc31Al7aPiPdcqKCnuo/Wgd7F7Puh8bsaHY86zSL+2en
+        B3sfjmbns4+zi6SiASSN2cXZrEGvmZ+8qGcxx3VaB8clqXVwtAbrK/vG0zg+H756/2DvdFafdYr7
+        dZD2eNaenUIxPtjrzHqzdnG/QUvdWaO4fzIv1bPSHMtvGyYPWBi1U5Lgt/7G0GpbxJ0braz82YOP
+        tmX0YbL++UOQ9pwYtCzzcz3pAHrvJxGFxZNPaThJo8mnJJhALJmdwUXqN8/r9J3Dj7Ythi+CjgaQ
+        DgSQ01k3CSGns+PifveM1rLiBYsbZ8X9HsWrwSLKMTR1WERJS/WsxAP8ykN/12CVLHE+tkQK+Lht
+        Opm65lMrmo+t1dUMLOfeZCm32K0a2CS0Ameabg2uyUi309lO4mvn/q/A+hwsEeNzMumMI9sJEdat
+        LH2kOMBWsse5Lk8zodj/xYPVoFRP6MLdWTOuL35tdUBc1/FF0rRYwy6vgefcJ32fFOEtXORNdynw
+        DXZcyoNItlSoOkezI3ph8bjVPJTZZlIe400cYZpgvu6W007tDac1V/EwH4dj1rgjmksZTmkHBNST
+        k9m0liilFlBuK0baNZRwQCTexDu+lDIgOSFMs3/ETsAeRkHDNYupRNz1LbEg9mB4P5hg9xYLlwat
+        jEw6vJfac7LdUmgihMeeCz8lQyej+i4isAdw6YGpdUaP04MN9MFl3bbZkYWXB3RkqmVk1MqorJZQ
+        lZbL8CMviopSQgr9U65AyqzqJcYducOQtxB2dOL9tvBP6v26ABFa/cwIKn+uy//F8tdLeTmirtbn
+        RFh2x7UcGCG5Liuogt7zsQawcijG5PDdMTkUYnL4npiEkTMezJ+XC3FpS71F+zboODcn/csfc2Re
+        jJaIfNJ/Z+2LHmrR6nfX/vn39wjHG0RXgAK5FYX4E086vyIQ3G93aEGSP6vu6kTKJXcTEuGQVYr4
+        nzfu8gJqIULeCoqT40+zemLBod07EgWHtmMFfuiPIukwdl0SOd52caLdW3n8v1KRExnaPdOUTdME
+        ckWRqzXzHRH40Os3RbMjq//LLLqmdIDBNB66S8d618XuUkKpuyBkZwHFvggNI4e49hoQD/rjflJQ
+        FwUhJPTQx367vd9srqmcDi+7NGqkJZIVx9GiNK9kgLHSt26XbNxF7DJ6qblEtEtbccmhv4HwlFnK
+        /FFyLnBTfB1MYjdyFlF2fpczWP0c40g69S36dCc9Hy2xzVU6ZbLjnRxXx1354tNGapWjbpKhg72N
+        5BpH3vNdHMAaeBO9ztEfEdsP8EbyCkfe+PlEwsM4JFmjwTX+DCr2/Y1jVXlW415rI3GNI66fbIbM
+        5Gg/Oh4oLJQOpPWgPVeIwndYOgyanI7mGW2fd6Vp4IPZTOYEvI6OAkIOe83NFsBr6WIYe1G8mZ7X
+        Us/F1jVNazZ34TXVpm+e4OsnevDqSw86jxyXSNiykhUyo+K11gAlf+htHpVX3NF5N6sW6CgzeGWJ
+        cwtu8ISHoCUX8Ryg9EdSeiI8I+J11HZCq5w1LHmM4BQ5I9KXbsE26KULz7nj9+eTM9JCBwHz+9Tr
+        ZTRLfkLPbwe+H0HqTyFngYdR8UCfdRtZdU1o3BchCaQJ9vCYTAh7rMCIzWWPTI9bszjBo5xtos6D
+        CI9ol5BAPvdl+lc6ogbRu4Kw4mUvMGk8so2TXuND1sAje+QE5Ba77vwWPKKHYNG27889TuNR7DXq
+        zXrWwEPX7GSIajxWAIUL9iqFiS7nY/LAddnrZ9Li0VFGZK6qBkvhFXHdVe3oypLVRBBNxvOQuoTe
+        yjsRjIBHjL76lqxRkjPuS5h5Y8B8KcbqS6Gg084cSuch65xkyOjGahhwbjZHeJ3Hst9mgabV2+yB
+        Oo/tYRDTyOEH4EeQN2COjEf3P7Hnb56aKksYWw7YNX3tSjp1vPhuc09eA21/SI22SXhrqPAq+BBg
+        Cyi2GJfXTn2Cv0L+t0UvXmVd7PpS3Y02T40VXpvHMb4lzmZ6Xs1Hlex9yifwra5h0G9v7sHr+cSz
+        HBt0Qt84mfpemJlwhddy3wmi2P/6dbO4hrLkELc9+kKf1Pi5d7q5G3p8vQXtpoxw22XOnjL7jCCd
+        T3J6pWQ8Fve+fAl/kOnP3mpT8ae9Emt4Zq+c5dMn+q/EfmX2u7KSUhTlLVb/6cs06+9E5qLZ5kj/
+        HsunnG2RFI8d3RLx42gai3alUrY/ZO0vZTwid1HJj65giqPF99nUSM11m6V+Iubfea2fgsWEzAXo
+        PGndajPSpdGcDUWzqVfZjoT8qkx/RAwm1dvuTz2gUuVxEXkXdVmgfooqJzDXlFINgq9cU2rKM2Jy
+        dmKTavuZcAR+5Fu+K4Jk0bTd7rE1havYpr+ONZm+hsr4qULA4hmxcBhJ/6JLKzIVK1DAaULNHvQn
+        I0Dx7c6l0IQEFpoC9tOWv8zWaEjIALuhLxSVQCrLmnZt8trw/HLjo8u8DT7IdkdUzlOfHmNpJ6/i
+        lwrH9EX8UqGRvYb/JgbHvc+9JsuiaZc2WXnm7z1/Gjqih4m9RdOOMh97YfYyOz35ckM8m52+XpXk
+        YkFHz770M7rv8oAugpXcteONyyMnCKPByI890dJm+YXNI0oLyywiNqW/RH4zB4Z9xGU7XE7xXx6W
+        dbO/mQblvHdYluHpBo7P1uVnmO6ASXv97lnxWfNe9jrLd3x7h33wYYsFwYrof5t1wdxv6OeJngam
+        F+WisR78OoTOp0fOHUvc6lbk3BCWwYVxMMLW6+RwER6Xe81fJNAWGfuBMClYbn7Bkz86wg12Y6Ka
+        0MpKK7X8bua8uiYkrgmJkSEiRoaQWEMiYg2JR64IR66IR9aFI+tiAYXEqphYE6KhidHQhGhoYjTU
+        qpCNqnhkIbEmJlaFOKtinIXy5YinCJlQxEwIiVUxsdA+xeYpohQSCnUhVoXQIMT2gISKQGJF6Jpw
+        YE0MmCoETBWzIUQXidHVhK6kiV1JF46si0fWhTzrYp5VIRuqmA0xGGIshCijHJSFZqHmuKhwZFU8
+        si70Ol3sdcKBxeMioXWinHAlHjhnZKHbIbHfaUKNaDkqEWKBxFgIzUJsFULnE/seEvKLxPxqQiQ0
+        MRJIGDKhdv3RT0gi+Yp9RCkteX70vCTBro1qo6FB5CoaWbJuKaZsWqoqW0PdJDaxK7peESQPW3Z7
+        QVLBPgXLJB6YVT5WrDS8DRjIxEpVkXW7qoJUhioP9ZEm20i1ahrBus1C+ToYW3X7NjBqFVUMBm14
+        CzDoLQTCptUvFGZFhDdhXLFUCxNsyERRhrI+HGG5hoeGrFjDSrWiG9bIMgSCbdnt27RoGDlapA1v
+        AQYa1ZBu2BWQxaSOqiky1g1NtiyiGyoamboh8u8tu70UDPYJ5URw+x4aHGsVFQHFW8Bj2TWCayCY
+        VjFATqQasonpRwFJtaoirCpINwXwbNntG8OfmRP9zFeC4pJ+ZDsi6UceA0I/t8pW9yHl2IsnA+uG
+        JB+VphfpByFRcpWRE3uZyplMsUVrU3JldeTPl4+P/wcEWwKSGlwAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:50:46 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - cb0148d1d9c28baaeeba751a49f14c50
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd/history/11063926
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAz1QSXKDMBD8i84WpX3xyT+hhtHgkACmQCrHlcrfIwjJrae7p2f5Yo/nTGs7JHZV
+        F7bhG6UyUlvKzrBM0zJCJp6CsCKB5AmU5D5Ky6WPhhutozfWJSQBLvZe9p6E85AwsZqXIZetBiHM
+        SCMdXMVtFdbMrtJ6o62U2lzORc7B5C0mDMQ7FYAb0J6HiIo7tI6CttEKYGdPtcOcVnretvTRPNZ7
+        FWr8nfI++RepZindDptMM3QjbYRlHfKrwce0B3XvhPl4g5TC6ajchZ279EpZZxzwTgvFjVLIY/Cx
+        lkr6UO29wL+7aE7/VxkdTja/FqpBy1ZtM0x0fHbL7SH2w2cuK7HvH6tCiweMAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:50:46 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - ''
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 85e926361eb75579325fd3d06913799b
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-d8050da1-da21-7915-1794-43397456dce0a69f71f7e067adcd/hosts/2
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9WUXWvbMBSG/4rQVQuJZyl2WXw3Grr1oiZdDWOUEhTrJBHow7WkbCHkv++4uGma
+        3HRjg+7G+jrveXl8dLSlyi4cLbbUiHoopGzBe1rYqPWArpwPw8WjtLSgQbRLCDxp4rybJgGsmGvw
+        UMdWhU1SO0N7hWowfpQn7IInnOGYjfHINdCKoOxy6Dc+gDk0mYGVqKlWkZRuTTgjLC+yj0WWEZ6y
+        cZ945tE5nMblxaiP2w3oOmqLRnOlVVCAKPdbWrtoUcf7NEru51YYeDNco+NS2dlCGKU3qJq6NhBf
+        C4uG/uW8S88YZ+P9Tu9S4q+Nntx9L59VKPKwhs6DFunLYqashJ9PWx3Pfrkb/DOYO2jXqgYiIUAd
+        lLOvgTgfX2THQM+ayYHmT3nYX+b5DN010EdlSRk7obi+vJmSShnA62Ua8hUeI05xNC4gm+g+ytfa
+        +djCuyfkaT46JvyCVuQKu21DbqPQaqFAkokzQllSYgg5u7qdlOeI7J2O/0Mhec55eoxZXU4/XB+U
+        ElstNg02Kch3xPMN5qRrnJM3Ixsxxk5KV1VTcgNh5aQnn7R2P7B0Z/iUEqlabDrXbs5/G+5hgHCm
+        0UrYGk3uH3a/AH6eUKwHBgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 15:50:46 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-d-ca-central-1-prod
+      X-Request-Uuid:
+      - 54352cb5ff2b835c82eb0ad26b36c50b
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/api/cassettes/test_scans_copy.yaml
+++ b/tests/integration/api/cassettes/test_scans_copy.yaml
@@ -11,7 +11,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -19,48 +19,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -71,11 +77,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:16 GMT
+      - Thu, 21 Nov 2019 15:14:18 GMT
       Expires:
       - '0'
       Pragma:
@@ -83,8 +89,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -94,9 +100,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 82aa20f46b65971f4b6ed88b1ecbcff7
+      - f28d3996c93710ec222b180734326187
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -104,7 +110,7 @@ interactions:
       message: OK
 - request:
     body: '{"uuid": "731a8e52-3ea6-a291-ec0a-d2ff0619c19d7bd788d6be818b65", "settings":
-      {"name": "test_scan_9690", "enabled": false, "text_targets": "fakehost.tenable.com",
+      {"name": "test_scan_fixture", "enabled": false, "text_targets": "fakehost.tenable.com",
       "acls": [], "asset_lists": []}}'
     headers:
       Accept:
@@ -114,13 +120,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '208'
+      - '196'
       Content-Type:
       - application/json
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -128,14 +134,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VS247jIAz9F55LlRsJ6dP+SWTAyaAlIeKiqjuaf1+TNh2ttMND5GD7+JxjPlnU
-        sLHbJ9N+S2A3DJM17MY6USulB8lH1Wje6bnlqgLB296gGdtBSWHYhfl76cj56MFBaKMlctVI4B20
-        A5ejbnivRY+yFaOogHpe1QnX3UFC3si+U6qjAJTiXTtLDmKeuVKVHJSBRrRGtMOohVQ1yA5rbAhm
-        gxUPmJimImIa+7Gie4NRB7sn60nXlp27sN07qx+HsKa6HJJPoc+C8+ZFrXod/p/PT6em0biCdfEN
-        ulLIyvUGyiEBz+AiEkOIH8pDMNNsHZ7ldtMuG5xgWQIuZAy7pZDxSW5KdsXpbjfj72eDzjH5dUoQ
-        Fkxl1DNqrntWJbym5+CIOgebHlftV2ITKZcK3IkTQqai869k/vjtnd18srPVUPwsfBOGb4UfEIou
-        8jRHsm/HsNoYqZJK6kaWZcyQXfo3U73eDVGGzQS8/4rm99WH5f2gjk1dmAPa7erNNwFz+FKLvm2a
-        cRx7ciHgT6n02MsLITto/YR9oNZfX38B9MPgZfUCAAA=
+        H4sIAAAAAAAAA3VS227jIBD9F55D5AuOcZ72T6wxjB1UDBYXZduq/97BiVOttOXBspiZcxs+WVTg
+        2PWTKe8SGIdhNJpdmejqaVK95MPUKC7U3PKpgo63F416aPtJdpqdmL+XiZz3Gew7pZVEPjUSuIC2
+        53JQDb+o7oKy7YauApp5didcNwsJuZihb3YqXVVcED7XrdB8rnu4SGzkIFs5zUKLGnFoxSB0oXaw
+        4g4T01hMjLP5m3JAKmmMKpgtGU/WXLb2xDZvjXrfvdXDcNptH2YfHcfNU171PPw/n99OTdy4grHx
+        BbrSLyvXDiaLBDyDjUgSId4mD0GTbItHu3HKZo0jLEvAhcJh1xQyPsSNyaw43o3T/n4MqByTX8cE
+        YcFUqGZ4w5uP6ZwejGflV6KP1JHK/DEYQrb4klkqH969qs4nMxsFJcEiMGH4sXSDUIxUtMlIeW0Y
+        VhMjdVJL3cgS/wzZpn8r1fOxkEZwOuD9T9RvZx+W1ysqsTcnZoEWunr9I0DvQdRdL2j5TUfbUwF/
+        K6X3rTyLLU+0cMLeUavq6+sbwiBHi+sCAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -146,7 +152,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:16 GMT
+      - Thu, 21 Nov 2019 15:14:19 GMT
       Expires:
       - '0'
       Pragma:
@@ -154,8 +160,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -167,9 +173,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 202cfd9fcb1ac96f8497a8832ede20b1
+      - 180e55e942c97b06cfe27e72bbc28829
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -191,19 +197,19 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/21/copy
+    uri: https://cloud.tenable.com/scans/template-4fa72c78-9d00-4ded-d34d-f17a68e289838bf4d41ee93494dd/copy
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WQS27EIBBErzLqNY4wjD94FSkHsTA0CQoGqwGNJlHuHhwpn03WVV31ut6h+B3f
-        UkRYYg2BAUa9BbSwOB0yMgg6l3VP1jtvdPEprlaX5u6HUQqhlBoZ+GYXkkEuutQMC+B+lDswqBlp
-        PZB2n3M7bVIvZgbpFpGaTUdLeHvM9vUh0TN8BVA5ib5pTIqFUoClUG0wtZ5VMFnrOL/K7jpw2ym0
-        Q6e4dN2o58m4jeMslDFSKL71/eR6hdK1dKIaMP9EE/73T1N+B8gvmv7sEfVJB0/puF+SuxRs82Sj
-        46pGxeHjEy3eqPVRAQAA
+        H4sIAAAAAAAAA3WQzW7DIBCEXyXaM65sAnbwKVIfxAKztKgYrAWUplXfvbhSfy49z+zMt/MOxW/4
+        liLCHGsIDDBqE9DC7HTIyCDoXJYtWe/8qotPcbG6NPcgJ3EWikvFwDc77zmDXHSpGWbAbS93YFAz
+        0rIjbT7ndtukgV8YpFtEajYdLeHtmu3LQ6In+AqgciB946wpFkoB5kK10dR6dMEgJU4WTSedVJ3q
+        zdStWupuvPR8FEYY6y5SrGJQE1dnMwo5DS2dqAbMP9GE/z3UlN8F8rOmP4NEfdDBY9rvp+ROBds+
+        edVxcf61VEL4+AQOr6ghVQEAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -214,7 +220,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:17 GMT
+      - Thu, 21 Nov 2019 15:14:19 GMT
       Expires:
       - '0'
       Pragma:
@@ -222,8 +228,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -235,9 +241,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - bda71f4651f28c223cfecc083c047ff7
+      - 16f2360a8eb4e842b357e32018e624fd
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -255,21 +261,21 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/21
+    uri: https://cloud.tenable.com/scans/template-4fa72c78-9d00-4ded-d34d-f17a68e289838bf4d41ee93494dd
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRyW7CMBD9FTTnpCJhCzlV7b0X1BNC0TiegIuJkT0WihD/3klYuqm30ZvlLXMG
-        0zYOyjO4U0seSsBWezo9B71/cn4LCbR4IMGZAlehxrZazpfjHncVo98SQ9mgDZRA46wmXxkNZRut
-        TaB2LXtnoWQfpR+DdI/kDyYE49oAZZYXCYR6RzpaqmLsV4XpcLTIlObFfKrUVApUKp1OmiLFWdOk
-        So2LhdKYzyZ6Nlks61mhMiymlFEuwkgbrtBadyJ9p+6Fi7/qZuZ9NXq1LurR6orL1tFZU3fSe8Fg
-        6tEb8cn5/TAg3bBDTw9fTn1QzYPRPEuAcXuLItwnsLZSr8/ww+44ucd8ndImiNPupuqKfa+/kuTu
-        2OvW1GC0DJfk1+UhyNvt7Pfhf3/6Bx8cPdj6f8FlI+4ZOQoLyGe4E3bYmcDOS1zrzeUTogRwKEQC
-        AAA=
+        H4sIAAAAAAAAA3VRS2/CMAz+K8jndiqlGm1P03bfBe2EUBVqFzJCUyWOugrx3+dCYS/tZvmz/T18
+        At02FsoT2L4lByWoFh31Tx4PD9btIIJWHUn6TJ4rX6u2avQHB0cjZCtWbkcMZaOMpwgaa5BcpRHK
+        NhgTQW1bdtZAyS4IHrygHbmj9l7b1kM5T/MIfL0nDIaqEMZVITt2RjHFWaOWab3M4wKTJM6QMMZF
+        hnEzX6rHnNK8yBf5tskwmxMVi6zIEEUYoeZKGWN7whv1qF0sVpOft9XsxdiAs9W1L1udNboeBHtW
+        XtezV+LeusNlQFC/V47uvuz2nWq+GE2TJAJWuykLfxtRtZF6fYIffmV2ivo6hdqL1WGSde19r7+i
+        5KEbhSM1KhiGc/Tr8iXJ6fb89+F///qnf7F0ZxsfBueN2GfFQVhAXsODsMNee7ZO8lpvzp9xes7v
+        SAIAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -280,12 +286,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:18 GMT
+      - Thu, 21 Nov 2019 15:14:20 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -295,9 +301,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 0025ae92b8991f21b5ea95461e410281
+      - 54913c0741df4511f21c425592d3264d
     status:
       code: 200
       message: OK

--- a/tests/integration/api/cassettes/test_scans_create.yaml
+++ b/tests/integration/api/cassettes/test_scans_create.yaml
@@ -8,10 +8,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -19,48 +17,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -71,11 +75,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:17 GMT
+      - Thu, 21 Nov 2019 15:14:16 GMT
       Expires:
       - '0'
       Pragma:
@@ -83,8 +87,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -94,9 +98,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - c16cc0261fee7f670a6c3134c87fad75
+      - 0d3a4ee440b4810522a454a548963bc6
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -104,7 +108,7 @@ interactions:
       message: OK
 - request:
     body: '{"uuid": "731a8e52-3ea6-a291-ec0a-d2ff0619c19d7bd788d6be818b65", "settings":
-      {"name": "test_scan_7539", "enabled": false, "text_targets": "fakehost.tenable.com",
+      {"name": "test_scan_fixture", "enabled": false, "text_targets": "fakehost.tenable.com",
       "acls": [], "asset_lists": []}}'
     headers:
       Accept:
@@ -114,13 +118,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '208'
+      - '196'
       Content-Type:
       - application/json
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -128,14 +132,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VS247jIAz9F55LlZCQS5/2TyIDTgYtgQiIqu5o/n1N2nS00g4PEbGPj8+x+WRJ
-        g2e3T6aDz2A9xskadmOtrJXS/cBHJTRv9dxwVYHkTWfQjE2vBmnYhYV7qdj3owZ7qY0ekCsxAG+h
-        6fkwasE7LTscGjnKCqjmhc64bg4y8qqrBwAx875RyOUwA8eh7TmCqJUQqu2gFUZ1DYzYNgSsVE00
-        HlY8aFKeiompl81IcYNJR7tlG8iX3527sC04qx+HMdFeDsun0SfgjLykVa/D//P56RRJuIJ16U26
-        0pWVsAflkIhncAlJIaQPFSCaabYOT7j12u0GJ1iWiAsNht1y3PEpbsp2xeluvQn3s0DvKYd1yhAX
-        zKXV8yau267K9ZqfjRPqPdr8uOqwkppEuVzoTp4YdwKdfyXzJ/h31odsZ6uhzLPozRi/HX5ALL4q
-        Wmqi8W0YV5sSIQlSi6EsY4bd5X8z1evdkGTwJuL9VzK/ryEu7wd1bOrCHNBu12C+BZhjLrXsGiHG
-        caQOOuJPqfzYyguhcdD6iftglV9ffwGCEMGM9QIAAA==
+        H4sIAAAAAAAAA3VSy27kIBD8F87DyDbGjzntn1gNtD0oGCzAmk2i/HsazyNaacPBsuiq7qpqPlnS
+        4Nnlk+ngM1iPcbKGXVgra6V0P/BRNZq3ehZcVSC56AyaUfRqkIadWLgVxr4fHOylNnpArpoBeAui
+        58OoG95p2eEg5CgrIM4DnXHdHGTkpgMD0PV8bgWBe40cJCBvUXe1UI3QxBuaYQahwHT9MFdltIcV
+        jzYpT8XENNu/eY9IJYNJR7tlG8ia3507sS04q98Pb/UoT4ftp9k74nnzkFc9Dv/P57dT02xcwbr0
+        arrSLyvXHpRDajyDS0gSIV1VgGhItsMn3HrtdoMTLEvEhcJhlxx3vIubsl1xullvwu1J0HvKYZ0y
+        xAVzGTXDG15Dyud8n3jWYaXxiRC58J/EGHeHL5ml8hH8q+pDtrPVUBIsAjPGH0tXiMVIRZtMlNeG
+        cbUpEZIgdTOU+GfYXf63Uj0eC2kEbyLe/iTzdg5xeb2iEntzYg5ooWswPwLMEUQt+1a0YyN7sh3x
+        t1J+38qz2HZFC6fe9413X1/f25EF3usCAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -146,7 +150,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:18 GMT
+      - Thu, 21 Nov 2019 15:14:17 GMT
       Expires:
       - '0'
       Pragma:
@@ -154,8 +158,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -167,9 +171,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 145cc09d0bee9ba8823353d97d04854e
+      - f6868ace00a81e384d1eaf8ed77a7cdd
       X-Xss-Protection:
       - 1; mode=block
     status:

--- a/tests/integration/api/cassettes/test_scans_create_schedule_uuid.yaml
+++ b/tests/integration/api/cassettes/test_scans_create_schedule_uuid.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
       User-Agent:
       - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
@@ -81,7 +79,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 21 Nov 2019 15:14:23 GMT
+      - Thu, 21 Nov 2019 18:21:47 GMT
       Expires:
       - '0'
       Pragma:
@@ -102,7 +100,7 @@ interactions:
       X-Gateway-Site-ID:
       - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 3555e6700381c10f97d2b32d2fd510b7
+      - e12a62556cc2145c0cce0d65a08cb8e4
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -134,14 +132,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VSy47kIAz8F85NKy8SMqf9k8iA6UZDIAKi3tnR/Pua9GO00g6HKMJV5SqbT5Y1
-        BPb2yXQMBVzAtDjD3tggWqX0JPmsOs0HbXuuGhC8Hw2auZ+UFIadWLxVxr4fHJyENloiV50EPkA/
-        cTnrjo9ajCh7MYsGiPNAF1w3DwW57efWiFZyO1jNjWgs7+SouTCyGYeukSCUEbMdpo4cSDXLvsoE
-        WPGQyWWpIRbrfpc9IZUMZp3cVlykaGH3/sS26J3+OLKR4umI/Qx7RzxvHvaax+H/+fx0WuqNKzif
-        X6Ir/bJ6HUB5JGELPiNZhHxVEZIh2x6fcBe03w0ucLkkvNBw2FtJO97NLcWtuNxcMPH2JOg9l7gu
-        BdIFS21l4R2vMZdzuXc867hS+0yIUvlPYkq7x5fNWvkTw6saYnHWaagTrAYLpu9IV0g1SEObzDSv
-        DdPqciYkQdpO1vFb2H35t9I8Hgt5hGAS3n5l836O6fJ6RcduTswDLXSN5tuAOQbRimnoh7kbB4qd
-        8KdS+djqs9h2RQsn7fvG56+vv3Qms+LrAgAA
+        H4sIAAAAAAAAA3VS247jIAz9F55LlZKQS5/2TyIDToqGQARE3ZnR/PuYtOlopR0eEMLn2OfY/mRJ
+        g2fXT6aDz2A9xtEadmWNvCilu54PSmje6KnmqgLJ69agGepO9dKwEwv3wti2nYOd1Eb3yJXogTdQ
+        d7wftOCtli32tRxkBcR5ojMuq4OMvFFaDe3QcTEMhWsEr6WpuRTQGtnqrtGgQYIchOhFPxmSRWk8
+        LLinSXksJsbJ/s1bRAoZTDraNdtA1vzm3ImtwVn9vnsTQpx224fZB+L4ecqrnof/5/rtXKg2LmBd
+        eiVd6MnKtwflkBJP4BKSREg3FSAaku3wgFuv3WZwhHmOOFNz2DXHDR/ixmwXHO/Wm3A/CHpLOSxj
+        hjhjLqUmeMNbSPmcHxXPOixUPhEiF/5BjHFz+JJZIh/Bv6I+ZDtZDaWDRWDG+GPpBrEYqWiSifq1
+        YlxsSoQkyEX0pf0TbC7/G6mey0IawZuI9z/JvJ1DnF9btM/mxBzQQJdgfgSYvREX2TV1W8mqI9sR
+        fwvl97WsxbopGjjlfky8/vr6BlZbH3TrAgAA
     headers:
       Cache-Control:
       - no-cache
@@ -152,7 +150,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 21 Nov 2019 15:14:24 GMT
+      - Thu, 21 Nov 2019 18:21:47 GMT
       Expires:
       - '0'
       Pragma:
@@ -175,63 +173,7 @@ interactions:
       X-Gateway-Site-ID:
       - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 1fb41e22dd504752019b2665ec7fd5f3
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - TenableIOSDK Python/3.7.3/1.9.1
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: GET
-    uri: https://cloud.tenable.com/scans/template-f391d518-f4fc-d50f-286c-5d8064208a5bd59f4720a58b983a/latest-status
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWKi5JLCktVrJSSs0tKKlUqgUAH8SqihIAAAA=
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Nov 2019 15:14:24 GMT
-      Server:
-      - tenable.io
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-d-ca-central-1-prod
-      X-Request-Uuid:
-      - d734ec0afcc7d1235b93c720ce6ef37e
+      - 264e757116c3ab2bed320024ab77148a
       X-Xss-Protection:
       - 1; mode=block
     status:

--- a/tests/integration/api/cassettes/test_scans_delete.yaml
+++ b/tests/integration/api/cassettes/test_scans_delete.yaml
@@ -11,7 +11,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -19,48 +19,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -71,11 +77,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:20 GMT
+      - Thu, 21 Nov 2019 15:14:17 GMT
       Expires:
       - '0'
       Pragma:
@@ -83,8 +89,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -94,9 +100,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 092a9aad5a906842b13d47df98ea1a79
+      - 517135e548d84cc4e0de13f8c98c8d09
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -104,7 +110,7 @@ interactions:
       message: OK
 - request:
     body: '{"uuid": "731a8e52-3ea6-a291-ec0a-d2ff0619c19d7bd788d6be818b65", "settings":
-      {"name": "test_scan_7596", "enabled": false, "text_targets": "fakehost.tenable.com",
+      {"name": "test_scan_fixture", "enabled": false, "text_targets": "fakehost.tenable.com",
       "acls": [], "asset_lists": []}}'
     headers:
       Accept:
@@ -114,13 +120,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '208'
+      - '196'
       Content-Type:
       - application/json
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -128,14 +134,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VSy47jIBD8F84hsk2wcU77J1YD7QxaDBZgRdnR/Ps2TpzRSjscLNyPoqq6P1k2
-        ENj1k5kYCriAaXKWXdlFtlqbQfFRd4ZfzCy4bkBy0Vu0oxi0kpadWLzXjm3be3CQxhqFXHcK+AXE
-        wNVoOt4b2aMScpQNUM+ruuCyeijIcVDDIKTlODfIGylaroQG3l1A9XpEYefRamhbg6NRFuSoWoIJ
-        sOAOk8tURUyDHHuKW8wmubW4SLrC5v2JrdE789iFifa0Sz6EPguOyIta8zr8P5+fTqWECzif36AL
-        XVkNB9AeCXgGn5EYQv7QEZKdZufxKHfB+M3iBLdbwhsZw64lbfgkNxW34HR3wcb70WC2XOIyFUg3
-        LPWp5607r5uu13N5PpzRbMmVx9nEhdhkypUKd+CktFHR8Vczf2J4Z0MsbnYGqp+Vb8H0rfADUtXV
-        0FAz2bdiWlzOVEklbafqMGbYfPk307z2hihDsAnvv7L9fY7p9l6oOoXuxDzQbJdovwnY3ZdW9qIT
-        1XVyIeFPqfJY64aQHTR+wt7n3319/QVJJwwH9QIAAA==
+        H4sIAAAAAAAAA3VSy27kIBD8F87DyMYP7Dntn1gNtD0oGCzAmk2i/HsazyNaacPBsuiq7qpqPlnS
+        4Nnlk+ngM1iPcbKGXVjb1UppOfBRCc1bPTdcVdDxpjdoxkaqoTPsxMKtMPb94KDstNEDciUG4C00
+        kg+jFrzXXY9D041dBcR5oDOum4OMhOmrpusl16qd+WxGxTVUgjeikkK0Zkap6lqMc4OgeykbhZLa
+        eFjxaJPyVExMs/2b94hUMph0tFu2gaz53bkT24Kz+v3wVo/ydNh+mr0jnjcPedXj8P98fjs1zcYV
+        rEuvpiv9snLtQTmkxjO4hCQR0lUFiIZkO3zCrdduNzjBskRcKBx2yXHHu7gp2xWnm/Um3J4Evacc
+        1ilDXDCXUTO84TWkfM73iWcdVhqfCJEL/0mMcXf4klkqH8G/qj5kO1sNJcEiMGP8sXSFWIxUtMlE
+        eW0YV5sSIQlSi6HEP8Pu8r+V6vFYSCN4E/H2J5m3c4jL6xWV2MWJOaCFrsH8CDBHEHUn26YdRUcT
+        dMTfSvl9K89i2xUtnHrfNz58fX0DqA0t0esCAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -146,7 +152,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:20 GMT
+      - Thu, 21 Nov 2019 15:14:18 GMT
       Expires:
       - '0'
       Pragma:
@@ -154,8 +160,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -167,9 +173,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 6da9febf9ba42d98be83d628adeca72d
+      - adace9759463b971fb96e09a6daa983b
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -189,11 +195,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/scans/32
+    uri: https://cloud.tenable.com/scans/template-89603567-cb4f-fd9b-ca02-3207224dfe7b1129f3eac6773be7
   response:
     body:
       string: ''
@@ -205,7 +211,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Mon, 15 Jul 2019 22:33:21 GMT
+      - Thu, 21 Nov 2019 15:14:18 GMT
       Expires:
       - '0'
       Pragma:
@@ -213,8 +219,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -222,9 +228,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 7b9fb0bf7805d39f653604c62e48e9f1
+      - 4bff253958efcaa1a6532dfe91f7fca3
       X-Xss-Protection:
       - 1; mode=block
     status:

--- a/tests/integration/api/cassettes/test_scans_details.yaml
+++ b/tests/integration/api/cassettes/test_scans_details.yaml
@@ -8,10 +8,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -19,48 +17,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -71,11 +75,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:19 GMT
+      - Thu, 21 Nov 2019 14:43:43 GMT
       Expires:
       - '0'
       Pragma:
@@ -83,8 +87,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -94,9 +98,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 02d796bf80e87b052f95467ce03d3369
+      - 209f9ad8d72afb79929225b656c2168f
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -104,7 +108,7 @@ interactions:
       message: OK
 - request:
     body: '{"uuid": "731a8e52-3ea6-a291-ec0a-d2ff0619c19d7bd788d6be818b65", "settings":
-      {"name": "test_scan_7511", "enabled": false, "text_targets": "fakehost.tenable.com",
+      {"name": "test_scan_fixture", "enabled": false, "text_targets": "fakehost.tenable.com",
       "acls": [], "asset_lists": []}}'
     headers:
       Accept:
@@ -114,13 +118,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '208'
+      - '196'
       Content-Type:
       - application/json
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -128,14 +132,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VS0Y7jIAz8F55LRZKShD7dn0QGnC46AhEQVb3V/vuZtOnqpFs/RATb45kxnywb
-        COz6yUwMBVzANDnLruwiG63NMHKlW8MvZu64FiB511u0qhv0KC07sXivHdu29+AgjTUjct2OwC/Q
-        DXxUpuW9kT2OnVRSAPW8qgsuq4eC3DbzSJN6bgV2vJVdw1UnLlxLkEPbd2IWo5qFMKjsrMRlVrrC
-        BFhwh8llqiKmQTYN3VvMJrm1uEi6wub9ia3RO/PYhbXjaZd8CH0WHDcvauIV/D+fn6KOxgWcz2/Q
-        hY6sXgfQHgl4Bp+RGEL+0BGSnWbn8Sh3wfjN4gS3W8IbGcOuJW34JDcVt+B0d8HG+9FgtlziMhVI
-        Nyx11PPUntdN1+O5PAdnNFty5XE2cSE2mXKlwh04KW1UdPzVzJ8Y3tkQi5udgepn5VswfSv8gFR1
-        CVpqJvtWTIvLmSqppKlWW5xh8+XfjHi9G6IMwSa8/8r29zmm2/tB7Zs6MQ+02yXabwJ296WRfde2
-        ioJcSPhTqjzW+kLIDlo/Ye+o6uvrL6w2vS/1AgAA
+        H4sIAAAAAAAAA3VS2W7kIBD8F56HkW3Axzztn1gNtD0oGCwOzSZR/j3gOaKVNjxYFl3VXVXNJ4kK
+        HLl8EuVdAuMwzEaTC+GilVINI51kpyhXC6OyAUFZr1FPbJCj0ORE/K0ycj44OAil1YhUdiNQDmyg
+        46Q62ivR48jEJBoonAc64bZbSEiZgqZtxoGySUxUazZSxjWnWnCh2Kil6pceJtFNner4IqdB19EO
+        NjzaxDRXE/Ni/qYcsJQ0RhXMnowv1ly29kR2b416P7y1Ezsdtp9m74jnzUNe8zj0P5/fTltm4wbG
+        xlfTrfySeu1AWiyNF7ARi0SIV+kh6CLb4hNunLJZ4wzrGnAt4ZBLChnv4uZkNpxvxml/exJUjslv
+        c4KwYqqjFnjDq4/pnO4Tz8pvZXwsiFT5T2II2eJLZq18ePeqOp/MYhTUBKvAhOHH0hVCNdKUTcaS
+        145hMzEWZIG03VjjXyDb9G+leTyWohGcDnj7E/Xb2Yf19Ypq7N2JWCgL3bz+EaCPIFoxcMYH3pXt
+        qYC/ldL7Xp/FnmVZeOl93zj/+voGryyjAusCAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -146,7 +150,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:19 GMT
+      - Thu, 21 Nov 2019 14:43:43 GMT
       Expires:
       - '0'
       Pragma:
@@ -154,8 +158,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -167,9 +171,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - b2ea4d897168dddf11892167e9f86257
+      - a2e9b8c6fcdacadf69880e9104f9d860
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -187,21 +191,21 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/29
+    uri: https://cloud.tenable.com/scans/template-3ca01087-3959-dd38-34d4-d545c38dbc6f6a95292c24fb97dd
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRyW7CMBD9FTTnpMpCIMmpau+9oJ4Qiow9BhcTR/ZYUYT49zoh0E29jd4sb5kL
-        qFYaqC9g+hYt1MBaYbF/duL0ZOwBImjZGQNO6KhxnLXNukjTETcNMXtAgloy7TACabRA2ygBdeu1
-        joCblqzRUJP1oe9d6HZoz8o5ZVoHdZqVETh+ROE1Nt6Pq4Hp3GlGGItUlnxdrmKRYB5nRZ7GVZ4s
-        433BinW2yhOZlJVMEo6VkFWylNWeBWEoFDVMa9OjuFOPwoO/Zjbzvlm8auPFYnPDw1ZntOJD6L0w
-        p/jiDak39jQNhK47MosPX2b/gZwmo1kVAbHDHIW7TzCuQ729wA+7SXSP+TYllAtOh1nVDftefyVJ
-        QzfqFiiZ1wTX6NflKcj5dvr78L8//YNPjh5s47/gugvuiZEPLBA+Q0Ngh6NyZGyIa7u7fgJThTIi
-        RAIAAA==
+        H4sIAAAAAAAAA3VRS2/CMAz+K8jndqIPoO1p2u67oJ0QqkLsQkZIqsQRQ4j/vpTXNqbdLH+2v4eP
+        oExnoTmC3Rty0IAw6Gj/7HH7ZN0aEjBiR7HP5Ln1Upi2U58cHA2QbVm4NTE0ndCeEuisRnKtQmhM
+        0DoBaQ07q6FhFyIefER7cjvlvbLGQ5PlVQJebgiDpjaEYTWS7XotmNJCinE2rmZpUU/qFLGo0qLE
+        MsVJOZFFhSs57aainuR1LvOyW9UzxCiMUHErtLZ7whv1oD1abK9+3uejV20DjuaXftzqrVbyELEX
+        4ZUcvRHvrdueByLqN8LR3ZddfZDks9GsLhNgsb5m4W8jQupYL47wy+84uUV9mULlo9XDVdal97P+
+        jpIP/SAcqRNBM5ySh8vnJK+3s8fD//71T38gzO9sw8PgtIz2WXCILBBfw4fIDhvl2bqY12J5+gLf
+        YuMpSAIAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -212,12 +216,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:20 GMT
+      - Thu, 21 Nov 2019 14:43:44 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -227,9 +231,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 75fe41f083946db76561a2e53386ce83
+      - 30e159c64fe932f2ca0947c7fa12f634
     status:
       code: 200
       message: OK

--- a/tests/integration/api/cassettes/test_scans_folder.yaml
+++ b/tests/integration/api/cassettes/test_scans_folder.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"name": "test_folders_4609"}'
+    body: '{"name": "test_folders_6069"}'
     headers:
       Accept:
       - '*/*'
@@ -15,7 +15,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -23,7 +23,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6tWykxRsjI2qAUA7WyvUQkAAAA=
+        H4sIAAAAAAAAA6tWykxRsjIyMK0FAM1xQKIKAAAA
     headers:
       Cache-Control:
       - no-cache
@@ -34,7 +34,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:20 GMT
+      - Thu, 21 Nov 2019 15:14:21 GMT
       Expires:
       - '0'
       Pragma:
@@ -42,8 +42,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -55,9 +55,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 3c6a67eddf512efd8c85c9e795e5267a
+      - e99f585f0db2873dec0bbdf4cda99741
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -75,7 +75,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -83,48 +83,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -135,11 +141,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:20 GMT
+      - Thu, 21 Nov 2019 15:14:22 GMT
       Expires:
       - '0'
       Pragma:
@@ -147,8 +153,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -158,9 +164,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - b11d0095fd69e1dd43a4df1f75134b9c
+      - 630d52360419f81aaa8cb70c93abf122
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -168,7 +174,7 @@ interactions:
       message: OK
 - request:
     body: '{"uuid": "731a8e52-3ea6-a291-ec0a-d2ff0619c19d7bd788d6be818b65", "settings":
-      {"name": "test_scan_1040", "enabled": false, "text_targets": "fakehost.tenable.com",
+      {"name": "test_scan_fixture", "enabled": false, "text_targets": "fakehost.tenable.com",
       "acls": [], "asset_lists": []}}'
     headers:
       Accept:
@@ -178,13 +184,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '208'
+      - '196'
       Content-Type:
       - application/json
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -192,14 +198,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VS247jIAz9F55LRci9T/snkQEng5ZABERVdzT/viZtOlpph4fIwfbhnGN/sqTB
-        s9sn08FnsB7jZA27saatlNL9wEclNW/0XHMloOV1Z9CMda+G1rALC/fSse9HD/atNnpAruQAvIG6
-        58OoJe902+FQt2MrgHpe1RnXzUFGXsmulWo0HBFG3jWz4H2PDR9moXRbmXnQEnVjsKmkGdEImAXB
-        eFjxgEl5KiKmSjTl3mDS0W7ZBtLld+cubAvO6schrK4vh+RT6LPgvHlRE6/D//P56VT0NK5gXXqD
-        rhSycu1BOSTgGVxCYgjpQwWIZpqtw7Pceu12gxMsS8SFjGG3HHd8kpuyXXG6W2/C/WzQe8phnTLE
-        BXN56hnJ67arEl7z8+GEeo82P646rMQmUS4XuBMnxp2Kzr+S+RP8O+tDtrPVUPwsfDPGb4UfEIsu
-        QUNNZN+GcbUpUSWVVHIow5hhd/nfjHjtDVEGbyLefyXz+xri8l6oMgV5YQ5otmsw3wTM4UvVdrWs
-        i+nkQsSfUvmxlQ0hO2j8hH3Mv/n6+gtIdrXO9QIAAA==
+        H4sIAAAAAAAAA3VS227kIAz9F56HEbmTedo/iRxwMqgEIi6abav+e03mUq205QEhfI59ju1PFhU4
+        dvlkyrsExmGYjGYX1nbVPKtB8nGuFW/V0vBZQMebXqMem2GWnWYn5m+FkfPBwaFTWknkcy2Bt9AM
+        XI6q5r3qepRNN3YCiPNAJ9x2Cwl5D1II2SiOumt50/UzF2PdcgHLMvRtXdX1KCvsq0Yu4ygqRcoo
+        jYMNjzQxTcXEtJi/KQekkMaogtmT8WTNZWtPbPfWqPfDWy3602H7afaOeP485InH4f+5fjsV1cYN
+        jI2vpBs9Wfl2MFukxAvYiCQR4nX2EDTJtviEG6ds1jjBugZcqTnskkLGu7gpmQ2nm3Ha354ElWPy
+        25QgrJhKqQXe8OpjOqd7xbPyG5WPhEiF/ySGkC2+ZJbIh3evqPPJLEZB6WARmDD8WLpCKEYETTJS
+        v3YMm4mRkASpalnav0C26d+IeCwLaQSnA97+RP129mF9bdExmxOzQAPdvP4RoI9GVN3QNu1Y94RR
+        AX8Lpfe9rMWeZxo45b5PfPj6+gYmhQKy6wIAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -210,7 +216,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:21 GMT
+      - Thu, 21 Nov 2019 15:14:22 GMT
       Expires:
       - '0'
       Pragma:
@@ -218,8 +224,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -231,16 +237,16 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 572b58f8e123003c910791bf33580673
+      - 6540c7b2dc5d912e82b00ae05e586afc
       X-Xss-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"folder_id": 30}'
+    body: '{"folder_id": 205}'
     headers:
       Accept:
       - '*/*'
@@ -249,17 +255,17 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '17'
+      - '18'
       Content-Type:
       - application/json
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: PUT
-    uri: https://cloud.tenable.com/scans/34/folder
+    uri: https://cloud.tenable.com/scans/template-6a80083c-ed54-356b-0924-0aff7642122981e6138f9901c1bb/folder
   response:
     body:
       string: ''
@@ -271,7 +277,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Mon, 15 Jul 2019 22:33:21 GMT
+      - Thu, 21 Nov 2019 15:14:23 GMT
       Expires:
       - '0'
       Pragma:
@@ -279,8 +285,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -288,9 +294,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - 5c7601cb25d216487390b6d448029ee4
+      - 1fedbc675ad2eb46a3be7b6a2855bfaf
       X-Xss-Protection:
       - 1; mode=block
     status:

--- a/tests/integration/api/cassettes/test_scans_list.yaml
+++ b/tests/integration/api/cassettes/test_scans_list.yaml
@@ -11,7 +11,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -19,17 +19,60 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA91VuW7cMBD9FYP1MuAlkdwqQOAyTZIuCIQhObSF6FhIFIyN4X/PaC1vnGOBFHbj
-        Shwej/PeG47uWR67hNPM9l/v2TJMCKmJ4zIUthc7Fpe5jP1pmDDD0pWmwM0pLscDsj0rE8y3bMcG
-        6Nfwyxa2ie31w+5PSHkZkpY2yB7a4Rfix+PV5wjDTDMrqPkb9FmeBHIhz43JOdGCc2k27o0y1m74
-        /oXwH6GbVZYGU1s2eCkfvu3YfCK0Kt7hDcQj22foZtyxA059O8/tuC5L5Z40GZau27HVnPPWDohA
-        P6Y2txEKnWgSFLJAVrVWymtZkdZ04sLSXKAsdAlr+8M4FUyU4LKsCjMXbZXQWy58jdxUJnDjIHPl
-        kgpBeq9s5SsL2gsAG8HQh07PtzARzBOVZSb6f/MZ7wac6BIY0oR37+f0/d043azH4y2mpcNmy8IE
-        k2uMdLdIgtfRWB599jwmWycXIQaHqHSyWbgknXJKrRxK2+OPcSAhNs0mwiSejxGxnsq65WkCBwjd
-        s6zjOJRp7M4strK+VtdXnzCS5JuP9Vom/+NWmRby9ZJZa+n+7hHNnK3B/lCOZ182Bi+rsk0pC2E0
-        2SwS95gq7oXOvAZnYw4CnfIxauVFkNJm6VHnF1T5UZ1N5A/j4Xg15qvT01yfSONrLzbB1ambvAHF
-        C7na0Uul51SbEAwNIFCV6+w4VDnzEISzIYGqdKq09bFyQYIzKFG9lvT/lly+NclFLR2AytzqgLxy
-        GTg6aiwISgalgqnBqBRqDR6Npo1U9a8vua20f6ryav09rA2KmkB/OHdz793DT6OJtQKrBwAA
+        H4sIAAAAAAAAA92bS28jxxWF/8qA66mg3o9ZJTC8dBaxN0EQCPW0hUiiQFKwJ4H/e77iUJQ0Q2lG
+        hloGtJFENdnsrlv33HPOvf2/1VhftL7Zrj7863+rm6tNz+2srm+udqsP8v2q3mx368v9n62PfHOx
+        O9vln/evdx+v++rDarfJ219W71dX+XK+/Onw8rytPpjf339+ShUfP6c6nvMyn1/dnfKHj+9+rPlq
+        y3/mWe2XZ713oZzkkQs93MrxSnd9uzs73PyZtiEczp9e6PyfTn021+Wst/Pd4fRKvdD5H1y/9TId
+        vsDIE8t+t+p/aIHOgjWH07vw+7/fr7b7gMwtc9F/zvXj6sPIF9v+fnXdN5fn2+35eh5WmnB/2idX
+        NxcX71dzdx3fepEJwOW6nY/zmnd84qzlHW9Vzhutk1GOq+YTjxza7vLuhi9ZnV9erze73rjAm5u5
+        Q1axBtd6CkIm34V1tggb8xA6Nl2KSkkHl1zIJsmcQ82WX3x6+0vecJrbW7nZEr4v72f961Xf8CX5
+        qm36r3/dtv/8Zb35eX68/tLbzUU/O1yFLXb4Xvlu2aTw1QZR00iituBbrLmW2Ls2LQwZm4o6aj3v
+        YXd+2f+7vrpbsw3n5D4/rSB3vdnNt9z+o1/lcnHvquv6ardZXxzv4pCX3+vv3/2jV5b8EEc/d8k3
+        Bm91PZPvm4NnffIpnAweh6S3+9v4FLy6vry+6A+iF4xRKtkhaqhGWBuciEFl4WxoxbWSbIkvH61d
+        50LYf0KPVmozRhhjqkjOR6GMCsIF3VXs0erIhlHVhFxdL9UrI18wbLvNDWl0iNo+x2euseW2+z9u
+        UUTHxeLnk7HO6cfiZzV5eYxfLp/lHvvZuGHcXDknrPdFRM3+1y5b76rLI9QFo2fSKLF2yTcHQqi6
+        EW5EL1rPJmdJssvaM6nvY6o1u+jMBP6XSrpvjJ7Rf1b0nPFPRi9FG63RQg03hE2uihirErb6YJM3
+        QY4lc8/K4lNLXTgDUBK4DGYPJVIZuTklm215aK970hM+leK9f0L09hRkGezUSWv7SOFLag+rT2Fn
+        bL7bQanzvRG/nqMoqUhRhuvDhAawlQWzz+bkXZBGNDYR1bcPoWrtoiXdW/LDNNt1H0ElWZqsiv00
+        t9Mi2dd/y7O0vJuoeeaq0baOW44XF6x+RkmZTkfQyGQDBOypCCpZY2vs/hAcKAaWieJ5WWwj/XwE
+        PvWSEazFjW6CaDYa0cewwinS0KjUe89JdZ/hLzUGVlM5iFOfG2rxCN7WPblg7pmklHskcklG+SBy
+        +ar2ybuOpJPgRhK0CAl5gbZ4LRL1RSgZXCzUG2WWhE5vB6y2KVG6b6JW2K+BA4thXZSudm997KNB
+        oUx1JqWsuloqcEfachbSrSxRermaZ0xMbMaTjIVDTqX7OfdF5FRNtsPuIOqKyPlQRQEwRVdNKcun
+        236pXlgeHAknOd2GzU2E0vnhtRQhQj2H53tJL5hLaD4HKaWuthvbxmRQi6TcXeSSOwrWZ4Hlr73k
+        6+ujXPhEiB6XekFFJ60+xTb3h0DMp/GyNhl7RuHFlAmeU13EnpoYvcrQXEoIvwWDl1spztQs0kAo
+        yNacqENBd5XKKXaELMXA1pAATAmFQsEsFrwf/vnup+9//Ondj9/97e+3wYt7N+Bbucpzg6elkTGc
+        DN485PRXgheNH11LLZwsiAVdusidHEzBIML0kMYtmXm5B5OMTmi+Gkn8yZuGjqLBFUojgHZ0MnN0
+        H2M06FKrpk+wSOadDN6CkKmN1FMLnHJYDEjzgGh+AZkptRj8IOv81AktJZGlVKLlOkzurQ69pMpD
+        JQSkCBXWjyqsmSwlFyu8zI20K3lq0GornKniJiH38vSvFgncHWTeIqZbFDBJLI1COxG5MA8pyaGn
+        CKZurBlEEoripi8Wh8gFe8VHa/tQZISfNHmpajd5fwwZmDQli1a1FSPwF9wkxdZdd1FRsZXM3E4i
+        eqrbpUJ3MueeRTA/A8yDCfpEuSNEzqjHomdTuG+unDDHiqrNyogeiIYQYmDCVWpApWflsiR8ez9j
+        qejVRG31zbJlShW6mgxhaQV1QrFrA5hEs0tD4knn0bK1xqlWFkm8k9FbzhYzlDplTyOmgeM7vO4n
+        8w7h5FLACS4pU2xGFNFNpYB/qCEHHvKwZOSKRAMrqqwlcj6j7nB6tMjJ6VQhutxdzx2bmkJnW1HB
+        T+q+SOQeSPMydGdTTR9nmvfpWeD5PGNaY+nGx2qehqN9RZrj9tpULVhlscToK4hYoSyyJki7rq3k
+        JRVeLR58By+lxFmVQwHcIDkOy5BVu+BQgJE71CbzTsnFtNeJ4CgKlbK3JWYEw8IIqtGz/jSCckhP
+        LfFUHvrhkhnOC5UqBkvpkBjZ8Mly683UBo9YUjCgzEcMZogRaXEoqSJOeQBQR0DXhVganksLQfkw
+        Co4fQmLyikXy8BSCpmcJhuflH/02iNlpmZ6Qel8zN6EEdGHArCgnfRlSxDYdahzFCWDUxiXzr2Wv
+        WqH2AdVJYHBi9SSNTVAH2O1NV3KAIR3BMGLjp42v4LD4eNuZVfpZofsj1MWa+Ch1keF+Z+EEddFS
+        DjgCoGlRyRZHWOSWiGGqMyP6qGNJb7rDbqVpFW+6YpAZj2bQgwYDnDfbrLQ3EKhstY/IP5wHs5cw
+        r5Z4S3rSdNPBzNNiLzH7YJ6GzNSUxL8clLvkiRyJh2NGCgbbOoRWW7WkJ43lTMYH2vmygNMVU7VW
+        G2nQ0tkvQaIZ8FyHVL1ypSEigRaT6Q+7CpCB6NXctbPwxSXJJ/g4E+yEXJ/m52Q1d0XvC7kOPZUu
+        IZBbyxreFzKgGWAuUPVCv5QW3+xhL6UasAR9AB1FprdAPwF/LCp6wl2GEYZuKdOykhpHoajRaC/A
+        SZdKvTu5zpjB0eJcMnIhkSKnIxfi17oK0aY0tGQQoU17ExuRyEHgncTooKeWrJv4v1zkmFPJDENo
+        jDIR0AdEDms8oDab1jFRcsEWW3OmzxBkVn4xtX4XuXH+2+5mc6sY2E7P8TifR1kstvv0wk7kHbMs
+        5muUxZNdThtszUS6WQN05SY9LieNM9qzGPx+yfC1abBG8BLdTmOKYSS3d+3gYUSwqxQrEJCyzjpI
+        2h05L9bNe3yW5dPE2rdMjj3dTZhjgA/nxfjPERWZ79l9PLbrDtNULzvxdWzpOKVdoTkqOv1e0bG5
+        MZbpyHWv8O6YZNg3ckDg0TTtXgfTX6wPvu9/fz6FqMNbW3J6MBIPg65ncok6hzuGjUHFc5bmf6Sd
+        4Iffmx0az5EFD3u7ZRF69yhSpb00fks7ncZky1R3+sxMDdE6BepcBur6HIwrmmazzMw2jozd23yI
+        Q/4Jy773lN7SstNdNK7CyFXC0itQJlx0VBUauDCl6ALuAX5idoppt0LnUbrlhxTPPqvL+s0tOwMW
+        jCXPcUIGUcWAyQpWHQtOT1ecPkZnvFhl2aHktJ0aHehXoEPBTQ4xFYjfNwzfwEYHnIeUzJBZiK6A
+        6DJPKjHN8K0ZPCosMKY1fjZzZEqFwXCSmabdImj+3fr647v1eHdvNoIp5sOK6/1DDm9gxY/chTag
+        d5OoNtYXVHGAOXNNUFaYPn4kc72VwedQtHeuMEgr0yvYXJDoW7Vm3hysSM+IXdZDBEM7wVEs4Yw8
+        LtCzVkXrwmSC1a14g+Szhjey65fa7fdmtxgTu93l7q3tcmyj2XXCfJ8Tljogj1qiDc14cQ8AD/Qw
+        BbqaBYvHVelK9K8wQfBZAU1vBc7vHq6IHsvOsuI0kOfgBnrYjUEPG+peMKcc6sgE+v6RmYRou+qv
+        4ATxuMoRz/ePZ70lPG9q8DzU5CyShyFYYMbpcWxEcZlmijeSx48wT3ksIjF2LO0gDV4DXNQtnuv9
+        E3dvaclxak1hDgLXDKuTB5acoHeksM5AHWs85rka0g9Q3w6XW/NqsVbDPdai1TQZ9k32NwcstG+c
+        Lsx9ziF1wTA0Q7Sh02uiVlanGE2pujOW0mlV8NBIkxjOy+9yJe0tsBg7n5ucBBVH6vJ6PubIQ5WW
+        BmL4/f+/L+IvhTsAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -40,11 +83,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '624'
+      - '3034'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:18 GMT
+      - Thu, 21 Nov 2019 15:14:17 GMT
       Expires:
       - '0'
       Pragma:
@@ -52,8 +95,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -63,9 +106,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-d-ca-central-1-prod
       X-Request-Uuid:
-      - aa3d7f207498c89122ef0d83526feed5
+      - 1b7fd901eddf1410a258eb99098b57da
       X-Xss-Protection:
       - 1; mode=block
     status:

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -145,6 +145,23 @@ def new_scan(client):
                 'test_scan_fixture',
                 TenableIOTestConfig.get('scan_text_targets'),
             )
+        ),
+        return_uuid=True
+    )
+
+@pytest.fixture
+def new_scan_id(client):
+    template_list = client.editor_api.list('scan')
+    assert len(template_list.templates) > 0, u'Expected at least one scan template.'
+
+    test_templates = [t for t in template_list.templates if t.name == 'basic']
+    return client.scans_api.create(
+        ScanCreateRequest(
+            test_templates[0].uuid,
+            ScanSettings(
+                'test_scan_fixture',
+                TenableIOTestConfig.get('scan_text_targets'),
+            )
         )
     )
 

--- a/tests/integration/api/test_scans.py
+++ b/tests/integration/api/test_scans.py
@@ -9,9 +9,12 @@ from tests.integration.api.utils.utils import wait_until
 
 
 @pytest.mark.vcr()
-def test_scans_create(new_scan):
-    assert isinstance(new_scan, int), u'The `create` method did not return type `int`.'
+def test_scans_create(new_scan_id):
+    assert isinstance(new_scan_id, int), u'The `create` method did not return type `int`.'
 
+@pytest.mark.vcr()
+def test_scans_create_schedule_uuid(new_scan):
+    assert isinstance(new_scan, str), u'The `create` method did not return type `str`.'
 
 @pytest.mark.vcr()
 def test_scans_list(client):
@@ -21,21 +24,21 @@ def test_scans_list(client):
 
 @pytest.mark.vcr()
 def test_scans_details(client, new_scan):
-    scan_details = client.scans_api.details(new_scan)
+    scan_details = client.scans_api.details(schedule_uuid=new_scan)
     assert isinstance(scan_details, ScanDetails), u'The `details` method did not return type `ScanDetails`.'
 
 
 @pytest.mark.vcr()
 def test_scans_delete(client, new_scan):
-    assert client.scans_api.delete(new_scan), u'The scan was not deleted.'
+    assert client.scans_api.delete(schedule_uuid=new_scan), u'The scan was not deleted.'
 
 
 @pytest.mark.vcr()
 def test_scans_copy(client, new_scan):
     scan_id = new_scan
-    copy_of_scan = client.scans_api.copy(scan_id)
+    copy_of_scan = client.scans_api.copy(schedule_uuid=new_scan)
     assert isinstance(copy_of_scan, Scan), u'The `copy` method did not return type `Scan`.'
-    scan_details = client.scans_api.details(scan_id)
+    scan_details = client.scans_api.details(schedule_uuid=new_scan)
     assert scan_details.info.name == copy_of_scan.name.strip('Copy of '), \
         u'Expected the copy of the scan to have the same name as the original.'
 
@@ -44,86 +47,147 @@ def test_scans_copy(client, new_scan):
 def test_scans_configure(client, new_scan):
     scan_id = new_scan
     after_name = 'scan_name_edit'
-    client.scans_api.configure(scan_id, ScanConfigureRequest(
+    client.scans_api.configure(schedule_uuid=new_scan, scan_configure=ScanConfigureRequest(
         settings=ScanSettings(
             name=after_name,
             text_targets=TenableIOTestConfig.get('scan_template_name')
         )
     ))
 
-    scan_details = client.scans_api.details(scan_id)
+    scan_details = client.scans_api.details(schedule_uuid=new_scan)
     assert scan_details.info.name == after_name, u'The returned scan name should match the the edited value.'
 
 
 @pytest.mark.vcr()
 def test_scans_folder(client, new_folder, new_scan):
-    assert client.scans_api.folder(new_scan, new_folder), u'The scan was not moved.'
+    assert client.scans_api.folder(schedule_uuid=new_scan, folder_id=new_folder), u'The scan was not moved.'
 
 
 @pytest.mark.vcr()
 def test_scans_latest_status(client, new_scan):
-    latest_status = client.scans_api.latest_status(new_scan)
+    latest_status = client.scans_api.latest_status(schedule_uuid=new_scan)
     assert latest_status == 'empty', u'Expected a status of `empty` on a scan that has never been run.'
 
 
 @pytest.mark.extended_testing
 @pytest.mark.vcr()
-def test_scans_control_endpoints(client, new_scan):
+def test_scans_control_endpoints_using_schedule_uuid(client, new_scan):
     scan_id = new_scan
-    scan_details = client.scans_api.details(scan_id)
+    scan_details = client.scans_api.details(schedule_uuid=new_scan)
     assert scan_details.info.status in [Scan.STATUS_CANCELED, Scan.STATUS_COMPLETED, Scan.STATUS_EMPTY], \
         u'Scan is not in an idling state.'
 
     # Launch the scan.
     client.scans_api.launch(
-        scan_id,
-        ScanLaunchRequest()
+        schedule_uuid=new_scan,
+        scan_launch_request=ScanLaunchRequest()
     )
-    scan_details = client.scans_api.details(scan_id)
+    scan_details = client.scans_api.details(schedule_uuid=new_scan)
     assert scan_details.info.status in [Scan.STATUS_PENDING, Scan.STATUS_INITIALIZING, Scan.STATUS_RUNNING], \
         u'The scan is not launching.'
 
-    scan_details = wait_until(lambda: client.scans_api.details(scan_id),
+    scan_details = wait_until(lambda: client.scans_api.details(schedule_uuid=new_scan),
                               lambda details: details.info.status in [
                                        Scan.STATUS_COMPLETED, Scan.STATUS_RUNNING])
     assert scan_details.info.status == Scan.STATUS_RUNNING, u'The scan is not running.'
 
     # Pause the running scan.
-    client.scans_api.pause(scan_id)
-    scan_details = client.scans_api.details(scan_id)
+    client.scans_api.pause(schedule_uuid=new_scan)
+    scan_details = client.scans_api.details(schedule_uuid=new_scan)
     assert scan_details.info.status in [Scan.STATUS_PAUSED, Scan.STATUS_PAUSING], u'The scan is not pausing.'
-    scan_details = wait_until(lambda: client.scans_api.details(scan_id),
+    scan_details = wait_until(lambda: client.scans_api.details(schedule_uuid=new_scan),
                               lambda details: details.info.status in [Scan.STATUS_PAUSED])
     assert scan_details.info.status == Scan.STATUS_PAUSED, u'The scan is not paused.'
 
     # Resume the paused scan.
-    client.scans_api.resume(scan_id)
-    scan_details = client.scans_api.details(scan_id)
+    client.scans_api.resume(schedule_uuid=new_scan)
+    scan_details = client.scans_api.details(schedule_uuid=new_scan)
     assert scan_details.info.status in [Scan.STATUS_RESUMING, Scan.STATUS_RUNNING], u'The scan is not resuming.'
 
-    scan_details = wait_until(lambda: client.scans_api.details(scan_id),
+    scan_details = wait_until(lambda: client.scans_api.details(schedule_uuid=new_scan),
                               lambda details: details.info.status in [
                                        Scan.STATUS_COMPLETED, Scan.STATUS_RUNNING])
     assert scan_details.info.status == Scan.STATUS_RUNNING, u'The scan is not running.'
 
     # Stop the running scan.
-    client.scans_api.stop(scan_id)
-    scan_details = client.scans_api.details(scan_id)
+    client.scans_api.stop(schedule_uuid=new_scan)
+    scan_details = client.scans_api.details(schedule_uuid=new_scan)
     assert scan_details.info.status in [Scan.STATUS_CANCELED, Scan.STATUS_STOPPING], u'The scan is not resuming.'
 
-    scan_details = wait_until(lambda: client.scans_api.details(scan_id),
+    scan_details = wait_until(lambda: client.scans_api.details(schedule_uuid=new_scan),
                               lambda details: details.info.status in [Scan.STATUS_CANCELED])
     assert scan_details.info.status == Scan.STATUS_CANCELED, u'The scan was not canceled.'
 
     # Test the history API.
     assert len(scan_details.history) > 0, u'The scan should have at least one history.'
     history_id = scan_details.history[0].history_id
-    history = client.scans_api.history(scan_id, history_id)
+    history = client.scans_api.history(schedule_uuid=new_scan, history_id=history_id)
     assert history.status == scan_details.info.status, u'Scan history should report same status as scan details.'
 
     # Test the scan host details API.
     assert len(scan_details.hosts) > 0, u'Expected the scan to have at least one host.'
-    host_details = client.scans_api.host_details(scan_id, scan_details.hosts[0].host_id)
+    host_details = client.scans_api.host_details(schedule_uuid=new_scan, host_id=scan_details.hosts[0].host_id)
+    assert isinstance(host_details, ScanHostDetails), \
+        u'The `host_details` method did not return type `ScanHostDetails`.'
+
+@pytest.mark.extended_testing
+@pytest.mark.vcr()
+def test_scans_control_endpoints(client, new_scan_id):
+    scan_id = new_scan_id
+    scan_details = client.scans_api.details(new_scan_id)
+    assert scan_details.info.status in [Scan.STATUS_CANCELED, Scan.STATUS_COMPLETED, Scan.STATUS_EMPTY], \
+        u'Scan is not in an idling state.'
+
+    # Launch the scan.
+    client.scans_api.launch(
+        new_scan_id,
+        scan_launch_request=ScanLaunchRequest()
+    )
+    scan_details = client.scans_api.details(new_scan_id)
+    assert scan_details.info.status in [Scan.STATUS_PENDING, Scan.STATUS_INITIALIZING, Scan.STATUS_RUNNING], \
+        u'The scan is not launching.'
+
+    scan_details = wait_until(lambda: client.scans_api.details(new_scan_id),
+                              lambda details: details.info.status in [
+                                       Scan.STATUS_COMPLETED, Scan.STATUS_RUNNING])
+    assert scan_details.info.status == Scan.STATUS_RUNNING, u'The scan is not running.'
+
+    # Pause the running scan.
+    client.scans_api.pause(new_scan_id)
+    scan_details = client.scans_api.details(new_scan_id)
+    assert scan_details.info.status in [Scan.STATUS_PAUSED, Scan.STATUS_PAUSING], u'The scan is not pausing.'
+    scan_details = wait_until(lambda: client.scans_api.details(new_scan_id),
+                              lambda details: details.info.status in [Scan.STATUS_PAUSED])
+    assert scan_details.info.status == Scan.STATUS_PAUSED, u'The scan is not paused.'
+
+    # Resume the paused scan.
+    client.scans_api.resume(new_scan_id)
+    scan_details = client.scans_api.details(new_scan_id)
+    assert scan_details.info.status in [Scan.STATUS_RESUMING, Scan.STATUS_RUNNING], u'The scan is not resuming.'
+
+    scan_details = wait_until(lambda: client.scans_api.details(new_scan_id),
+                              lambda details: details.info.status in [
+                                       Scan.STATUS_COMPLETED, Scan.STATUS_RUNNING])
+    assert scan_details.info.status == Scan.STATUS_RUNNING, u'The scan is not running.'
+
+    # Stop the running scan.
+    client.scans_api.stop(new_scan_id)
+    scan_details = client.scans_api.details(new_scan_id)
+    assert scan_details.info.status in [Scan.STATUS_CANCELED, Scan.STATUS_STOPPING], u'The scan is not resuming.'
+
+    scan_details = wait_until(lambda: client.scans_api.details(new_scan_id),
+                              lambda details: details.info.status in [Scan.STATUS_CANCELED])
+    assert scan_details.info.status == Scan.STATUS_CANCELED, u'The scan was not canceled.'
+
+    # Test the history API.
+    assert len(scan_details.history) > 0, u'The scan should have at least one history.'
+    history_id = scan_details.history[0].history_id
+    history = client.scans_api.history(new_scan_id, history_id=history_id)
+    assert history.status == scan_details.info.status, u'Scan history should report same status as scan details.'
+
+    # Test the scan host details API.
+    assert len(scan_details.hosts) > 0, u'Expected the scan to have at least one host.'
+    host_details = client.scans_api.host_details(new_scan_id, host_id=scan_details.hosts[0].host_id)
     assert isinstance(host_details, ScanHostDetails), \
         u'The `host_details` method did not return type `ScanHostDetails`.'
 

--- a/tests/integration/examples/cassettes/TestExamples.test_folders.yaml
+++ b/tests/integration/examples/cassettes/TestExamples.test_folders.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -21,7 +21,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6tWykxRsjI0MKgFAGYqgs0KAAAA
+        H4sIAAAAAAAAA6tWykxRsjIysagFAFyn5xAKAAAA
     headers:
       Cache-Control:
       - no-cache
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:52 GMT
+      - Thu, 21 Nov 2019 19:47:38 GMT
       Expires:
       - '0'
       Pragma:
@@ -40,8 +40,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -53,9 +53,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 359e4fde5ce28b46dc7bb72acf221501
+      - 2b8ac62f149e4e21debcb5b5353e32a6
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -73,7 +73,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -81,10 +81,10 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7XQsQqDMBQF0F+RNzskVRvMP3Rqt1JCMLEVTCzmOYj470WNtlScardcCOfepIO8
-        KpWuHfBrB42ttVQiqxqLwEkIWeOwMuNR6Vw2JQqU9zFj+9TAAWvpHhCClWaIFx8LBTzqw28y2Sbp
-        QhpZ2Ld4aoNzJq3zaLxGP3bSzZ3+xsKidij828UhZsz76U7+RIshCa0K9Dyl/9gfH0k6fzpZF9Af
-        CwSLI88nbKf9pg2GhmBqmH+HkP7WvwCH50NMlAIAAA==
+        H4sIAAAAAAAAA7XQvQqDMBQF4FeROzskNv6+Q6d2KyUEE1tBYzHXQcR3L2q0peJU3XIgfOckHWRV
+        IVVtILl10OhaCcnTqtEICXEhbQxW5XiUKhNNgRzFY8zYvhQkgLUwT3BBi3KIVxtzCcmpd39JL9o2
+        6WKWItcf8tw6l1RoY1W2Vr+G0s2h9sbCojLI7eO5x8LQ+vFO/kTzIXElc7Q8pUfsZwGJ518n6wL6
+        ZwEP2cnyfnjE/oAE836P+Ds1lK0zlDhTycyzqL/3b/eI5SX3AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:52 GMT
+      - Thu, 21 Nov 2019 19:47:38 GMT
       Expires:
       - '0'
       Pragma:
@@ -103,8 +103,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -116,9 +116,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 90d6acc4347eae33b7b7ccb9b3569de5
+      - 8df10f5e4a5f1f31dc0e1ab0b4dfd757
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -136,7 +136,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -144,48 +144,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -196,11 +202,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:52 GMT
+      - Thu, 21 Nov 2019 19:47:39 GMT
       Expires:
       - '0'
       Pragma:
@@ -208,8 +214,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -219,9 +225,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 0c49ba5870cc4f26b581735772092f83
+      - 85930c7d345d63b69ae3fb6d86842255
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -245,7 +251,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -253,14 +259,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VSy47jIBD8lRHnMMLgB85p/8RqoO1Bi8ECrCg7mn9fcOKMVtrhYFl0VXdVNZ8k
-        afDk+kl08BmsxzhZQ66k7Rql9CDpqLimrZ4FVQw6KnqDZhSDkp0hFxJulbHvBweHThstkSougbYg
-        BipHzWmvux6l6MaOQeE80RnXzUFGOo9mNLxvqRwKY5zlQDmCpo1qGsFaLhRTczeMg2j7fm5ly/hY
-        2nhYsbRZ728ZU347fFyIwaSj3bINxZXfnbuQLTir74ethjWXw/Hp84E4b57K2PPQ/3x+Ok2ZjStY
-        l15N1/JL6rUH5bA0nsElLBIhfagA0UyzdXjCrdduNzjBskRcSi7kmuOOD3FTtitON+tNuJ0Evacc
-        1ilDXDCnI9Bj0LsOa5maSiFX2omPcXf4Ulcrf4J/VX3IdrYaanBVV8b47eQDYtXPyu5SiWnDuNqU
-        CrJAGi5r6jPsLv9bYc/nUaSBNxFvv5L5/R7i8no3NW1+IQ5SntZgvgWYw3/T9UIwKRtR3Eb8qZTv
-        W30I267Knkvvx6L519dfjD40790CAAA=
+        H4sIAAAAAAAAA3VSy27EIAz8lYpzqMiDhOypfxIZcFJUHhEQrbZV/70k3WxVqeWAEB6PZ2x/kKTA
+        k8sHUcFnMB7jZDS5kI7XUqpB0FE2inZqbqlkwGnba9RjO0jBNalIuO4Z23bk4MCVVgKpbATQDtqB
+        ilE1tFe8R9HykTMoOXd0RrdayEjnbhBcNprykWk61l1D2TgziqzHGlD3vKuZEqCwk+PAQYiaFRoP
+        DguNuz1lTPnp8FERjUlFs2YTiiu/WVuRNVijboetphurw/Hp8xtx/tyVsfuhf1z/nbrURgfGpgep
+        K0+yf3uQFgvxDDZhkQjpVQaIepqNxRNuvLKbxgmWJeJS+kIuOW74LW7KxuF0NV6H65mgtpSDmzLE
+        BXM6GnoUelbBlaqpBPKeduJj3Cw+1O2R9+AfUR+ymY2CvXG7rozxx8krxF0/K7NLpU0rRmdSKsgC
+        qRuxd32GzebfEXZfjyINvI54fUn67TnE5bE3x0gqYiHlyQX9I0Af/ms+dG3Pe16GpiL+F8q3dV+E
+        dZNlzoX7YOXs8/MLnrgBg90CAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -271,7 +277,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:53 GMT
+      - Thu, 21 Nov 2019 19:47:39 GMT
       Expires:
       - '0'
       Pragma:
@@ -279,8 +285,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -292,9 +298,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 575398ac423a532fb0c5f5d71da6caef
+      - 945fde6e376a6569b3553ccb59f7671a
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -312,21 +318,21 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRyU7DMBD9lWjOCcpGs5yQ4MC94lRVkRNPWoNjR/aYKqr67zhtWqCI2+jN8pY5
-        glC9hvoI+qDQQA1McYOHJ8s/HrTZQQiKDejxYQoILQW2Y2pGdUPM7JCg7pm0GEKvJUfTCA61clKG
-        0GlFRkuoyTjfd9Z3RzSDsFZoZaFO0jIE2+2RO4mNc/MqEA6jZIRRX/GKp6s8KousiKq+LKIUWRcl
-        bZJkcZ5mbdz2j0VVZPlq1edlHqeVF4ZcUMOk1AfkV+pZs3fXLFbe1sGz1I4H6wvut0YtRTf53qv2
-        Hl+E7fQnmsl37J4ZvHnS7Tt2dDaZxGkIxHZLDvY6wjrp680RfnmNw2vClykurLc5LZIu2M/6O0aa
-        xlk0x545SXAK7y6fU1xuJ/eH/33nH3wmTG9s87PgtPX2iZHzLODfQpNnh72wpH009WZ7+gJAzruy
-        PwIAAA==
+        H4sIAAAAAAAAA3WRy26DMBBFfyWaNVSAIAFWldpF91FXUYQce0jcGozscSMU5d87JCR9qbvRnee5
+        cwLdtxbqE9hjjw5qEL1yeHz06v3Buj1E0IsOWe/GBaGnhZein1TbkHB7JKhbYTxG0Fqj0DVaQd0H
+        YyKQtidnDdTkAueD5+yArtPea9t7qNOsjMDLA6pgsAlhagXCbjCCMG7zVVnsMhUXVaLiKs2zOKna
+        JMZkialAtSzyNJGlkJjvqlUhyjJN+DBUmhphjD2iuq2ebma6ZkZ5XS+ejA1qsb7q3DVYo+XIuRfL
+        jM/aS/uBbuSMPwiHdya7e0NJF8isSCIgsZ998LcSIQ3HmxP8YOXa2eFrldKeMcf5pKv2Pf6ykcZh
+        OlphK4IhOEe/Jl9cnGenvwf/+84/+gXpvm16Fpy3jE+CAm8BfguNvB0O2pNla+rN9vwJlzDvUD8C
+        AAA=
     headers:
       Cache-Control:
       - no-cache
@@ -337,12 +343,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:53 GMT
+      - Thu, 21 Nov 2019 19:47:39 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -352,14 +358,72 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 23fe348e247ee05a34d7d3097072ac14
+      - 6bf5b5d701704d0cf13b08f5fed12184
     status:
       code: 200
       message: OK
 - request:
-    body: '{"folder_id": 100}'
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WRy26DMBBFfyWaNVSAIAFWldpF91FXUYQce0jcGozscSMU5d87JCR9qbvRnee5
+        cwLdtxbqE9hjjw5qEL1yeHz06v3Buj1E0IsOWe/GBaGnhZein1TbkHB7JKhbYTxG0Fqj0DVaQd0H
+        YyKQtidnDdTkAueD5+yArtPea9t7qNOsjMDLA6pgsAlhagXCbjCCMG7zVVnsMhUXVaLiKs2zOKna
+        JMZkialAtSzyNJGlkJjvqlUhyjJN+DBUmhphjD2iuq2ebma6ZkZ5XS+ejA1qsb7q3DVYo+XIuRfL
+        jM/aS/uBbuSMPwiHdya7e0NJF8isSCIgsZ998LcSIQ3HmxP8YOXa2eFrldKeMcf5pKv2Pf6ykcZh
+        OlphK4IhOEe/Jl9cnGenvwf/+84/+gXpvm16Fpy3jE+CAm8BfguNvB0O2pNla+rN9vwJlzDvUD8C
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:47:40 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-c-ca-central-1-prod
+      X-Request-Uuid:
+      - b68935cc63a5d931d34d89ebd32207b7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"folder_id": 248}'
     headers:
       Accept:
       - '*/*'
@@ -374,11 +438,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: PUT
-    uri: https://cloud.tenable.com/scans/102/folder
+    uri: https://cloud.tenable.com/scans/250/folder
   response:
     body:
       string: ''
@@ -390,7 +454,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Tue, 16 Jul 2019 20:26:54 GMT
+      - Thu, 21 Nov 2019 19:47:40 GMT
       Expires:
       - '0'
       Pragma:
@@ -398,8 +462,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -407,9 +471,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 0cd3a4891a1d43c1ab6ca6f65f33c45c
+      - f80c228e72ec8fb5d2e326baf4684840
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -427,21 +491,21 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRyU7DMBD9lWrOCcpGs5yQ4MC94lRVkRNPWoMTR/aYKqr670xoWkERt9Gb5S1z
-        AjV0BqoTmOOAFioQg7R4fHLy48HYPQQwiB4Z76cVoaOVa8Uwo6YmYfdIUHVCOwygM1qirZWEKo6i
-        AFozkDUaKrKe295xc0TbK+eUGRxPJUUArj2g9Bpr7+dNIOxHLQjDrpSlTNZZWORpHpZdkYcJijaM
-        mzhOoyxJm6jpHvMyT7P1usuKLEpK1oVSUS20NkeUV+pZMpurFydvm9WzNl6uNhect0ajVTtx79Ww
-        xRflWvOJduKOOwg7Xxq81gGY5h1bWjwmAZDYLzG464hoNdfbE/zyynksAV+mpHJsc1okXbCftbpR
-        0jTOoiV2wmuCc3B3+TvF5XZ8f/jfb/7BZ8LkxjY/C847tk+CPLMAv4UmZoeDcmQ4mmq7O38BKHau
-        UT4CAAA=
+        H4sIAAAAAAAAA3VRwW7CMAz9FeRzO7VVC21Pk7bD7mgnhKqQuJAtJChxhirEv8+Fgjam3aznZ7/3
+        7BNo2ztoT+COFj20IKzyeHwO6vPJ+S0kYMUeGd8PM8JAsyCFHVHXkfBbJGh7YQIm0Duj0HdaQVuU
+        dQLSWfLOQEs+cjsGbh7Q73UI2tkAbV4wK8gdqmiwi3GcBML9wQjCtC8XdbUpVFo1mUqbvCzSrOmz
+        FLM55gLVvCrzTNZCYrlpFpWo6zxjX6g0dcIYd0R1kx4tc7huSvK+nL0YF9VsecV56uCMlgP33hxH
+        fNVBui/0A3fCTvhxk43GJOA2HyjpmrHKEiCxnc4QbhQhDderE/zKytzpwFeW0oFjDpOlK/az1ndJ
+        Gg6jaYW9iIbgnDxsvlxx2p0/Lv73m3/wS6S72vgsOK85PgmKrAL8FhpYHXY6kOPTtKv1+RsFzn/X
+        PgIAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -452,12 +516,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:54 GMT
+      - Thu, 21 Nov 2019 19:47:40 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -467,9 +531,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 90d0020860f741224c40bc468dbbead9
+      - ed18ba0dfa5849492df4224ec17f9418
     status:
       code: 200
       message: OK
@@ -485,7 +549,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -493,10 +557,10 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7XQsQqDMBQF0F+RNzskVRvMP3Rqt1JCMLEVTCzmOYj470WNtlScardcCOfepIO8
-        KpWuHfBrB42ttVQiqxqLwEkIWeOwMuNR6Vw2JQqU9zFj+9TAAWvpHhCClWaIFx8LBTzqw28y2Sbp
-        QhpZ2Ld4aoNzJq3zaLxGP3bSzZ3+xsKidij828UhZsz76U7+RIshCa0K9Dyl/9gfH0k6fzpZF9Af
-        CwSLI88nbKf9pg2GhmBqmH+HkP7WvwCH50NMlAIAAA==
+        H4sIAAAAAAAAA7XQvQqDMBQF4FeROzskNv6+Q6d2KyUEE1tBYzHXQcR3L2q0peJU3XIgfOckHWRV
+        IVVtILl10OhaCcnTqtEICXEhbQxW5XiUKhNNgRzFY8zYvhQkgLUwT3BBi3KIVxtzCcmpd39JL9o2
+        6WKWItcf8tw6l1RoY1W2Vr+G0s2h9sbCojLI7eO5x8LQ+vFO/kTzIXElc7Q8pUfsZwGJ518n6wL6
+        ZwEP2cnyfnjE/oAE836P+Ds1lK0zlDhTycyzqL/3b/eI5SX3AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -507,7 +571,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:54 GMT
+      - Thu, 21 Nov 2019 19:47:40 GMT
       Expires:
       - '0'
       Pragma:
@@ -515,8 +579,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -528,9 +592,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 722d4664a965ae3c21186d3f9158ec36
+      - 98b011399e479b05fc70cd3caa8f9868
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -552,11 +616,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: PUT
-    uri: https://cloud.tenable.com/scans/102/folder
+    uri: https://cloud.tenable.com/scans/250/folder
   response:
     body:
       string: ''
@@ -568,7 +632,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Tue, 16 Jul 2019 20:26:55 GMT
+      - Thu, 21 Nov 2019 19:47:41 GMT
       Expires:
       - '0'
       Pragma:
@@ -576,8 +640,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -585,9 +649,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 59bbf5300d20202370a70dad41fffea2
+      - 39065d96c4316fd7486e233cd76e54c1
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -605,21 +669,21 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRyWrDMBD9FTNnuXhrvJwK7aH30FMIRrZGiVrZMtKowYT8e+VsdKG34c3yljmC
-        GqWB5gjmMKKFBvgoLB6enPh4MHYHDEY+YMCHOSJ0FLmejwtqWuJ2hwSN5NohA2m0QNsqAU3OoDcj
-        WaOhIetD07vQmtAOyjllRgdNmlUMXL9H4TW23i97QDhMmhPGsha1yFZFXJV5GdeyKuMMeR+nXZrm
-        SZHlXdLJx7Iu82K1kkVVJFkdVKFQ1HKtzQHFjXoRHKy1Vx9v6+hZGy+i9QUPW5PRqp9D79UEgy/K
-        9eYT7Rw6bs/tcmn0WjMw3Tv2dHaYJhkD4rtrCO42wnsd6s0RfnhN2C3ey5RQLticr5Iu2Pda3Slp
-        nhbRAiX3muDEfl0+p3i9nf4+/O8v/+ALYXZnW54Fp22wT5x8YIHwFpoDO+yVIxOiaTbb0xeBeGQH
-        PAIAAA==
+        H4sIAAAAAAAAA3VRTW+DMAz9K8hnmIBBSzlN2g67VztVFUoT02YLBCXOKlT1v8+0tNqHdrPes9/z
+        s0+g+9ZCfQJ77NFBDaJXDo9PXn08WLeHGHrRIePdGBF6irwU/YTahoTbI0HdCuMxhtYaha7RCurH
+        GKTtyVkDNbnAZPBMDeg67b22vYc6y6sYvDygCgabEKY5IOwGIwiTtlhW5S5XSblKVbLKijxJV22a
+        YLrATKBalEWWykpILHarZSmqKkt5K1SaGmGMPaK6WU8Lc7RmzvG2jp6NDSpaX3GeGqzRcmTu1XLA
+        F+2l/UQ3MuMPwk1KfTAmBrt7R0mXhHmZxkBiPx/B31qENFxvTvAjK/fO5712Ke055jivdMW+1/pu
+        SeMwLa2wFcEQnONfypcrztrZb+F/f/kHv0S6u03PgvOW45OgwC7Ab6GR3eGgPVk+Tb3Znr8AVoYw
+        5TwCAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -630,12 +694,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:55 GMT
+      - Thu, 21 Nov 2019 19:47:41 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -645,14 +709,14 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 3157b33c249fe2e2d500c95cb432a07e
+      - 6b254e122f77c237ba3ce6d32cb465a3
     status:
       code: 200
       message: OK
 - request:
-    body: '{"folder_id": 100}'
+    body: '{"folder_id": 248}'
     headers:
       Accept:
       - '*/*'
@@ -667,11 +731,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: PUT
-    uri: https://cloud.tenable.com/scans/102/folder
+    uri: https://cloud.tenable.com/scans/250/folder
   response:
     body:
       string: ''
@@ -683,7 +747,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Tue, 16 Jul 2019 20:26:56 GMT
+      - Thu, 21 Nov 2019 19:47:41 GMT
       Expires:
       - '0'
       Pragma:
@@ -691,8 +755,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -700,9 +764,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 3a16ff9adeb892d3a2ea500b3f774aec
+      - 78a44eeedb543dfcd6f3f156df719665
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -720,21 +784,21 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRyU7DMBD9lWrOCcpGs5yQ4MC94lRVkRNPWoMTR/aYKqr670xoWkERt9Gb5S1z
-        AjV0BqoTmOOAFioQg7R4fHLy48HYPQQwiB4Z76cVoaOVa8Uwo6YmYfdIUHVCOwygM1qirZWEKo6i
-        AFozkDUaKrKe295xc0TbK+eUGRxPJUUArj2g9Bpr7+dNIOxHLQjDrpSlTNZZWORpHpZdkYcJijaM
-        mzhOoyxJm6jpHvMyT7P1usuKLEpK1oVSUS20NkeUV+pZMpurFydvm9WzNl6uNhect0ajVTtx79Ww
-        xRflWvOJduKOOwg7Xxq81gGY5h1bWjwmAZDYLzG464hoNdfbE/zyynksAV+mpHJsc1okXbCftbpR
-        0jTOoiV2wmuCc3B3+TvF5XZ8f/jfb/7BZ8LkxjY/C847tk+CPLMAv4UmZoeDcmQ4mmq7O38BKHau
-        UT4CAAA=
+        H4sIAAAAAAAAA3VRwW7CMAz9FeRzO7VVC21Pk7bD7mgnhKqQuJAtJChxhirEv8+Fgjam3aznZ7/3
+        7BNo2ztoT+COFj20IKzyeHwO6vPJ+S0kYMUeGd8PM8JAsyCFHVHXkfBbJGh7YQIm0Duj0HdaQVuU
+        dQLSWfLOQEs+cjsGbh7Q73UI2tkAbV4wK8gdqmiwi3GcBML9wQjCtC8XdbUpVFo1mUqbvCzSrOmz
+        FLM55gLVvCrzTNZCYrlpFpWo6zxjX6g0dcIYd0R1kx4tc7huSvK+nL0YF9VsecV56uCMlgP33hxH
+        fNVBui/0A3fCTvhxk43GJOA2HyjpmrHKEiCxnc4QbhQhDderE/zKytzpwFeW0oFjDpOlK/az1ndJ
+        Gg6jaYW9iIbgnDxsvlxx2p0/Lv73m3/wS6S72vgsOK85PgmKrAL8FhpYHXY6kOPTtKv1+RsFzn/X
+        PgIAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -745,12 +809,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:56 GMT
+      - Thu, 21 Nov 2019 19:47:41 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -760,9 +824,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - dbdcbd90bed76aebf5432724982804cd
+      - 122f432914959656cf5433cde07ed3c5
     status:
       code: 200
       message: OK
@@ -778,7 +842,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -786,10 +850,10 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7XQsQqDMBQF0F+RNzskVRvMP3Rqt1JCMLEVTCzmOYj470WNtlScardcCOfepIO8
-        KpWuHfBrB42ttVQiqxqLwEkIWeOwMuNR6Vw2JQqU9zFj+9TAAWvpHhCClWaIFx8LBTzqw28y2Sbp
-        QhpZ2Ld4aoNzJq3zaLxGP3bSzZ3+xsKidij828UhZsz76U7+RIshCa0K9Dyl/9gfH0k6fzpZF9Af
-        CwSLI88nbKf9pg2GhmBqmH+HkP7WvwCH50NMlAIAAA==
+        H4sIAAAAAAAAA7XQvQqDMBQF4FeROzskNv6+Q6d2KyUEE1tBYzHXQcR3L2q0peJU3XIgfOckHWRV
+        IVVtILl10OhaCcnTqtEICXEhbQxW5XiUKhNNgRzFY8zYvhQkgLUwT3BBi3KIVxtzCcmpd39JL9o2
+        6WKWItcf8tw6l1RoY1W2Vr+G0s2h9sbCojLI7eO5x8LQ+vFO/kTzIXElc7Q8pUfsZwGJ518n6wL6
+        ZwEP2cnyfnjE/oAE836P+Ds1lK0zlDhTycyzqL/3b/eI5SX3AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -800,7 +864,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:57 GMT
+      - Thu, 21 Nov 2019 19:47:42 GMT
       Expires:
       - '0'
       Pragma:
@@ -808,8 +872,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -821,9 +885,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 213d346619424f89e091b408ede6bc85
+      - ad60fd54dd048f3cec47ab4b3185ef90
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -845,11 +909,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: PUT
-    uri: https://cloud.tenable.com/scans/102/folder
+    uri: https://cloud.tenable.com/scans/250/folder
   response:
     body:
       string: ''
@@ -861,7 +925,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Tue, 16 Jul 2019 20:26:57 GMT
+      - Thu, 21 Nov 2019 19:47:42 GMT
       Expires:
       - '0'
       Pragma:
@@ -869,8 +933,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -878,9 +942,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - f5e2819ad7ea62369f95d29d2568756a
+      - 7a555b66fb97340c3a6f1948115ae34b
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -898,21 +962,21 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRyWrDMBD9FTNnuXhrvJwK7aH30FMIRrZGiVrZMtKowYT8e+VsdKG34c3yljmC
-        GqWB5gjmMKKFBvgoLB6enPh4MHYHDEY+YMCHOSJ0FLmejwtqWuJ2hwSN5NohA2m0QNsqAU3OoDcj
-        WaOhIetD07vQmtAOyjllRgdNmlUMXL9H4TW23i97QDhMmhPGsha1yFZFXJV5GdeyKuMMeR+nXZrm
-        SZHlXdLJx7Iu82K1kkVVJFkdVKFQ1HKtzQHFjXoRHKy1Vx9v6+hZGy+i9QUPW5PRqp9D79UEgy/K
-        9eYT7Rw6bs/tcmn0WjMw3Tv2dHaYJhkD4rtrCO42wnsd6s0RfnhN2C3ey5RQLticr5Iu2Pda3Slp
-        nhbRAiX3muDEfl0+p3i9nf4+/O8v/+ALYXZnW54Fp22wT5x8YIHwFpoDO+yVIxOiaTbb0xeBeGQH
-        PAIAAA==
+        H4sIAAAAAAAAA3VRTW+DMAz9K8hnmIBBSzlN2g67VztVFUoT02YLBCXOKlT1v8+0tNqHdrPes9/z
+        s0+g+9ZCfQJ77NFBDaJXDo9PXn08WLeHGHrRIePdGBF6irwU/YTahoTbI0HdCuMxhtYaha7RCurH
+        GKTtyVkDNbnAZPBMDeg67b22vYc6y6sYvDygCgabEKY5IOwGIwiTtlhW5S5XSblKVbLKijxJV22a
+        YLrATKBalEWWykpILHarZSmqKkt5K1SaGmGMPaK6WU8Lc7RmzvG2jp6NDSpaX3GeGqzRcmTu1XLA
+        F+2l/UQ3MuMPwk1KfTAmBrt7R0mXhHmZxkBiPx/B31qENFxvTvAjK/fO5712Ke055jivdMW+1/pu
+        SeMwLa2wFcEQnONfypcrztrZb+F/f/kHv0S6u03PgvOW45OgwC7Ab6GR3eGgPVk+Tb3Znr8AVoYw
+        5TwCAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -923,12 +987,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:58 GMT
+      - Thu, 21 Nov 2019 19:47:42 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -938,9 +1002,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 8f6483bc11e5ab239a4dccf7676b5b1d
+      - f208bf615192431b09e4d0651506bc1d
     status:
       code: 200
       message: OK
@@ -956,7 +1020,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -964,10 +1028,10 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7XQsQqDMBQF0F+RNzskVRvMP3Rqt1JCMLEVTCzmOYj470WNtlScardcCOfepIO8
-        KpWuHfBrB42ttVQiqxqLwEkIWeOwMuNR6Vw2JQqU9zFj+9TAAWvpHhCClWaIFx8LBTzqw28y2Sbp
-        QhpZ2Ld4aoNzJq3zaLxGP3bSzZ3+xsKidij828UhZsz76U7+RIshCa0K9Dyl/9gfH0k6fzpZF9Af
-        CwSLI88nbKf9pg2GhmBqmH+HkP7WvwCH50NMlAIAAA==
+        H4sIAAAAAAAAA7XQvQqDMBQF4FeROzskNv6+Q6d2KyUEE1tBYzHXQcR3L2q0peJU3XIgfOckHWRV
+        IVVtILl10OhaCcnTqtEICXEhbQxW5XiUKhNNgRzFY8zYvhQkgLUwT3BBi3KIVxtzCcmpd39JL9o2
+        6WKWItcf8tw6l1RoY1W2Vr+G0s2h9sbCojLI7eO5x8LQ+vFO/kTzIXElc7Q8pUfsZwGJ518n6wL6
+        ZwEP2cnyfnjE/oAE836P+Ds1lK0zlDhTycyzqL/3b/eI5SX3AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -978,7 +1042,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:58 GMT
+      - Thu, 21 Nov 2019 19:47:42 GMT
       Expires:
       - '0'
       Pragma:
@@ -986,8 +1050,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -999,9 +1063,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - c7ed2489023d10fd7adebd04ff05ea4d
+      - a1548bd9fff12edba94a127edf64a6a5
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1023,11 +1087,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: PUT
-    uri: https://cloud.tenable.com/scans/102/folder
+    uri: https://cloud.tenable.com/scans/250/folder
   response:
     body:
       string: ''
@@ -1039,7 +1103,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Tue, 16 Jul 2019 20:26:59 GMT
+      - Thu, 21 Nov 2019 19:47:43 GMT
       Expires:
       - '0'
       Pragma:
@@ -1047,8 +1111,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -1056,9 +1120,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 4bebe947e0f919cb7ea9e5c7544d4798
+      - 600fa4feae21fbb64d9a9062be6e51d1
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1076,20 +1140,20 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRyWrDMBD9FTNnuXhrvJwK7aH30FMIRpbGiVrZMtKowYT8e+VsdKG34c3yljmC
-        GnsDzRHMYUQLDfBRWjw8OfnxYOwOGIx8wIAPc0ToKHKCjwtqWuJ2hwRNz7VDBr3REm2rJDQFA2FG
-        skZDQ9aHpnehNaEdlHPKjA6aNKsYOLFH6TW23i97QDhMmhPGfS1rma2KuCrzMq77qowz5CJOuzTN
-        kyLLu6TrH8u6zIvVqi+qIsnqoAqlopZrbQ4ob9SL4GCtvfp4W0fP2ngZrS942JqMVmIOvVcTDL4o
-        J8wn2jl03J7b5dLotWZguncUdHaYJhkD4rtrCO42woUO9eYIP7wm7BbvZUoqF2zOV0kX7Hut7pQ0
-        T4toiT33muDEfl0+p3i9nf4+/O8v/+ALYXZnW54Fp22wT5x8YIHwFpoDO+yVIxOiaTbb0xeA+5St
+        H4sIAAAAAAAAA3VRwW6DMAz9lcpnmABBC5wmbYfdq52qCqWJabMFghJnFar67zMtrbZOu1nv2e/5
+        2SfQfWuhPoE99uigBtErh8dnrz6frNtDBL3okPFuXBB6Wngp+gm1DQm3R4K6FcZjBK01Cl2jFdR5
+        BNL25KyBmlxgMnimBnSd9l7b3kOdZmUEXh5QBYNNCNMcEHaDEYRxm6/KYpepuKgSFVdpnsVJ1SYx
+        JktMBaplkaeJLIXEfFetClGWacJbodLUCGPsEdXNelqYozVzjvf14sXYoBbrK85TgzVajsy9WQ74
+        qr20X+hGZvxBuEmpD8ZEYHcfKOmSMCuSCEjs5yP4W4uQhuvNCX5l5d75vNcupT3HHOeVrtjPWt8t
+        aRympRW2IhiCc/SgfLnirJ0+Cv/7yz/4JdLdbXoWnLccnwQFdgF+C43sDgftyfJp6s32/A1XBcBP
         PAIAAA==
     headers:
       Cache-Control:
@@ -1101,12 +1165,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:26:59 GMT
+      - Thu, 21 Nov 2019 19:47:43 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1116,9 +1180,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - a10900e8113d1957bf52c55c60f16bc0
+      - f48aa262931a0bafc55f0baed34edfd7
     status:
       code: 200
       message: OK
@@ -1134,7 +1198,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -1142,10 +1206,10 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7XQsQqDMBQF0F+RNzskVRvMP3Rqt1JCMLEVTCzmOYj470WNtlScardcCOfepIO8
-        KpWuHfBrB42ttVQiqxqLwEkIWeOwMuNR6Vw2JQqU9zFj+9TAAWvpHhCClWaIFx8LBTzqw28y2Sbp
-        QhpZ2Ld4aoNzJq3zaLxGP3bSzZ3+xsKidij828UhZsz76U7+RIshCa0K9Dyl/9gfH0k6fzpZF9Af
-        CwSLI88nbKf9pg2GhmBqmH+HkP7WvwCH50NMlAIAAA==
+        H4sIAAAAAAAAA7XQvQqDMBQF4FeROzskNv6+Q6d2KyUEE1tBYzHXQcR3L2q0peJU3XIgfOckHWRV
+        IVVtILl10OhaCcnTqtEICXEhbQxW5XiUKhNNgRzFY8zYvhQkgLUwT3BBi3KIVxtzCcmpd39JL9o2
+        6WKWItcf8tw6l1RoY1W2Vr+G0s2h9sbCojLI7eO5x8LQ+vFO/kTzIXElc7Q8pUfsZwGJ518n6wL6
+        ZwEP2cnyfnjE/oAE836P+Ds1lK0zlDhTycyzqL/3b/eI5SX3AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -1156,7 +1220,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:27:00 GMT
+      - Thu, 21 Nov 2019 19:47:43 GMT
       Expires:
       - '0'
       Pragma:
@@ -1164,8 +1228,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1177,16 +1241,16 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 2d5d4b7363bc70aead98ace5ea71f341
+      - 638db03a60ce60f89d1695d99e26410a
       X-Xss-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"folder_id": 100}'
+    body: '{"folder_id": 248}'
     headers:
       Accept:
       - '*/*'
@@ -1201,11 +1265,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: PUT
-    uri: https://cloud.tenable.com/scans/102/folder
+    uri: https://cloud.tenable.com/scans/250/folder
   response:
     body:
       string: ''
@@ -1217,7 +1281,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Tue, 16 Jul 2019 20:27:00 GMT
+      - Thu, 21 Nov 2019 19:47:43 GMT
       Expires:
       - '0'
       Pragma:
@@ -1225,8 +1289,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -1234,9 +1298,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 254efaaf0c1b77c60597aa96dd5a1e74
+      - 777d49f61cc7fbb16d98177a1a969cc0
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1258,16 +1322,16 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/102/launch
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/launch
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSMjFNMzI1tTTUNU1LMdI1MTNK0rW0TDbRTTI1MrVINUkx
-        MbQwV6oFAA7KqXI0AAAA
+        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSSkxONTJJSjHXTUxJNNE1sUi00LWwNDfTtUwzTjKyME9M
+        tTRLVaoFAEuLutg0AAAA
     headers:
       Cache-Control:
       - no-cache
@@ -1278,7 +1342,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:27:01 GMT
+      - Thu, 21 Nov 2019 19:47:44 GMT
       Expires:
       - '0'
       Pragma:
@@ -1286,8 +1350,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1299,9 +1363,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - d4c652540f7921eb8626dc7d011e7f11
+      - 7d0884f1a1ffa61fb7de6fb04501c2e7
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1319,11 +1383,67 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102/latest-status
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/latest-status
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKi5JLCktVrJSyszLLMlMzMmsysxLV6oFABs/DHcZAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:47:44 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-c-ca-central-1-prod
+      X-Request-Uuid:
+      - bf49d7b62fb26b277634cdba3b13b783
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/latest-status
   response:
     body:
       string: !!binary |
@@ -1338,12 +1458,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:27:01 GMT
+      - Thu, 21 Nov 2019 19:47:54 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1355,9 +1475,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - cee4920e746d5fa4e5ffcd3d36d82d4a
+      - 48d095dec827e02c8ef04eeb63f936b4
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1375,11 +1495,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102/latest-status
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/latest-status
   response:
     body:
       string: !!binary |
@@ -1394,12 +1514,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:27:12 GMT
+      - Thu, 21 Nov 2019 19:48:14 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1411,9 +1531,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 8c7d05ff5a9773709ff89a45690967f6
+      - 97d6d50a68fb02765e9a8fd27a432dd2
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1431,67 +1551,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102/latest-status
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWKi5JLCktVrJSKkjNS8nMS1eqBQDhdJo4FAAAAA==
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 16 Jul 2019 20:27:32 GMT
-      Server:
-      - tenable.io
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
-      X-Request-Uuid:
-      - 6629a817034a86dc69459e55337e2970
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: GET
-    uri: https://cloud.tenable.com/scans/102/latest-status
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/latest-status
   response:
     body:
       string: !!binary |
@@ -1506,12 +1570,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:28:12 GMT
+      - Thu, 21 Nov 2019 19:48:54 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1523,9 +1587,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 4c1f4a6e8bef6e952fad5db0908610e1
+      - f55feaee09bc512cb31d9b28db57f2e6
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1543,11 +1607,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102/latest-status
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/latest-status
   response:
     body:
       string: !!binary |
@@ -1562,12 +1626,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:28:13 GMT
+      - Thu, 21 Nov 2019 19:48:55 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1579,9 +1643,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - cb61c4a979db7794a0b866097ebdd4e0
+      - d086a486cbd5f4577b34312d77d28655
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1599,23 +1663,23 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans?folder_id=100
+    uri: https://cloud.tenable.com/scans?folder_id=248
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA62Ty46bMBSGXyXyGip84WJWfYGu2l1VIYPtBNXYyBeN0lHevccJIdNOZ1Nlx7Hh
-        O//5z88r0s5I5QPqv7+iZL0ScphcshH1VYGmFKJbro9SaZFMHKI4Xut4XhXqUfQinFCBrFhy+W0r
-        Z4l6ein+RtYfI/GOXMRsH8Qv58PXSdgAJxnK3kPf6ATIBzq3SXahUYU4bLMPhLXtxudP4t/QQ7Zl
-        UHKOGx7jJ/H/0M+aim8NaPW+AbhyX+R/GTS0jG74un0Sfjkf8giHm093d6rq8qNA4brvHEijjmI6
-        o14LE9QekDWHISd1vzACtrk4Oet5EnF2dpAiQh5x3VBadV3DwQL44h9XBCwJUcQEHZFP1s72CPiU
-        ctoQqzWpa47LWktSsoaMJecTK8ea1J1ikuEuJyechFcPOSnA6lfllzkEEANkTLoCuRcLo/ZIWOnV
-        y+cgf35yPjcL00nJZNSwdY1qWQ0MUGouuSQNK7uWtiXXXVsSJaYSjxjTihE6VqOuW95S1jSadawi
-        OQhxXtQvZ8EAm4wBrzzAQcWtgml9zK/cD5QVo3kjf3I2emdQH30C17df+76xvJ19XyTvK7MAuqwP
-        wzm9/AbXdpTUWwQAAA==
+        H4sIAAAAAAAAA7WU3Y6bMBCFXyXydagM2Pxd9QV6tXtXVWjAQ4JqDPKPVukq795xAsm20d5U6R3G
+        5pszZ455Z8OsFVrHmu/vLBiLoNp+Dsazhu9ZH5yfp8ujwgGC9q2Hw2XtTwuyhnkL7sj2zMAUl6/r
+        clSsyc/7v5FZ9TkzvTEnGM0d+e20e+nBOHoTqeKR+kEoQT4RurZyU+rR+XZtvs1EWa78+kn8K7qN
+        vrSoRr/i0/RJ/D/0i4LXa4GcPxYgV7ZJ/pNBbSnyFS/L/6G/4MWmP+PySQ1Mp100aXedxKo/E9X5
+        x565S6Ji5jUeoD+xZgDt8BbBJcYtXobbhgbKyzSrcRh78ONsWgWeIp9KMqeQZSrJZPricasoBBX0
+        4ANVZDYYM5oD4UOIeWbQYyY6VSagQCSigiqp6rJI6iHvsqoErAuk0+4IFu9ygqNwLWin0TkSQ+Q0
+        Xq75zVCrBDXK4ttXp35+mW0s5vojqqCxXat6nBZNDSSDKCvZZSqRNVdJnYos4fXAE+QFpoCqkCLl
+        fUUqRVeXEqoq5cTz44S/ZkMGmKA1eWUJTiquK+rW+nhke4EGOv1Bfj8bb2fNGm8Dub7+PbaJxels
+        85I8ziuyCDotd8Nzef4NwwhES74EAAA=
     headers:
       Accept-Ranges:
       - bytes
@@ -1626,11 +1690,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '469'
+      - '479'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:28:13 GMT
+      - Thu, 21 Nov 2019 19:48:55 GMT
       Expires:
       - '0'
       Pragma:
@@ -1638,8 +1702,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1649,9 +1713,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 5eff5e4b1bc919e98b8d3aad0fdc28f1
+      - 0fe0b53c800ef27bfd8b3b65ef994a46
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1673,11 +1737,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/102/stop
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/stop
   response:
     body:
       string: ''
@@ -1689,7 +1753,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Tue, 16 Jul 2019 20:28:14 GMT
+      - Thu, 21 Nov 2019 19:48:55 GMT
       Expires:
       - '0'
       Pragma:
@@ -1697,8 +1761,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -1706,9 +1770,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 6c13f06cee10fe2f42a68656dc3f15a2
+      - 2dc965151ee60453fe8c582e3a5b157a
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1726,11 +1790,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102/latest-status
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/latest-status
   response:
     body:
       string: !!binary |
@@ -1745,12 +1809,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:28:14 GMT
+      - Thu, 21 Nov 2019 19:48:55 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1762,9 +1826,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - ba0eedf5bcaed829361adab2b8495cc8
+      - 1929c738e14ae37c74db3fdab95ee332
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1782,11 +1846,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102/latest-status
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/latest-status
   response:
     body:
       string: !!binary |
@@ -1801,12 +1865,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:28:25 GMT
+      - Thu, 21 Nov 2019 19:49:05 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1818,9 +1882,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 40485a67cbedc5346de5bd4a3f3a4ba4
+      - 30fa512b5fb9b5d54721aac4eb0ae329
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1838,11 +1902,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102/latest-status
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/latest-status
   response:
     body:
       string: !!binary |
@@ -1857,12 +1921,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:28:45 GMT
+      - Thu, 21 Nov 2019 19:49:26 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1874,9 +1938,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 89a7ca51c636eb63c30da715fb88ed2a
+      - eb2d0cf819ffd0bd123fefb560a92c56
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1894,11 +1958,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102/latest-status
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/latest-status
   response:
     body:
       string: !!binary |
@@ -1913,12 +1977,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:29:26 GMT
+      - Thu, 21 Nov 2019 19:50:06 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1930,9 +1994,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 1384dfb91246a9fd0c76ffd653b9f0d3
+      - fe6ddbc7b1ba592bb0ecc422dbc2481c
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1950,11 +2014,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102/latest-status
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/latest-status
   response:
     body:
       string: !!binary |
@@ -1969,12 +2033,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:30:36 GMT
+      - Thu, 21 Nov 2019 19:51:16 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1986,9 +2050,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - c6fecb0d8d545fbef4c60ed062f7b07e
+      - 6b222977d15146ddbf0169358684be00
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -2006,11 +2070,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102/latest-status
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810/latest-status
   response:
     body:
       string: !!binary |
@@ -2025,12 +2089,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:30:37 GMT
+      - Thu, 21 Nov 2019 19:51:16 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -2042,9 +2106,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - b9a47df0d573aa8dc10362c64bdb7b2c
+      - ae48c4aa6f06728e6e6b6a7fce89f113
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -2064,11 +2128,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/folders/100
+    uri: https://cloud.tenable.com/folders/248
   response:
     body:
       string: ''
@@ -2080,7 +2144,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Tue, 16 Jul 2019 20:30:37 GMT
+      - Thu, 21 Nov 2019 19:51:16 GMT
       Expires:
       - '0'
       Pragma:
@@ -2088,8 +2152,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -2097,9 +2161,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 0c93480e0fa4ef858be17812f8fd4812
+      - b16a02598fd878d8f8e0bb4baf7d98d8
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -2119,11 +2183,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/scans/102
+    uri: https://cloud.tenable.com/scans/250
   response:
     body:
       string: ''
@@ -2135,7 +2199,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Tue, 16 Jul 2019 20:30:38 GMT
+      - Thu, 21 Nov 2019 19:51:17 GMT
       Expires:
       - '0'
       Pragma:
@@ -2143,8 +2207,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -2152,9 +2216,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 51875cbc00dc9adc8cc12aedcdcbec98
+      - af979c64e4dcdd1eefa1085815b5e875
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -2172,7 +2236,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -2180,10 +2244,10 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7XQsQ6CMBAG4FcxNzNQKTb0HZx0M6a50KIkUAy9DoTw7gasaCRM6tY/ab7773oo
-        mkqb1oE89eBta1CrvPGWQMYR5N5RU09PbQr0FSnCy5SpuxmQQC26K0RgsR7jMcRSg0yG6JNM10k2
-        kzWW9iXuu80hR+sCypfoW0+22jP8mFkyjlTYXW25EMHPfuQ/aDUmZXRJgWfsH/35Ls6eR4+XA9iX
-        A5TgSeBTMZyHOyLt+wc1AgAA
+        H4sIAAAAAAAAA7XQsQ6CMBAG4FcxNzO0WED6Dk66GdM0tCgJFEOvAyG8uwELGgmTsvVPmu/+uw7y
+        ulS6scAvHTjTaKlEVjuDwEkAmbNYV+NT6Vy6EgXK25ixfWjggI20dwjAyGqIZx8LBXzfB99keFg3
+        6WxWsjBv8tjuTpk01qtsqX4UpatF/Y+ZRW1R+OVFyJLE++mf/BcthiS0KtDzlG7Rn8Ukna5OlgPo
+        jwNEwvaej5It+scknvqHJOqv/RMkt/kZmAIAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -2194,7 +2258,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:30:39 GMT
+      - Thu, 21 Nov 2019 19:51:17 GMT
       Expires:
       - '0'
       Pragma:
@@ -2202,8 +2266,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -2215,9 +2279,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 9d31c30c9a68d1db433a51cc1ce0e826
+      - 5a7538952802dc9c2365211271b9f0a3
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -2235,11 +2299,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/102
+    uri: https://cloud.tenable.com/scans/template-f4785b2d-590d-9142-09f0-e06e1aed65410c8ace4b975a8810
   response:
     body:
       string: !!binary |
@@ -2254,12 +2318,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Jul 2019 20:30:40 GMT
+      - Thu, 21 Nov 2019 19:51:17 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -2269,9 +2333,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-d-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 8e1969a17e4b30dbf1dd257774fb8188
+      - b1aca1ed27e3e87b61b405b738ba7929
     status:
       code: 404
       message: Not Found

--- a/tests/integration/helpers/cassettes/test_folder_helper_add_stop.yaml
+++ b/tests/integration/helpers/cassettes/test_folder_helper_add_stop.yaml
@@ -11,7 +11,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -19,48 +19,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -71,11 +77,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:45 GMT
+      - Thu, 21 Nov 2019 19:51:39 GMT
       Expires:
       - '0'
       Pragma:
@@ -83,8 +89,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -94,9 +100,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 124a194fb5c8026aae5362a77b95a2b5
+      - 9bbbb3603224e5c159782d7a8b213767
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -104,7 +110,7 @@ interactions:
       message: OK
 - request:
     body: '{"uuid": "731a8e52-3ea6-a291-ec0a-d2ff0619c19d7bd788d6be818b65", "settings":
-      {"name": "test_scan_5", "enabled": false, "text_targets": "fakehost.tenable.com",
+      {"name": "test_scan_359", "enabled": false, "text_targets": "fakehost.tenable.com",
       "acls": [], "asset_lists": []}}'
     headers:
       Accept:
@@ -114,13 +120,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '205'
+      - '207'
       Content-Type:
       - application/json
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -128,14 +134,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VS247jIAz9F55LlYaQS5/2TyIDTgctgYiLqu5o/n1N2nS00g4PEcHHx+fY/mRJ
-        g2fXT6aDz2A9xtkadmWdvCilh5FPqtW804vgqgHJRW/QTGJQozTsxMK9ZpSy5+AgtdEjctWOwDsQ
-        Ax8n3fJeyx5HISfZAOW80BnXzUEmdD8NQ7O0fOoXKiWWjktQHe8bMDCNCgYhF93pzlQiMYAAQTQe
-        VtxpUp6riVnSo8Gko92yDWTKF+dObAvO6sfuSsrT7vdw+QQcLy9dzevw/3x+OhcqjStYl96kK11Z
-        ffagHBLxAi4hKYT0oQJEMy/W4QG3XrticIbbLeKNusKuORZ8ipuzXXG+W2/C/UjQJeWwzhniDXMt
-        9by1562oej3nZ+GEukSbH2cdVlKTKJYr3cETYyHQ8Vcjf4J/R33IdrEaaj+r3ozx2+EHxOqroYkm
-        at+GcbUpEZIgl3asw1iguPxvpHktDUkGbyLefyXz+xzi7b1NdQrtiTmgwa7BfAswe18utAOtaJqW
-        hqkj/hTKj62uB7WDxk/c+/z7r6+/0OYjRfICAAA=
+        H4sIAAAAAAAAA3VS247jIAz9F55LlRsJ6dP+SWTA6aAlEAFR1R3Nv69Jmo5W2uEhcnw5Psf2J0sa
+        PLt9Mh18BusxTtawG+tErZQeJB9Vo3mn55arCgRve4NmbAclhWEXFh6lYtv2GhyENloiV40E3kE7
+        cDnqhvda9ChbMYoKqOaVnXFZHWTkXdWIXreKq7lWXNRU1hkYeN8a1L1GKY1sFYhOmr6Z6xn6riEY
+        DwvuMClPRcREDchtMOlo12wDyfKbcxe2Bmf1c9fViPqySz6FHhmn50Wtej3+n89Pr6beuIB16Q26
+        kMmK24NySMAzuIREEdKHChDNNFuHZ7r12m0GJ7jfI95pMOyW44YHuSnbBaeH9SY8zgK9pRyWKUO8
+        Yy6tDqu5rpsq5jUfjRPqLdr8vOqwEJtEsVzgTpwYN0o6/0rkT/DvqA/ZzlZDGWjhmzF+K/yAWHRV
+        tNRE41sxLjYlyqSUupFlGzNsLv8bqV53Q5TBm4iPX8n8voZ4fx/UvqoLc0C7XYL5JmD2udRi6Npe
+        yHGkKUT8KZSfa7kQGgftn7CPA2i+vv4CfTn2cfYCAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -146,7 +152,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:45 GMT
+      - Thu, 21 Nov 2019 19:51:39 GMT
       Expires:
       - '0'
       Pragma:
@@ -154,8 +160,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -167,16 +173,74 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 3ddde15be69c0b181a024a4a1b2693a4
+      - b569ae8734353b2358186af1a6fe3ea3
       X-Xss-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "test_folder_743"}'
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3VRyWrDMBD9lTBnu8RrXJ9Ke+8l9BSCkaVxokaRjDTCmJB/r+wsbVN6G94sb5kT
+        SN0ZqE9gBo0WamBaWBxenDg8GbuDCDQ7YsAJHTWOM91kxfMEm4aY3SFB3THlMILOKIG2kQJq7ZWK
+        gBtN1iioyfrQ9y50e7RH6Zw02kGdpFUEju9ReIWN99NqIDr2ihHG+TItSp61cdslbVwk2SrOBVvF
+        ZSaQlxyrSlRZy4q8EmXaJR0r8zQIQyGpYUqZAcWNetId7DVXLx/rxZsyXizWFzxs9UZJPobeK3OS
+        L96RBmMP80Douj2zePdl2k/kNBtNizQCYrtrFu42wrgK9eYEv/wuo1vMlykhXbA6XmVdsJ/1d5Q0
+        9pNwgR3ziuAcPVyek7zeTh4P//vTP/hs6c42PQzO22CfGPnAAuE1NAZ22EtHxoa8NtvzF1J+mg5E
+        AgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:51:39 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-c-ca-central-1-prod
+      X-Request-Uuid:
+      - bc5c7381d30370da26ed0fa17151eb80
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "test_folder_938"}'
     headers:
       Accept:
       - '*/*'
@@ -191,7 +255,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -199,7 +263,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6tWykxRsjI1rwUAmIZjGgkAAAA=
+        H4sIAAAAAAAAA6tWykxRsjIyNa4FAKAU0fIKAAAA
     headers:
       Cache-Control:
       - no-cache
@@ -210,7 +274,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:45 GMT
+      - Thu, 21 Nov 2019 19:51:40 GMT
       Expires:
       - '0'
       Pragma:
@@ -218,8 +282,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -231,9 +295,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 0221627dc70acc43dd6824dc8c918958
+      - 86b8ee454ae7c5e9b4aa07be1dde0728
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -251,21 +315,21 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRyW7CMBD9FTTnpKJkg5yq9t4L6gmhaGJPwMXEkT1WFCH+vQ4E2lL1NnqzvGVO
-        oNrGQHkC07dkoQRspaX+xcnDk7E7iKDFIwWcyXHlBLZVNoKmYrQ7Yigb1I4iaIyWZCsloWy91hEI
-        07I1Gkq2PvS9C92O7FE5p0zroHxeLCNwYk/Sa6q8H1cDzbHTyBTX+aoo5s0iXuWNiNOkSeMM6zTO
-        5yhxtayxSLJGpCKVucjypMAEkyCMpOIKtTY9yRv1qDqYqyYnH+vZmzZeztZXPGx1RisxhN4rOiVm
-        78S9sYfLQOi6PVq6+zL1Jwm+GM3yCBh3UxTuNoFCh3pzgl9259Et4+uUVC44HSZVV+xn/Z0kD92o
-        W1KDXjOco4fLlyCn28+Ph/996B98JFzc2cZ/wXkb3DOyDywQPsNDYIe9cmxsiGuzPX8Bxn9ct0EC
-        AAA=
+        H4sIAAAAAAAAA3VRyWrDMBD9lTBnu8RrXJ9Ke+8l9BSCkaVxokaRjDTCmJB/r+wsbVN6G94sb5kT
+        SN0ZqE9gBo0WamBaWBxenDg8GbuDCDQ7YsAJHTWOM91kxfMEm4aY3SFB3THlMILOKIG2kQJq7ZWK
+        gBtN1iioyfrQ9y50e7RH6Zw02kGdpFUEju9ReIWN99NqIDr2ihHG+TItSp61cdslbVwk2SrOBVvF
+        ZSaQlxyrSlRZy4q8EmXaJR0r8zQIQyGpYUqZAcWNetId7DVXLx/rxZsyXizWFzxs9UZJPobeK3OS
+        L96RBmMP80Douj2zePdl2k/kNBtNizQCYrtrFu42wrgK9eYEv/wuo1vMlykhXbA6XmVdsJ/1d5Q0
+        9pNwgR3ziuAcPVyek7zeTh4P//vTP/hs6c42PQzO22CfGPnAAuE1NAZ22EtHxoa8NtvzF1J+mg5E
+        AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -276,12 +340,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:46 GMT
+      - Thu, 21 Nov 2019 19:51:40 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -291,14 +355,14 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 3aa68ec45cab2f667284b23475eab09e
+      - db3866e15d95658721e31687ec758195
     status:
       code: 200
       message: OK
 - request:
-    body: '{"folder_id": 57}'
+    body: '{"folder_id": 253}'
     headers:
       Accept:
       - '*/*'
@@ -307,17 +371,17 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '17'
+      - '18'
       Content-Type:
       - application/json
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: PUT
-    uri: https://cloud.tenable.com/scans/56/folder
+    uri: https://cloud.tenable.com/scans/252/folder
   response:
     body:
       string: ''
@@ -329,7 +393,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Mon, 15 Jul 2019 22:33:46 GMT
+      - Thu, 21 Nov 2019 19:51:40 GMT
       Expires:
       - '0'
       Pragma:
@@ -337,8 +401,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -346,9 +410,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 34f544f8bb3e7cbef6e8ae6eb2974093
+      - 56e3fa85c8ed175d70ad4b5a1e1bf6ab
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -366,21 +430,21 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRy27CMBD8FbRnpwLygpyq9t4L6gmhaOMHuJg4steKIsS/14GAWqreVjO7Mzu7
-        Z9CtslCdwfatdFABtsLJ/tWL44t1e2DQ4klGnKSn2nNs63wEbU3o9pKgUmi8ZKCsEdLVWkCVlwy4
-        bclZAxW5ENngI9dJd9Lea9t6qBbLFQPPD1IEI+sQxsFocuoMkkyaYl2Wc7VM1oXiSZaqLMmxyZJi
-        jgLXqwbLNFc845koeF6kJaaYxrWk0FSjMbaX4m497hyj1VOOz83s3dggZpsbHqc6azQfIveGXvPZ
-        h6TeuuO1IbL+gG5Ua4MxDGzzJTndYhYMCPfTIfy9A7mJ9fYMv+LO2f3Cty6hfUw6TFvdsJ+1fjjS
-        0I17C6kwGIILe1K+HnLSXjwL//vOP/houHy4jf+Cyy6mJ6QQXSB+hoboDgftybp4ru3u8g3+tkm6
-        PwIAAA==
+        H4sIAAAAAAAAA3VRy27CMBD8FbRnpyJP0pyq9t4L6gmhyLE34GLsyF4rQoh/rwMB9aHeVjO7Mzu7
+        Z1Cmt9CcwY4GHTTAjXQ4vnh5eLJuBwwMP2LECT21XnDT5uXzBNuWuNshQdNz7ZFBb7VE1yoJTVbm
+        DIQ15KyGhlyIdPCRHNAdlffKGg9NmtUMvNijDBrbEKbJ6HMcNCdMimVWViLvkq5Pu6RM81VSSL5K
+        qlyiqATWtazzjpdFLausT3teFVncC6WilmttR5R362ntmK6do3ysF2/aBrlY3/A4NVitxClyr9wr
+        sXhHGq07XBsi6/fcTWomaM3Adp8oaM6ZMSC+m0/h7y1c6FhvzvAj75Ldr3zrksrHqKd5rRv2vVYP
+        SzoN0+ISex40wYX9Ur5ectZOfwv/+9I/+DXSw216GFy2MT5xCtEF4mvoFN1hrzxZF++12V6+AP+Z
+        RUNDAgAA
     headers:
       Cache-Control:
       - no-cache
@@ -391,12 +455,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:47 GMT
+      - Thu, 21 Nov 2019 19:51:41 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -406,9 +470,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - d548bb9a165cf6c1d2b6ea29894a5a00
+      - 5a3d76ad9ce1afd444e06a72bbc48f48
     status:
       code: 200
       message: OK
@@ -428,16 +492,16 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/56/launch
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/launch
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSsrRMsTA3S0vStTAzTdM1SbG01E00MDDUTUlMTjNOTE1J
-        TjNKVqoFAHzNLKc0AAAA
+        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSMjYxNDVLSUvVtTQ2NdA1STE20U1KM0nSNTexMDNOMklO
+        Nrc0VqoFAM+ppnk0AAAA
     headers:
       Cache-Control:
       - no-cache
@@ -448,7 +512,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:47 GMT
+      - Thu, 21 Nov 2019 19:51:41 GMT
       Expires:
       - '0'
       Pragma:
@@ -456,8 +520,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -469,9 +533,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - cd437e046b91ec7db4c1174693567241
+      - 2077f239eb157306e7655f99dc84cfc4
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -489,11 +553,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56/latest-status
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/latest-status
   response:
     body:
       string: !!binary |
@@ -508,12 +572,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:48 GMT
+      - Thu, 21 Nov 2019 19:51:41 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -525,9 +589,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - ad5f0534b055364556e95793547040cb
+      - 687a21d743e0269fbc869087c5c93e31
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -545,11 +609,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56/latest-status
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/latest-status
   response:
     body:
       string: !!binary |
@@ -564,12 +628,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:33:58 GMT
+      - Thu, 21 Nov 2019 19:51:52 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -581,9 +645,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 95bd92f9e474c746389f11008f25f7be
+      - 835353eb73f1f1e769af1d18bafeb3a8
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -601,11 +665,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56/latest-status
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/latest-status
   response:
     body:
       string: !!binary |
@@ -620,12 +684,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:34:18 GMT
+      - Thu, 21 Nov 2019 19:52:12 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -637,9 +701,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 64474dcd31d59d58fca9dfd5acbc124e
+      - 219569ba0e3746ed953429687a4db0bf
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -657,11 +721,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56/latest-status
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/latest-status
   response:
     body:
       string: !!binary |
@@ -676,12 +740,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:34:58 GMT
+      - Thu, 21 Nov 2019 19:52:52 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -693,9 +757,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - a9339655440f71dfbd36083a69d9cbbc
+      - 2f9cda86ae24c2b08d79917f209f8ffd
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -713,11 +777,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56/latest-status
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/latest-status
   response:
     body:
       string: !!binary |
@@ -732,12 +796,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:34:58 GMT
+      - Thu, 21 Nov 2019 19:52:52 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -749,9 +813,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 3deff27f49dcdf07fabd324ee1067606
+      - d9fcf894d6788f9a5a883182db54d9d4
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -769,22 +833,23 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans?folder_id=57
+    uri: https://cloud.tenable.com/scans?folder_id=253
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA62Ty27bMBBFf6XgWir0oERTq/5AV+2uKIgRH7ZQihT4QOAG/vcOHcVxH+kiyE4j
-        Umfu3Dt6JMZbpUMk07dHkl3QoIT02SUyNRWROSa/Xh+VNpBtEgmO1zqdN00mkgLEE6mIg7WUX/dy
-        UWTqL9WfyPZ1JB7tyBUW90L8fP7wRYKL+KZA6d/QO50IeUXnPslNaNIxiX120VHGdj5/J/4TWhRb
-        hFZL2vFt+0783/TTseF7g775r+tvMkgw2u/4gV2+VyReAykbY/UR5JlMBmzUtwS3klZZpduBBbR7
-        9Woxi4S0eCcUJFyYdhj7rm8a3uFm4Bf/OOoYNkyQMnYkITu3uCPicy7rQDhXBzaauT6Mg6mp4ryG
-        pmlrBdL0oJU0ncTb8QRBv8jJEbPZdFiXGFEMktvuUBH/4HRAKDgV9MOnqH589KE0i/KkVbZa7F2T
-        XjeLA9TzyBlrTFfz0cia9obWA8y0HhtQwA8zsH4wkkqqRomjMuihWJmWVf/0Dg1w2Vr0KiAcVTxV
-        OG1I5crzC+1gtnfypXcpeEumFDK6vv9715Uo0YjhOa2xpFVIiFy3O7v55RemP4gV+gMAAA==
+        H4sIAAAAAAAAA7WUy27cIBSGX6ViPa5sc/Fl1Rfoqt1VFcKAZ6xgsLgomkbz7j1MGE/aNJsq2fmA
+        /Z3//Pz4Cc3OKO0DGn88oWS9FopLl2xEY31AMoXo1uuj0rNIJvIojtc6njeNRhS9CCd0QFasufxe
+        ykWhEV8OfyPb/m1mszNXsdg78uv50zcpbICVTCWvqS+EAuQNoWWUXWnUIfIyPG9J1xX+8E78ZzTP
+        vnCtlljwTfNO/D/0E1YPpQGuXzcAV24n+V8G8Y7ggqfdR+hnNbvpb2v6AQMMuC8DtBRffh5QuEYq
+        h97oo5BnNM7CBL1ncMt5y7dh3zACArM6tcyLFHFxlisRIfMNBXcYHegALsMX/9iqwfUQRUzQEflk
+        7WKPgE8pBxph0lCmZl0NmNYVUZhU00ymqiM9wxORshuy++EkvL7LSQHStWm/LiGAGCA3+Xa5R6s9
+        QIVVXj9+Cerhs/O5WZAnrZLRvHSNet0MDFCRuqVM4gmaNlNFG9yBBtFVDCstmdR9r3o8CUp6xdq5
+        mQUjLfDisupfzoIBNhkDXnmAg4rnCqb1Mb9yW9BWTOaFfOls9M6gMfoErpffxzXU+Wg4pnsgaJsP
+        LMOAum53xzt8+Q0/7N7HwAQAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -795,11 +860,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '451'
+      - '475'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:34:59 GMT
+      - Thu, 21 Nov 2019 19:52:53 GMT
       Expires:
       - '0'
       Pragma:
@@ -807,8 +872,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -818,9 +883,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - ee4c2b74a56eb25bf0359668d951c025
+      - 233952a0ae0e7eb2f21b37a4e8a2aae7
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -842,11 +907,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/56/stop
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/stop
   response:
     body:
       string: ''
@@ -858,7 +923,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Mon, 15 Jul 2019 22:34:59 GMT
+      - Thu, 21 Nov 2019 19:52:53 GMT
       Expires:
       - '0'
       Pragma:
@@ -866,8 +931,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -875,9 +940,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - cb7b1de2e5f4bcd357c27f40a7cf14f4
+      - 9fa5dfe4b9c40d8e431549cc22e0da7a
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -895,11 +960,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56/latest-status
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/latest-status
   response:
     body:
       string: !!binary |
@@ -914,12 +979,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:34:59 GMT
+      - Thu, 21 Nov 2019 19:52:53 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -931,9 +996,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - de3b72e2c742018fee45c9c60e1d4ef2
+      - caed8e10722803cf4db21db8041d2d6d
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -951,11 +1016,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56/latest-status
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/latest-status
   response:
     body:
       string: !!binary |
@@ -970,12 +1035,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:35:09 GMT
+      - Thu, 21 Nov 2019 19:53:03 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -987,9 +1052,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 2df832be2da3c0abe09a0acb773cfcc5
+      - 1c8497d2fa484aa430b2dd362596e0e5
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1007,11 +1072,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56/latest-status
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/latest-status
   response:
     body:
       string: !!binary |
@@ -1026,12 +1091,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:35:30 GMT
+      - Thu, 21 Nov 2019 19:53:23 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1043,9 +1108,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - a3b99761373575aaa10d075cb360500b
+      - c04f4e0179222b96b3076a3396ea2072
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1063,11 +1128,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56/latest-status
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/latest-status
   response:
     body:
       string: !!binary |
@@ -1082,12 +1147,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:36:10 GMT
+      - Thu, 21 Nov 2019 19:54:03 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1099,9 +1164,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 5602880a94082f117f5bf18ebf5dd610
+      - 73b8cd0d9550af7c1da583a076148e0e
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1119,11 +1184,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56/latest-status
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/latest-status
   response:
     body:
       string: !!binary |
@@ -1138,12 +1203,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:37:28 GMT
+      - Thu, 21 Nov 2019 19:55:14 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1155,9 +1220,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - db5a587ce55cd2a582dcd5c094405399
+      - 32fe7958032d58675bd3e8a0cc438b99
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1175,11 +1240,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/56/latest-status
+    uri: https://cloud.tenable.com/scans/template-40256c3b-bf1b-5137-4da7-63dec6ce88d83ba548d62f1fa642/latest-status
   response:
     body:
       string: !!binary |
@@ -1194,12 +1259,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:37:28 GMT
+      - Thu, 21 Nov 2019 19:55:14 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1211,9 +1276,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-c-ca-central-1-prod
       X-Request-Uuid:
-      - 272427b910c8e79d731a7a7c5c363de9
+      - 5311176ac721f1165e17dce0ddeae5e1
       X-Xss-Protection:
       - 1; mode=block
     status:

--- a/tests/integration/helpers/cassettes/test_scan_helper_cancel_after.yaml
+++ b/tests/integration/helpers/cassettes/test_scan_helper_cancel_after.yaml
@@ -8,8 +8,10 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -17,48 +19,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -69,11 +77,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:56:25 GMT
+      - Thu, 21 Nov 2019 19:03:56 GMT
       Expires:
       - '0'
       Pragma:
@@ -81,8 +89,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -92,9 +100,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - bf5fcf5699167b150e560fff96c9c762
+      - af845a079ec7f0347657ba6f0fe90452
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -102,7 +110,7 @@ interactions:
       message: OK
 - request:
     body: '{"uuid": "731a8e52-3ea6-a291-ec0a-d2ff0619c19d7bd788d6be818b65", "settings":
-      {"name": "test_scan_331", "enabled": false, "text_targets": "fakehost.tenable.com",
+      {"name": "test_scan_63", "enabled": false, "text_targets": "fakehost.tenable.com",
       "acls": [], "asset_lists": []}}'
     headers:
       Accept:
@@ -112,13 +120,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '207'
+      - '206'
       Content-Type:
       - application/json
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -126,14 +134,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VS247jIAz9F55LFZISSJ/2TyIDpoOWQAREVXc0/76QNh2ttMND5PhyfI7tT5I1
-        BHL9JDqGAi5gmp0hV3LhTCktJJ1Ur+lF24GqDjgdRoNmGoSS3JATifdWsW17DQqujZZIVS+BXmAQ
-        VE66p6PmI8qBT7yDWvPKLrisHgpSVDAK1lkK3CLljHVUMtNR7IQVtjcTWLBdL8WomDVGjBPvK0yA
-        BXeYXOYmYh4GVt0Gs05uLS5WWWHz/kTW6J1+7LoYE6dd8iH0mXF4XtS616P/+fz0Wm9cwPn8Bl2q
-        SZo7gPJYgS34jJUi5A8VIZnZOo9HugvabwZnuN0S3upgyLWkDZ/k5uIWnO8umHg/CvSWS1zmAumG
-        pbV6Wv153VQzz+XZOKPekiuPs45LZZNrrDS4AyelrSYdfy3yJ4Z3NMTirNPQBtr4FkzfCj8gNV1d
-        XWqu41sxLS7nmllTWC/bNixsvvwb6V53UylDMAnvv7L5fY7p9j6otoX+RDzU3S7RfBMw+1wYH4dB
-        TkLyOoWEP4XKY20XUsdR91+xnwcgv77+AkdgOxX2AgAA
+        H4sIAAAAAAAAA3VS246jMAz9lzw3FRBCoE/7J8hJTCfaQFASVHVH8+/rQOlopZ08IOPL8Tm2P1ky
+        sLDbJzNhyeAWjKOz7MZaWWttVM8H3RjemklwXYHkorNoB6F0Ly27sPAoFdu216CSxpoeuW564C0I
+        xfvBNLwzssNeyEFWQDWv7Izz6iEjl02FRknFm1YKXvUN8EnrmnettWqq+6my2g5glDWDaBsANBPB
+        LDDjDpPyWESMnSCvxWSiW7MLpGrZvL+wNXhnnruspu0uu+JT55Fxel7Mqtfj//n89GrqjTM4n96g
+        M5msuBfQHgl4Ap+QKEL60AGiHSfn8Ux3i/GbxRHu94h3mgu75bjhQW7Mbsbx4RYbHmeB2VIO85gh
+        3jGXVofVXNdNF/Oaj8YJzRZdfl5NmIlNolgucCdOjBslnX8l8ics7+gSspucgTLQwjdj/Fb4AbHo
+        qminica3YpxdSpRJKXXTl21MsPn8b6R6nQ1RhsVGfPxK9vc1xPv7nvZVXZgHWu0c7DcBu8+llqoV
+        naiEoilE/CmUn2s5EBoH7Z+wjwNQX19/ATqyQev1AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -144,7 +152,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:56:25 GMT
+      - Thu, 21 Nov 2019 19:03:57 GMT
       Expires:
       - '0'
       Pragma:
@@ -152,8 +160,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -165,11 +173,69 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 1fb9f43aa65cb96bd8ea163068636602
+      - 3b1fb84e1e7d4552a7e816a504308f9e
       X-Xss-Protection:
       - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3VRS2+CQBD+K2bO0CCiWE5Ne+/F9GQMGXYH3bqyZHc2hBj/exdE29r0Nvnm8T3m
+        DKqpDRRnMF1DFgrARlrqXpw8Phm7hwgaPFHAmRyXTmBTrhYDakpGuyeGokbtKILaaEm2VBKKxmsd
+        gTANW6OhYOtD37vQbcmelHPKNA6KebqOwIkDSa+p9H5YDTynViNTvEwTEvkyj9NsuYiTdYpxXVXz
+        eJVJmdfzdZ3ISj6jyKV4XmQpIok6CCOpuEStTUfyRj3IDu7KycrHZvamjZezzRUPW63RSvSh94pO
+        idk7cWfscRwIXXdAS3dfpvokwaPRNMsjYNxPWbjbCAod6u0ZfvlNolvK1ympXLDaT7Ku2M/6O0ru
+        20G4pBq9ZrhED5fHJKfb88fD/770Dz5aurMND4PLLthnZB9YILyG+8AOB+XY2JDXdnf5AiMHfjlD
+        AgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:03:58 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - 4162c0566c8a0a1e1ea91e98876c478b
     status:
       code: 200
       message: OK
@@ -189,16 +255,16 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/118/launch
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/launch
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSMjA3NTC1TDLRTUlJNNI1sTBP1LVINU/VNTAwTk5Kski2
-        SDY0UKoFAM6LKUY0AAAA
+        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSMjQxN7Q0TknVTUtJNNc1sTRK0rVIsjTWNU01MbU0Mku1
+        TEuzVKoFACbBFJU0AAAA
     headers:
       Cache-Control:
       - no-cache
@@ -209,7 +275,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:56:26 GMT
+      - Thu, 21 Nov 2019 19:03:58 GMT
       Expires:
       - '0'
       Pragma:
@@ -217,8 +283,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -230,9 +296,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - aa1fa6c2857b59e4086fcce3db190aaa
+      - a3db120d205f84c3a98faeea18221b0b
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -250,11 +316,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -269,12 +335,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:56:26 GMT
+      - Thu, 21 Nov 2019 19:03:58 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -286,9 +352,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 0be68d65d47a2a97b9153962bc40f91d
+      - 9c6509782195538f25017f2084ca8bab
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -306,11 +372,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -325,12 +391,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:56:37 GMT
+      - Thu, 21 Nov 2019 19:04:08 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -342,9 +408,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - aaa687f1647a82dc34211f528da482d4
+      - 4116fba8657855ef91c08483c74d4358
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -362,11 +428,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -381,12 +447,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:56:57 GMT
+      - Thu, 21 Nov 2019 19:04:29 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -398,9 +464,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 6726662f843e5f6cacd257b038665056
+      - d56c077cbadf34f2f87c9b124e2bddd8
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -418,67 +484,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWKi5JLCktVrJSKkjNS8nMS1eqBQDhdJo4FAAAAA==
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 17 Jul 2019 18:57:37 GMT
-      Server:
-      - tenable.io
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
-      X-Request-Uuid:
-      - fe70ecb316a1a1885777ed351bc4c930
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -493,12 +503,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:58:47 GMT
+      - Thu, 21 Nov 2019 19:05:09 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -510,9 +520,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 830b3a47d84403bbefe14442557230df
+      - d0316e1122e51bb522b7ca1d37ba2c5d
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -530,11 +540,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -549,12 +559,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:58:48 GMT
+      - Thu, 21 Nov 2019 19:05:09 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -566,9 +576,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - eb97ad8f73fd2086c03c37197c4f86a7
+      - 0fab6cf5083eafde1ed4a87ec6e95a56
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -586,11 +596,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -605,12 +615,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:58:58 GMT
+      - Thu, 21 Nov 2019 19:05:19 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -622,9 +632,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 54f31fa85f70c38c2cd5b9cb30c4c399
+      - 1455b73b0690637bcb8b9c79973a32f7
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -646,11 +656,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/118/stop
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/stop
   response:
     body:
       string: ''
@@ -662,7 +672,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Wed, 17 Jul 2019 18:58:58 GMT
+      - Thu, 21 Nov 2019 19:05:19 GMT
       Expires:
       - '0'
       Pragma:
@@ -670,8 +680,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -679,9 +689,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - e9a4e535e6219fe1e41a333a0ecd3f60
+      - 9d3252bee701ccc1242e0988dc1f204c
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -699,11 +709,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -718,12 +728,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:58:59 GMT
+      - Thu, 21 Nov 2019 19:05:20 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -735,9 +745,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - c70157a424fb51a9cb864c5654d4cdfc
+      - 5ceebb6c95f5efec26f958ba4f803710
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -755,11 +765,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -774,12 +784,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:59:09 GMT
+      - Thu, 21 Nov 2019 19:05:30 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -791,9 +801,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 93ca7a92864442a5b10e61ae4641eac9
+      - 532c7c14b39322f10f741c2a057c81ae
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -811,11 +821,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -830,12 +840,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:59:29 GMT
+      - Thu, 21 Nov 2019 19:05:50 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -847,9 +857,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - c6e01317b3cf219ba43c378f03fffa1b
+      - 30f763f54819550dd9f32a64ab1bd4ed
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -867,11 +877,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -886,12 +896,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 19:00:10 GMT
+      - Thu, 21 Nov 2019 19:06:30 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -903,9 +913,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 3ef9131da170042c66e86eff57742b14
+      - 761a3cb9c63b6ae9d95728773f08bb34
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -923,11 +933,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -942,12 +952,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 19:01:20 GMT
+      - Thu, 21 Nov 2019 19:07:40 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -959,9 +969,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - ea64f707e4f6b78dbeabcb2455bdd1e0
+      - 28c2a9a0fb9e8442f9cb833933f8a342
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -979,11 +989,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/118/latest-status
+    uri: https://cloud.tenable.com/scans/template-520ec757-2453-082a-fbb1-64dd7f18f0dbd9ac7dc9342aaecf/latest-status
   response:
     body:
       string: !!binary |
@@ -998,12 +1008,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 19:01:20 GMT
+      - Thu, 21 Nov 2019 19:07:40 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1015,9 +1025,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-a-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 2e264dfcfa0b9510ce1dd078fcce0581
+      - c6a7e9a5a4c29b4d5809ed51298d04b3
       X-Xss-Protection:
       - 1; mode=block
     status:

--- a/tests/integration/helpers/cassettes/test_scan_helper_details.yaml
+++ b/tests/integration/helpers/cassettes/test_scan_helper_details.yaml
@@ -8,10 +8,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -19,48 +17,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -71,11 +75,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:34:13 GMT
+      - Thu, 21 Nov 2019 19:03:55 GMT
       Expires:
       - '0'
       Pragma:
@@ -83,8 +87,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -94,9 +98,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 68a964528466b23f879e3706ab8b13a3
+      - 1c607242e0877df3d789dfbe3a8af827
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -104,7 +108,7 @@ interactions:
       message: OK
 - request:
     body: '{"uuid": "731a8e52-3ea6-a291-ec0a-d2ff0619c19d7bd788d6be818b65", "settings":
-      {"name": "test_scan_756", "enabled": false, "text_targets": "fakehost.tenable.com",
+      {"name": "test_scan_119", "enabled": false, "text_targets": "fakehost.tenable.com",
       "acls": [], "asset_lists": []}}'
     headers:
       Accept:
@@ -120,7 +124,7 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -128,14 +132,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VS247jIAz9F55LFZISkj7tn0SAnQ5aAhEQVd3R/PuatOlopR0eIseX43Nsf7Js
-        dWDXT2ZjKNoFTJMDdmUXKYyxauCjaS2/2LnjptGSdz0gjJ0ygwR2YvFeK7Ztr0ElLdgBuWkHzS+6
-        U3wYbct7K3scOjnKRlPNK7vgsnpdkCsJnZBDz8FI4LMUgiuQiot2hB5mZdAYIXSDw6j6TkGj4EIw
-        QS+4w+QyVRGTkj25AbNNbi0ukqyweX9ia/TOPnZdvTjtig+dz4TD82LWvB7/z+enJ6g1Ltr5/AZd
-        yGTVHbTxSMCz9hmJoc4fJuoE0+w8HukuWL8BTvp2S3ijubBrSRs+yU3FLTjdXYB4PwrslktcpqLT
-        DUtt9bTa87qZap7Ls3FGuyVXHmcbF2KTKVYq3IGT0kZJx1+N/InhHQ2xuNlZXedZ+RZM3wo/dKq6
-        GtpppvGtmBaXM2VSimiHuoxZb778G2leZ0OUdYCE918Zfp9jur3vqW6hPTGvabVLhG8CsM9FyL5r
-        u6aRHU0h4U+h8ljrgdA4aP2Eve+//fr6CwqSw870AgAA
+        H4sIAAAAAAAAA3VS247jIAz9F55LlYSQS5/2TyIDTgctgQiIqu5o/n1N0nS00g4PkePL8Tm2P1nS
+        4Nntk+ngM1iPcbKG3Vgra6V0P/BRNZq3ehZcVSC56AyaUfRqkIZdWHiUim3ba7CX2ugBuWoG4C2I
+        ng+jbninZYeDkKOsgGpe2RmX1UFGDlUnhalG3jfKcKXqijeiVVx1SkFTj2YcurHWsyZCA4wt9p0k
+        GA8L7jApT0XEVNcjuQ0mHe2abSBZfnPuwtbgrH7uupq2ueyST6FHxul5Uatej//n89OrqTcuYF16
+        gy5ksuL2oBwS8AwuIVGE9KECRDPN1uGZbr12m8EJ7veIdxoMu+W44UFuynbB6WG9CY+zQG8ph2XK
+        EO+YS6vDaq7rpop5zUfjhHqLNj+vOizEJlEsF7gTJ8aNks6/EvkT/DvqQ7az1VAGWvhmjN8KPyAW
+        XRUtNdH4VoyLTYkyKaVuhrKNGTaX/41Ur7shyuBNxMevZH5fQ7y/D2pf1YU5oN0uwXwTMPtcatm3
+        ohOVkDSFiD+F8nMtF0LjoP0T9nEA4uvrL9u9cbj2AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -146,7 +150,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:34:13 GMT
+      - Thu, 21 Nov 2019 19:03:55 GMT
       Expires:
       - '0'
       Pragma:
@@ -154,8 +158,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -167,9 +171,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 52f90e1127857aa616205499f1d60e18
+      - bf18b7d87226db8879c20b1620e2fd4e
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -187,20 +191,20 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.0
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/62
+    uri: https://cloud.tenable.com/scans/template-a0653d09-72bd-bb10-234b-b6bba219d98691cfcbbc8a94e765
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VRS2+CQBD+K2bO0AgWUE5Ne+/F9GQMWZhBt667ZHc2hBj/exdF29r0Nvnm8T3m
-        BFK3BsoTmF6ThRKERkv9i8PDk7E7iECLIwWcyXHlGqGrIstH2FQs7I4YylYoRxG0RiHZSiKU2isV
-        QWM0W6OgZOtD37vQ7cgepXPSaAdlki4jcM2e0CuqvB9XA9GxU4IpLjJcJNkyj7HOMG6zJIkLzIo4
-        SVeYY1vUVNdJIua0XBX5osB5gc9BGKHkSihlesIb9ag72KsmLx/r2ZsyHmfrKx62OqNkM4Teq3Cy
-        mb0T98YeLgOh6/bC0t2XqT+p4YvRPI2AxW6Kwt0mRKNCvTnBL7vz6JbydQqlC06HSdUV+1l/J8lD
-        N+pGaoVXDOfo4fIlyOl28nj435f+wUfC9M42/gvO2+CeBfvAAuEzPAR22EvHxoa4NtvzFxsfI61D
+        H4sIAAAAAAAAA3VRyW7CMBD9FTTnpEoCBJJT1d57QT0hFHmZgIuxI3usKEL8e52wdFNvozfLW+YM
+        yrQW6jPY3qCDGpiRDvtnL49P1u0hAcNOGHFCT40XzDR5Xo2wbYi5PRLULdMeE2itlugaJaE2QesE
+        hDXkrIaaXIj94GO3Q3dS3itrPNR5sU7AiwPKoLEJYVyNRKdOM8KUZeVyLrMqXRVcppznWVrMFzzl
+        JeesyCtZrcsqF63gXKxZtcBVuYzCUCpqmNa2R3mnHnVHe83Ny/tm9qptkLPNFY9bndVKDLH3wrwS
+        szek3rrjNBC7/sAcPnxZ/oGCJqPFYp4Asf0tC38fYULHenuGH36z5B7zdUoqH60ON1lX7Hv9FSUN
+        3ShcYsuCJrgkvy5PSd5u578P//vTP/hk6cE2Pgwuu2ifGIXIAvE1NER2OChP1sW8trvLJ7Xb5c5E
         AgAA
     headers:
       Cache-Control:
@@ -212,12 +216,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 15 Jul 2019 22:34:14 GMT
+      - Thu, 21 Nov 2019 19:03:56 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -227,9 +231,67 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 325dfc531ec15bd76ee35c280d458b0e
+      - 174852ec2e3810142c5b4517c7f7720b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-a0653d09-72bd-bb10-234b-b6bba219d98691cfcbbc8a94e765
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3VRyW7CMBD9FTTnpEoCBJJT1d57QT0hFHmZgIuxI3usKEL8e52wdFNvozfLW+YM
+        yrQW6jPY3qCDGpiRDvtnL49P1u0hAcNOGHFCT40XzDR5Xo2wbYi5PRLULdMeE2itlugaJaE2QesE
+        hDXkrIaaXIj94GO3Q3dS3itrPNR5sU7AiwPKoLEJYVyNRKdOM8KUZeVyLrMqXRVcppznWVrMFzzl
+        JeesyCtZrcsqF63gXKxZtcBVuYzCUCpqmNa2R3mnHnVHe83Ny/tm9qptkLPNFY9bndVKDLH3wrwS
+        szek3rrjNBC7/sAcPnxZ/oGCJqPFYp4Asf0tC38fYULHenuGH36z5B7zdUoqH60ON1lX7Hv9FSUN
+        3ShcYsuCJrgkvy5PSd5u578P//vTP/hk6cE2Pgwuu2ifGIXIAvE1NER2OChP1sW8trvLJ7Xb5c5E
+        AgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:03:56 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - 561dc8e275f0069fa70ccf586f5896a3
     status:
       code: 200
       message: OK

--- a/tests/integration/helpers/cassettes/test_scan_helper_return_last_history.yaml
+++ b/tests/integration/helpers/cassettes/test_scan_helper_return_last_history.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
@@ -17,48 +17,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA8VZTW/cRhb8K4ROCeAO+ovNpm+yFGwCRLETZePDYiG87n4tEZ4hJyRHihDkv2+R
-        M/ZaSGROZrzZXAIYEpss1atXVf3b2cjrzYpGHs5e/uu3s207bDebrh85nb3MtBr4xVlcddt007Wr
-        xw//lHiIZy/PzjebvrvnVOSuL37ZEn6tXz0W/Cv+39KqGCK1bdPeFjQUPf+ybXr8bHgs3lx8+9XZ
-        i7OuT9yfvWy3q9WLs2Ebhtg3m7Hp2qeHNcPNA+H1dj83NuOKcTaeUfzw4civ3x95jSPxaPwO3XI7
-        vv+t7bbBB53FHK2LOgkjuRIh6CBMqLWIVZlIGVfVOkkvo8o5x2h1HXPC09bU4mn909dqaT29Bw33
-        Z7+/+KvIvQUwdNE/Fpc8cpy++VQ8PjzxR2qHbv1APT95+DOIeKfIh7oUWdoorAxScGQntDNBBY62
-        rKIEDFFpHWuH/2y5gMjD9G2xfzwClh953Y1cUJuKVRfBoHjH8d0w8+vi56+FlqoSpfP1yfT5th15
-        VZxf/VRcc9z2zfhYvHrc0DAcAprJpbIsWTjHUngmLYIDoZJO3oVSu7quqTbk69rapGpWWS2A1kzv
-        Q+vxCNDOi6HBDPM8bsXYFakZIsayL1bNPRd33TAOM6TdhttiGu7hZPi+wUOLy/05j88PXAjJZi9L
-        YcAdkayzIuikhJRVzcHXydWV9NGQLDlqr3SIeQGp9193DL/OiwwRKYbHAbK3w2vYNiMFoDdxjNrH
-        Ga+T8XlFQxOL73l86Pp3xadFqTIYQS61MExOkK4VRlAS2JSzdKqOqk5VSJX3yQX2yge3NIJhOv4Y
-        Km3HO6hmE7EQJib9lzvcbtfcT/+8boZh0vTtJk1r42SoLrAUpjNpheXwhsZ4V5xvUzM+TyrpNOav
-        ilDxzCJVdRZc2iwiVzGmqtSG6+BM8jYGr6I2US+RajOde0PzuX9dzS+6Nje3Wygu7Ui1nRH6nodh
-        O8x//Zb7j4Cyf33dfce3FB+LtxwKbN0FRkUTQ8SwCaOBDdWchJIVlBMo+agpG5NksjZLMMu42tVh
-        CaAHDrTZHIHN9PXzbK1pNS+lri3eNm3qHnai9M+2+XU/kKdz6Wp/xqcHLikXS5VJlHWVhavIi5pS
-        EpVNJQXpXLCQb+WtlPAAJE2ZqwVR2n/cEficDwNoUqy70ECEEt83kYfivqHiqol9N3R5LL7+Nd5R
-        ewvsJokqri6vTp66q915l/N5C3TyxuvAsAdalk4AOSy+kowgU7lQ1QoQKZNKD5dgas0yU1wSqN3n
-        HgPXNKIFVKqI+6GjyT0VXX4KIeg2e7bPwKnLq2I34Eu6lLG8cg3zJKOPgh3VwiZPgqwhxxAnaYPJ
-        VLK2UeboVTB2iVdpfTRI+y33BCfM3C01LZY3Fe/a7qEtsCp41bR8MqPedKsGCnXRwYs01IJVs4xD
-        CJ9XciuNLUOG8fSBhalCFHWILGChQopsqtJr9pnZG/xzTrGybgGx+OH8I4B7wz2kaj0N2WTI5hAz
-        BY3L6+viC6W+0l+pL4v77QpyTiDw5BonvT8Zu8mNfjjsMNfA1kkmLEEMIJyVlAqTmUA7azgb5Tw7
-        1jKrVMM7cMiWbL0A3SY2R2A2/5X/fCLbvf/Zq9rJML3OeaLqgeOojLfZgE0SOiUqD4S0TgH7ULEi
-        Vi4xeRh2wwoWzHipw5JL73Yv8HlRGu+aPokN0vNjMWftYuB+XgMnA7b721zMD/22zT0NY7+NI5zK
-        8zOJnVhDp4LI3hqBQAxicQU7mqXOdQqZiLOVxNKEnDJV2iwRa9cgHOuudh+xU7Nhb62uL87fzPbh
-        9c/n32Fr5qaF1HTt6ZA9ffKyhOVQx0AQLsqugs2qGVFaG6FYplq7WHNZ65Ih/ySJPMJ2WmIZJOUY
-        pwUjPfnzJxaUik2PFd9tB/QyM0ww2ZtZqU8m18V2GLv1gnegYAPFpIUssxNWl1B4OHbULmRqsCjB
-        n1suMZHglMkMnyGXFH4+94gZPKBdsMLpSs3M2vcNVlTKnd43IBDeFdd3vFoNd118d0jL4MpUhgr6
-        5ROmEYY9i2wrg5LGGROCQyOjpKdSSbLWVJaUW7Kpw4cXOAK+755pZEoBvpcn0+kf37y+/qn44nbV
-        hPjlIfhkJUM0zgist1JUWnkRLLFgFAq+hHoRSV8HqomcUaqS6PMWqHU7Bd4joNkz649tFbygl/Jk
-        bC5/fP32+0MwCTVLhTwtYim1IIm+BVGQgElGxVlV1pQWjQsgIZnwZuTKaRV8quBMPWzi8Zh8qstD
-        zaiU/3jagJfS/mS8XlFCf3jQlEGEqgraI0orvcglArOsgkLC8RFJkJOWcAs6+pTRwuQKRSgtIBZ2
-        px+B2Yew/LHHbJAHp9Jr1Q0Q7wYVH9LP9R0hQhev+u4dQk6xYnr3GXbf04d+OkXDmGsYdIXYTBWC
-        Tm2El1iBxEaqoNHCwHdh4U1cwwqgRLwE3DCffxN2H3UEfgcoPFqQqjQvPqqTK1W++JiD809Mweyk
-        +4nrDXr9qRHCKrni1YgPaw+Z4DKhmPG2EiY6ElbpKMLk8F2MWiXMbOXLlOsKi9XWkP4Ia7HAx2H3
-        Kjfr/WscAewfGq6HZrzrtuPejk29ac+IXmtu0Qp+FiN2nu6nFJkObFEpOY2iHQJighM+qoQ+EJaD
-        0XjVKQHN0idtQ9LITbmccvpSlKT9G5yGV4vIjX5zVwz+jbCdz6f+YYYRAHCnt78PwzLAjowonMsM
-        vCTXIgePJtUaA7x0KiVHn/PUTyOqs0+kl+7DpmNvToBu1sD3bh/lRQvyggVTI7YvVOcvO13tdh39
-        ITAxZi7Ay4sy2CRwVehx84NwhFsMJpU9swJKyEEQPDDMlqQWrw1nmI7v6T+ORP9LkA5sdZ6yCo27
-        NwatvDUWJqTMoiTcb8goo47KSbjaVMdaKmdsRLmIG9mDWHVSt/N/jZHzLP5pmHyCXMbqxB1sggXB
-        YnWVKYWKGZfUuZKyLiP6LzgUyjpLhulOynA8CLkjI+Wflfd/x2g+2+M/RQv3OsjTmEPtg/CGvdAM
-        8GwlS8QlNj5Ep1UOAbf93pQK/eJBaB3f5r/P4E9Ef3cb9DdE8UO0LAflCZkAN7IxiuRw5WimfBmU
-        RULPmimxgwtGUqfoPDpZvZQq5/12E/ex/N+//wd1op3IVSIAAA==
+        H4sIAAAAAAAAA8VaXW/bRhb9K4SfWiBTzDdn8uY4xbZA3GTjtnlYLIw7XzYRidSSkl2j6H/fQ0rx
+        WpsmVKRsNy8ODItDHp177znn8vezdV6uFrTOw9nzf/x+tmmHzWrV9euczp4XWgz52VlcdJt03bWL
+        h8dfpTzEs+dn56tV393lVJWur/61IXysXzxU+Tf8bGlRDZHatmlvKhqqPv9r0/T42/BQvbn48buz
+        Z2ddn3J/9rzdLBbPzoZNGGLfrNZN1+4f1gzX94Tb2/7dulkvMs7GNaq/Px75/Ycjr3AkLo3P0E1u
+        1x8+tdk0eKCzWKK2USameK5ZCDIwFbxksTaJhLK1l4k7HkUpJUYtfSwJV1tSi6v1+7fV0nK8Dxru
+        zv549qXIvQMwdNE/VC/zOsfxmU/F4/GKb6kduuU99Xnv4p9AxFlBLnjDCteRaR44yzFbJq0KIuSo
+        TR05YIhCyugt/mkzg8j9+GyxfzgClrd52a1zRW2qFl0Eg+Jtju+HiV8Xv37PJBc1M9b5k+nzY7vO
+        i+r88ufqKsdN36wfqhcPKxqGQ0BTxQideWbWZs5cJsmCBaGSTM4GI633nrwi573WSfgsipgBrRnv
+        h5brI0A7r4YGNZyncqvWXZWaIaIs+2rR3OXqthvWwwRpt8ptNRb3cDJ8P+Ci1cvdOQ+fLrgQki6O
+        G6bAHZa01SzIJBjntc/B+WR9zV1UxE2O0gkZYplB6sPTHcOv86qgiVTDw4C2t8Vr2DRrCkBv5Bi1
+        DxNeJ+PzgoYmVj/l9X3Xv68+35RqhRLMRjKVyTKSXqAEOYFNpXArfBQ+1SHVziUbshMu2LkSDOPx
+        x1Bps75F12wiBsLIpP9wJ7ebZe7HXy+bYRh7+maVxrFxMlQXGArjmbTAcHhD63hbnW9Ss/40qbiV
+        qL86oouXzFLtC8tGFxZzHWOqjVTZB6uS0zE4EaWKco5Uq/Hca5rO/fJuftG1pbnZoOPSllSbCaGf
+        8jBshunbb3P/BCj95ePuVb6h+FC9y6HC1J1hVFQxRBQbUxLYkM+JCV6jcwIlFyUVpRJPWhcOZinr
+        rQ9zAN3nQKvVEdiMTz/V1pIW01Dq2upd06buftuUfmmb33YFeTqXLndnfL7gkrDRiELM+LowW5Nj
+        nlJitU6GArc2aLRv4TTn0ADElSn1TFPaPdwR+JwPA2hSLbvQoAmlfNfEPFR3DVWXTey7oSvr6vvf
+        4i21N8BubFHV5cvLk6vucnvey+m8GTo55WTIkAeSG8uAHAafIcVI1TbUXgAioZJxUAnKy8wLxbkG
+        tX3cY+AaS7RCl6riruhoVE9VV/YhBN0mzfYVOPXystoW+FxfKhhexUM88egiy5Y808kRI63IZjQn
+        roMqZLLUkZfoRFB6jldpeTRIuym3hxNq7oaaFsObqvdtd99WGBV50bT5ZEa96RYNOtRFBy3SUAtW
+        TW0cjfDTnVxzpU0oEJ4uZKbqEJkPMTNIqJBiVrVxMruSs1P4dUmx1nYGsfh4/hHAvck9WtVyLLJR
+        kE0mZjQaL6+uqm+E+E5+J76t7jYLtHMCgUfVOPb7k7Eb1ejjYYephqwtz4QhiAKEsuJcoDITaKdV
+        LkpYl22WvIjkoR1yKJq0n4FuFZsjMJu+5T+vyHanf3Zd7WSYXpcyUvXAchTK6aLAJo4+xWoHhKRM
+        AfNQZEFZ2JTJQbCrLCDBlOMyzKn0bnsDXxel9W3TJ7aCe36oJq9dDbmfxsDJgG2/m4vpoj+2padh
+        3W/iGkrl0zWJmejRpwIrTisGQwxi5RpytHBZfAqFKBfNKXMVSipUSzVHrG2CcKy62j7EtpsNO2l1
+        dXH+ZpIPr389f4WpWZoWraZrT4ds/8rzLawEHwOhcVGxNWSWz7DSUjGRefLSRp+Nlyaj/RMncjDb
+        aY5laCnHKC0I6VGf70lQqlY9Rny3GZDLTDBBZK+mTn0yuS42w7pbzmgHCjpQTJJxUyzT0qDDQ7Ej
+        diHlwaIEfa6zQUWCU6pk6Aw+1+Gnc4+owQPSBc2srMXErF3eoFkt7Ol5AwzhbXV1mxeL4baL7w9J
+        GaxJJtToXy6hGiHYCyu6VghprFIhWCQygjsygpPWqtYk7JxMHR5v4Aj4Xn0ikTEMfDcn0+lvP7y+
+        +rn65mbRhPjtIfgUwUNUVjGMN8NqKRwLmjLLCBScQfci4s4H8kRWCVFz5Hkz1LoZDe8R0OyY9XFa
+        BS3oOD8Zm5dvX7/76RBMgs9cwE+zaLhkxJG3wAoSMCmIOOtaK6ORuAAS4gl3RtaMo+BzAWfqIROP
+        x+RzWR5iRiHc02oDXkK6k/F6QQn54UFVhiZU1+g9zGjuWDEwzLwOAg7HRTjBnCSHWpDRpYIUptQI
+        QmkGsbA9/QjMHs3yU43ZwA+OodeiG9C8G0R8cD9XtwQLXb3ou/cwOdUi0/uvMPv2L/p5Fw1hLiHQ
+        BWwz1TA6XjHHMQIpKy6CRAoD3YWBN3INI4AS5Tnghun867B9qCPwO6DDIwWpjXr2JE6uhXn2lIPT
+        X4zG7KT9xNUKuf6YCGGUXObFGg/WHlLBJiGYcbpmKlpiWsjIwqjwbYxSJNRs7UwqvsZg1R6tP0Ja
+        zPBx2N7K9XJ3G0cA+1HCdd+sb7vNeifHxty0z7Bey9wiFfwqQuw83Y0uMh2YolKyEkE7GogKlrko
+        EvJASI6MxMunBDSNS1KHJOGbihl9+pyVpN0dnIZXC8uNfHMbDP6FsJ1Pp35UwzAA2Ont9mEYBpiR
+        EYGzKcCLZ89KcEhStVLASybDc3SljPk0rHp2ieTcPmw89voE6KYe+EHtI7xoQV6wYEzEdoHq9GSn
+        d7ttRn8ITBk1F6DlmQk6MawKHTY/MEfYYmQSxeUsgBJ8EBoeGKYNidm14QTT8Tn9U0v0vwTpwFRn
+        n1VI3J1SSOW10hAhpjBD2G/wyKOMwnKo2uSj58IqHREuYiN7EKtOynb+rzZyqsU/NZN7yBWMTuxg
+        EyQIBqutlWEiFiypS825NxH5FxQKFVl4huhOQuV4EHJHWso/C+//itL8ZI6/jxb2OvDTqEPpAnMq
+        OyYzwNM1N7BLWbkQrRQlBGz7nTIC+eJBaB2f5n/w4HtNf7sN+gus+CG9rAThCJ4AG9kYWbJYOarR
+        Xwah4dCLzJSyhQqGU6doHTJZOecqp/l2HY+15Y+5xbvzq6frs68L2JY5H94e2WUX44kfTcjday+7
+        EYkFmUwR3pvIa+achzITBLzqZK0pMQWvZU02SCW8RPJfZv0B3mY5Hi1s+6c1/y2tKwiwMY4cql/e
+        vqqwwrzdrtTCplkk/BfvBYz7Wlo98VPykNXjPlYfdo6v8UrBXZPv96LDfbCMU1JBs7JkpGBeO4nI
+        VWLnnwq2Hglm05KOtk5YQGolpYX1mn2bZLgeX2aYTv7y1exTuHb2nCosMytsM5GCbZdH43ryvxzX
+        E8jU8ZDNcIt7vBrBjcGMxKCE/3TMeYd3ALBAg6QwdTLlS/e04NZIkKOgelKAu5e6xuXH+dWvE+ee
+        Ki7BvxyU8VoHFJzERlqPYQ5UlWFa68DGbsSErzPCOWnHzcd2eR20wfIaseYBHJqWG//8498+JiFA
+        8SYAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -69,11 +75,11 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '2374'
+      - '2683'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:48:10 GMT
+      - Thu, 21 Nov 2019 19:03:55 GMT
       Expires:
       - '0'
       Pragma:
@@ -81,8 +87,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -92,9 +98,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - ad65f07693f191c9658426382e856b92
+      - f3903e5fa3d522cd48139874da368c19
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -102,7 +108,7 @@ interactions:
       message: OK
 - request:
     body: '{"uuid": "731a8e52-3ea6-a291-ec0a-d2ff0619c19d7bd788d6be818b65", "settings":
-      {"name": "test_scan_95", "enabled": false, "text_targets": "fakehost.tenable.com",
+      {"name": "test_scan_217", "enabled": false, "text_targets": "fakehost.tenable.com",
       "acls": [], "asset_lists": []}}'
     headers:
       Accept:
@@ -112,13 +118,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '206'
+      - '207'
       Content-Type:
       - application/json
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
@@ -126,14 +132,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3VS247jIAz9F55LlRu59Gn/JDLgdNASiLio6o7m39ckTUcr7fCAwJfjc2x/sqjA
-        sdsnU94lMA7DbDS7sU7UUqph5JNsFO/U0nJZgeBtr1FP7SBHodmF+UfJyHnPwUEorUbkshmBd9AO
-        fJxUw3slehxbMYkKKOcVnXDdLCTk/bjopQPNB4l09U3Fh7FVfKFSNaBEAtI9DFVVNarDttOLIhgH
-        K+4wMc1FxDwJsmqMKpgtGU+qXLb2wjZvjXrusupaXHbFp84j4rS8mFWvw/9z/XRqqo0rGBvfoCs9
-        WTE7kBYJeAEbkShC/JAegp4XY/EMN07ZrHGG+z3gnfrCbilkPMjNyaw4P4zT/nEmqByTX+cE4Y6p
-        lDpezXXLsjyv6SgcUeVg0vOq/EpsIvlSgTtxQsgUdP6K5493b6/zySxGQWlo4ZswfCv8gFB0VTTT
-        SO3bMKwmRoqkkLoZyzQWyDb966lea0OUwemAj19R/776cH/vU5lCc2EWaLSr198E9N6XWvRtO07N
-        REgq4E+u9NzKglA7aP6EfSxA//X1F1SJKtL1AgAA
+        H4sIAAAAAAAAA3VS247jIAz9F55LlYRcaJ/2TyIDTgYtgQiIqu5o/n1N0nS00g4PEcHHx+fY/mRJ
+        g2f3T6aDz2A9xtEadmdtVyulB8lvqtG81ZPgqoKOi96guYlByc6wCwuPkrFtew4OnTZaIleNBN6C
+        GLi86Yb3uutRiu7WVUA5L3TGZXWQkWOj5CAbxdU01QRua14Zg1xUstG6v6lByAknKU3dqqEGLZUg
+        Gg8L7jQpj8XE2NQDPRtMOto120C2/Obcha3BWf3cfTVte9ktn0YPxPnykla9Dv/P56dTU21cwLr0
+        Jl3oysqzB+WQiCdwCUkipA8VIJpxsg5PuPXabQZHmOeIMzWG3XPc8BA3Zrvg+LDehMeZoLeUwzJm
+        iDPmUuq4Ndd1U+V6zUfhhHqLNj+vOiykJlEsF7qTJ8aNQOdfifwJ/h31IdvJaigNLXozxm+HHxCL
+        r4qGmqh9K8bFpkRIgtSNLNOYYHP530j12huSDN5EfPxK5vc1xPm9UPuoLswBzXYJ5luA2ftSd0Mr
+        elGJjroQ8adQfq5lQ6gdNH/iPhag+/r6C+BZjJj2AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -144,7 +150,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:48:10 GMT
+      - Thu, 21 Nov 2019 19:03:56 GMT
       Expires:
       - '0'
       Pragma:
@@ -152,8 +158,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -165,9 +171,468 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - e83260ee09547f85392652d8f4542906
+      - 019eefeebf4607083c0e9aed20726a81
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3VRyW7CMBD9FTTnpCKBEjenqr33gnpCKHLsMbgYO7LHiiLEv9cJSzf1NnqzvGVO
+        oK1yUJ/A9RY91MCt9Ng/B3l4cH4HGVh+xIQTBmqC4LYpi2qEXUPc75CgVtwEzEA5I9E3WkJtozEZ
+        CGfJOwM1+Zj6MaRuh/6oQ9DOBqiLkmUQxB5lNNjEOK4momNnOGGOZcsqVrZ5q1SRr8SyyOdSYr6Y
+        s1KI1VNbLZhCxZgslm1VcMHaRRKGUlPDjXE9yhv1qDvZa65e3tezV+OinK0veNrqnNFiSL0XHrSY
+        vSH1zh+mgdQNe+7x7su1HyhoMlouHzMgvrtmEW4jXJhUb07ww+88u8V8mZI6JKvDVdYF+15/RUlD
+        NwqXqHg0BOfs1+Upyevt4vfhf3/6B58s3dnGh8F5m+wTp5hYIL2GhsQOex3I+ZTXZnv+BHxK8spE
+        AgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:03:56 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - 2015128fc98131b3a979dac820e4582a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/launch
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSskgzNLRMSTLSNTQyS9M1MTYx07VMTk7VTUk1S7EwSTQ2
+        NjOxUKoFAFziXC80AAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:03:56 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - ''
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - d9a7db63ab3a367bbe3cb6be97322c28
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKi5JLCktVrJSyszLLMlMzMmsysxLV6oFABs/DHcZAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:03:57 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - 82af785a6fe20996cc46f86a4d9a13fc
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKi5JLCktVrJSKkjNS8nMS1eqBQDhdJo4FAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:04:07 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - 4537b11e17fed1628e5c5f1fb54ba4ff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKi5JLCktVrJSKkjNS8nMS1eqBQDhdJo4FAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:04:28 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - 8e1be3101500e33ffa3fc103bb402ae2
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKi5JLCktVrJSKirNy8vMS1eqBQAqTkzLFAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:05:08 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - cc02f5ee291bc4cfbb4f1eb5eb2f6949
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKi5JLCktVrJSKirNy8vMS1eqBQAqTkzLFAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:05:08 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - d284abb32078c81c2148adcce736b26a
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKi5JLCktVrJSKirNy8vMS1eqBQAqTkzLFAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:05:18 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - bbea7002825323ab93cbc82cb8b86e42
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -189,412 +654,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/116/launch
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSsrQ0MzVPNjDVTUoxStQ1SUo21bU0Mk3RNU9LNDY0NjZI
-        STRNVKoFAG/i9jc0AAAA
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 17 Jul 2019 18:48:11 GMT
-      Expires:
-      - '0'
-      Pragma:
-      - ''
-      Server:
-      - tenable.io
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
-      X-Request-Uuid:
-      - e244006cd108613d856ff114ade8aa5c
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWKi5JLCktVrJSKkjNS8nMS1eqBQDhdJo4FAAAAA==
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 17 Jul 2019 18:48:12 GMT
-      Server:
-      - tenable.io
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
-      X-Request-Uuid:
-      - c6ad4cc47aa0078fd95949dfe08fbf4b
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWKi5JLCktVrJSKkjNS8nMS1eqBQDhdJo4FAAAAA==
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 17 Jul 2019 18:48:22 GMT
-      Server:
-      - tenable.io
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
-      X-Request-Uuid:
-      - cc5d4b3811b0b343bfbce1140eb759ad
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWKi5JLCktVrJSKkjNS8nMS1eqBQDhdJo4FAAAAA==
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 17 Jul 2019 18:48:43 GMT
-      Server:
-      - tenable.io
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
-      X-Request-Uuid:
-      - 4479fce92cf9c737780509f77ebe8a43
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWKi5JLCktVrJSKirNy8vMS1eqBQAqTkzLFAAAAA==
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 17 Jul 2019 18:49:23 GMT
-      Server:
-      - tenable.io
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
-      X-Request-Uuid:
-      - 127ac5799ebbde0cb362f89a8a715ba8
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWKi5JLCktVrJSKirNy8vMS1eqBQAqTkzLFAAAAA==
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 17 Jul 2019 18:49:23 GMT
-      Server:
-      - tenable.io
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
-      X-Request-Uuid:
-      - 860f89cb1541867f04924b20a19f7225
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWKi5JLCktVrJSKirNy8vMS1eqBQAqTkzLFAAAAA==
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 17 Jul 2019 18:49:33 GMT
-      Server:
-      - tenable.io
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
-      X-Request-Uuid:
-      - 7aede9dcbc9f6bb5d1ec08905492f5e2
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: POST
-    uri: https://cloud.tenable.com/scans/116/stop
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/stop
   response:
     body:
       string: ''
@@ -606,7 +670,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Wed, 17 Jul 2019 18:49:34 GMT
+      - Thu, 21 Nov 2019 19:05:18 GMT
       Expires:
       - '0'
       Pragma:
@@ -614,8 +678,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -623,9 +687,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 44cc7df8fa0b401fccecd2c325fe6e77
+      - b6c1b9ba76542deb16b92ca315481c7c
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -643,11 +707,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -662,12 +726,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:49:34 GMT
+      - Thu, 21 Nov 2019 19:05:19 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -679,9 +743,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - cdebdd2dcb7c1688a84535eb5f138264
+      - 1e7b1fdbb0cbb86c1c3f15a6e9e3741e
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -699,11 +763,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -718,12 +782,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:49:45 GMT
+      - Thu, 21 Nov 2019 19:05:29 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -735,9 +799,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 66b6ab4f03ed4ff840e0956ab703f7d5
+      - 03228636120faf6367c825b85ad5f686
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -755,11 +819,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -774,12 +838,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:50:05 GMT
+      - Thu, 21 Nov 2019 19:05:49 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -791,9 +855,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 74df935fda007b1a45bb90b72a715d2c
+      - ee5ba73f8f8fe366fb1ccc430440c62a
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -811,11 +875,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -830,12 +894,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:50:45 GMT
+      - Thu, 21 Nov 2019 19:06:29 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -847,9 +911,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - aeecd613c2afacfad1fab436082eef04
+      - d440275107d0fb522874633042e471cb
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -867,11 +931,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -886,12 +950,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:51:57 GMT
+      - Thu, 21 Nov 2019 19:07:39 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -903,9 +967,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - d6d35223d021a0c2df923e1940219705
+      - 5bebb61410b4c0640cfeb08ef892143e
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -923,11 +987,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -942,12 +1006,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:51:58 GMT
+      - Thu, 21 Nov 2019 19:07:40 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -959,9 +1023,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 77c28c11dfe8b6aaca3e897f110327f8
+      - dbd17b0b7af03b0af194f8b53d59cd09
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -983,16 +1047,16 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/116/launch
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/launch
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSMky2NEk1N0rVNTEwNNE1MTNP1k1KSjPVTTVMMTQ0MTW0
-        TEk1VKoFAPQdbmE0AAAA
+        H4sIAAAAAAAAA6tWKk5OzIsvLc1MUbJSMk9NMjRJszDVNTRIMtM1SUlM1k1MNjbXtTA2SUtMSzE3
+        M0kyVaoFAEzGDW40AAAA
     headers:
       Cache-Control:
       - no-cache
@@ -1003,7 +1067,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:51:59 GMT
+      - Thu, 21 Nov 2019 19:07:40 GMT
       Expires:
       - '0'
       Pragma:
@@ -1011,8 +1075,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1024,9 +1088,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 4f233e3a13885f1d579008bf22c53db2
+      - fb8921b7052ea33434a0e9d8311cbd43
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1044,11 +1108,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -1063,12 +1127,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:51:59 GMT
+      - Thu, 21 Nov 2019 19:07:41 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1080,9 +1144,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 09217ad2e72407b0691c7450dc03cf24
+      - 51598fba7c51a9365026927026575d8a
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1100,11 +1164,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -1119,12 +1183,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:52:10 GMT
+      - Thu, 21 Nov 2019 19:07:51 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1136,9 +1200,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 629e193eb6eaad8cbb04929f1f7de68f
+      - b047a5f6fa40dfa62d55b2bebd222485
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1156,11 +1220,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -1175,12 +1239,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:52:30 GMT
+      - Thu, 21 Nov 2019 19:08:11 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1192,9 +1256,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 39ddd66193780118322a7f2ed94447af
+      - 1694f8df22948741a6cc6af77eeaad71
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1212,15 +1276,15 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6tWKi5JLCktVrJSKirNy8vMS1eqBQAqTkzLFAAAAA==
+        H4sIAAAAAAAAA6tWKi5JLCktVrJSKkjNS8nMS1eqBQDhdJo4FAAAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -1231,12 +1295,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:53:11 GMT
+      - Thu, 21 Nov 2019 19:08:51 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1248,9 +1312,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 1e41cd3d40b1555ba466281a1cbd9790
+      - 2c6e6915c88a2decc64cb3336105fdd7
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1268,11 +1332,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -1287,12 +1351,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:53:11 GMT
+      - Thu, 21 Nov 2019 19:10:02 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1304,9 +1368,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 0d0b996a1c816e7b7ad5af65d689ca3d
+      - 7df416bd5bcd2571de640e238d23f77b
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1324,11 +1388,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -1343,12 +1407,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:53:22 GMT
+      - Thu, 21 Nov 2019 19:10:02 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1360,9 +1424,65 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 890713fc76405dd2f6621727d66a3c3f
+      - 4fc207f8d3e50bf57f30748a36514fb5
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKi5JLCktVrJSKirNy8vMS1eqBQAqTkzLFAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:10:12 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - a2f846a08c812f5a1ed4b460ed947242
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1384,11 +1504,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
-    uri: https://cloud.tenable.com/scans/116/stop
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/stop
   response:
     body:
       string: ''
@@ -1400,7 +1520,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Wed, 17 Jul 2019 18:53:22 GMT
+      - Thu, 21 Nov 2019 19:10:12 GMT
       Expires:
       - '0'
       Pragma:
@@ -1408,8 +1528,8 @@ interactions:
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-Content-Type-Options:
@@ -1417,9 +1537,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 43411efd87004dd00e78729ae7dd40d1
+      - 5952c9c02958d3c076aef4dc1986c2c3
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1437,11 +1557,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -1456,12 +1576,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:53:22 GMT
+      - Thu, 21 Nov 2019 19:10:12 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1473,9 +1593,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - e438d54d57d0fd72031288763f401354
+      - d5fde0c3710db2a0567e5a21d9c9d99d
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1493,11 +1613,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -1512,12 +1632,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:53:33 GMT
+      - Thu, 21 Nov 2019 19:10:22 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1529,9 +1649,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 1d0fba54583a0f989e765930a693a300
+      - 9b741d897041ee00c0a8e2f25dfbfd81
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1549,11 +1669,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -1568,12 +1688,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:53:53 GMT
+      - Thu, 21 Nov 2019 19:10:43 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1585,9 +1705,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 287a53765d1cef3b6df5cfc1d393edb1
+      - f713bd409abcb763cad8abdb2e7e14dc
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1605,11 +1725,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -1624,12 +1744,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:54:34 GMT
+      - Thu, 21 Nov 2019 19:11:23 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1641,9 +1761,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 710480984d8fe325be7c1abc00f0f8bd
+      - 4c46d9ac3fb49011002c712b19035c48
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1661,11 +1781,67 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKi5JLCktVrICMvILCjLz0pVqAZ0xt4QVAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 21 Nov 2019 19:12:33 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-b-ca-central-1-prod
+      X-Request-Uuid:
+      - 6873a8afeecf27f346120a21e5bbe860
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - TenableIOSDK Python/3.7.3/1.9.1
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -1680,12 +1856,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:55:44 GMT
+      - Thu, 21 Nov 2019 19:14:23 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1697,9 +1873,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 055d66849e11dee943a93d70c3d01513
+      - 4b8d4708dfb8a4ed938bfca190eda3d3
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1717,11 +1893,11 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116/latest-status
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3/latest-status
   response:
     body:
       string: !!binary |
@@ -1736,12 +1912,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:55:45 GMT
+      - Thu, 21 Nov 2019 19:14:23 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1753,9 +1929,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - 72f57aac1d8f9a160bcbb9eb7ec18ce7
+      - 12c36687b4db0aea85cc747074d1e4f3
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -1773,84 +1949,95 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYuInYP7ZIzw2uQuEDQkzuzNZStgy8cVYjB8kmZDvfi3Z
-        BgGGkMlj2NmpGiJLLan7161W62E/5BzPJrnqQ47cetjPVXPIs3x8++/AuikSf5Qr5Dw0xpAf4iAc
-        BCbyBoZOc8kgRP4Ih7mqjdwAF3I2cS3sDxwrV/Ui1y3kTOKFPnFz1dCPoDwKoHSC/bETBA7xglxV
-        ViqFXGBeYyty8SCKaFXoZzxxUYjFUsW2bA1ZYnmI4aekSGK5opqiXbKwjPAQI7VslVBZkiTF1LCq
-        WbYJjGHLCQfIdckttua8Ub5BvEEiy2VPqLsksoRenA/VJsR1zHsoO0KBYwodHN4S/4YRQGlwjXw8
-        F4wM/4fNkEkqy6VCLkSjBIwgJUGmC+lPD7klgaVCCnNMZTkByHqfsBXn8ekFluH9hDJuYRtFbph7
-        LKy0zKBM2pZXG96o07V82qEy741qLPd4VchdkyA0SeSFrPFEUbJpaLisYFGTZE3USmVTHA5tXcSy
-        JcuaLhugJgpdiMIIOMwBkiZ2AcVYHYOkk0mQowgm6CUppTiJhjRZDLGHhi4OsBn5TnhfNMkY6JEb
-        pogPgMuFoiemI0LjYjRxCVrW/wA48akEeklVKwYwCP06YzBrNJ7Ms8uynpBjz1rOvUbBzTC1ZnhA
-        EZha6CNnbuKpmSU9xapLM1l7NOsRajtBSPx7ZiFJOjYnqaIYqqwluhwk+jB9jEJQ9MCCgbEsgYtg
-        WI6J5diOmUHDGH+ewni9ZCsvHrA+s+cNmqAGui6YVNlJMMWQnxRMlxaCGUZJL5uSLg4tBYna0NRF
-        Q9HBZ9hIlVVVspCOXk2wZDjEoxsFAQ5TYWh2mk44U6yyoZYNRSyVFEvUKmUsDhXJFrGKTFtRNNlS
-        KOS0Zupmd7L/iU9GPg6oALIkifD/UIG/8D8ZXSkB1PIxG7eStFwSkhC5Sb4XjUF28yYAlx044MWx
-        lZQwqg1lAZ5iylPiGR5yDvhuBkuSoy9oXPgLvUnULpJSaa1U3lqqbC1Vt5Zqj1ePi8yYM5P4mKXi
-        GRASMGewymOYQ6IxS147o2uWMKEiGKIb5zJNexa+oyKBRUwjF6waDR0XqHDAgwDGMHGjkeMl84VC
-        R22Sk+i8A+qIAqH3e0cI5hPSgllpTm+jsePSSapL/DClpeZM+08Z4lGUlzuXZOpaljs/qbe7wkXq
-        B4Vz/CWCJPwdkxALDUR/nMB0SRABXk/w9SumMLgrHCmbOVIkXV3l6BjQFVrgKO+F3yLkggPAltAg
-        Y+R4QgdIhIPWb41OHlgMiBtR1/BtbKkb2VJ0RZFW2bqodw9POKhAYdFkAoqIncfz+9eo5cB4nqT+
-        JHl0HeqT4mfbcUOqYmpQCR+UuujQPsF5WtQ5pBzWqDcSTho5LvZ6SN0eeAGYcGilEe0890kSDSTa
-        Vw+VR/Fg/qA9ivkH9XH+LCuPB4WdSfM/8VylPUmyomp6qSyioWmJ2JZkkWaIpXLFoFk0ByKaHIGI
-        BsGMQaXN4S80TGG/YxSa1/QpTgAqI59Ek1Rqfuzds8goKYi1UEQwRzvDCOLX4jATtqNoBLP4l12B
-        +5NKfPVzDMvVz9kydy7bR81zxvydi71RCF5ErryLkPgOYh+IgW0fKGgQOwA/MUVBhuT1Wqdf6wnN
-        uIbQSmtk4mD5ZGLB7A2FLszslH8a9cAjmxhzVxule4EwMeuDCTJv0AhvFqE7J9iJ8bgWZDSURHja
-        ADx/uIZJbNCFMQaj0ocI4U2kuvOxXa03zy/Eej1LJigRatbUCSB82tks6zUxtkgxNdDVnPxP/8yy
-        VSD7Hf6JJw3hwMFVAZ4hkFBFqZJ/n2E5h2MTFn2+rW8ep9nCY5hJ+5cCsAChDfjdGAMIcFQ5vy/j
-        l/iZpn923tzrsTvJ5Lrb3El9xUy/etH8ePE+RmlOcdFHt1kS9HeT4M8DoJyBq8mLB7JhGDNF+iTJ
-        V8wc8/GQfNAKML/uRrfJgPtNGK4yLHkq5VIheSrBkgCm3PdCKggGQxTgQbDJUvu9nnAEFEIvodh9
-        +H7+XEwG8C+Z8peL+pqYEDMB6Yj9voolUwnpxhSBKG67lBcJ1YskzRRUKyrvLOgUm9DRxlHAS9tn
-        pDtOVFBT+UezenA5657VZ63Z8azTyB+en1YPzlqzi9mH2WWcUQeS+uzyfFanz2ycfFPN/Iah06we
-        F4RmtbUG6yuPjadxfD58tX714HRWm3XyhzWQ9njWnp1CMqoedGa9WTt/WKep7qyePzyZp2ppao7l
-        y5rZBCy02ikI8Ft7Y2jVHfzOVC1Kf3Xno+7ofZisf30XpD7HBy3L/NyRVIXah7FHYf7kY+JOEm/y
-        MXYm4Etm5/CQjJvnVfrO7kfdFcNvgo46kA44kNNZN3Yhp7Pj/GH3nOay5CXzG+f5wx7Fq848yjEU
-        dZhHSVK1NMUD/MpNf1dnFS9xPjSzFPBh13AyGZpPrWg+NFdXM7Cce5Ol3GK3amDhwPSdSbIbtyYj
-        3UFmm3evHfu/AutzsLIYn5MJ5xzZXoiwbmXJ8eAAmfG25ro8jZji8L8erAaFWkwX7M+acX3xaykD
-        7LoOyZKmyQr2eQ085z6u+6QIbzFE3nSXAk2R41IesmRLhKpxNHuiF+aPm40jkW0mbWK8gUJEA8zX
-        3XLaq73hJOc6Gm7G4ZgV7onmEoYT2gEG9WyIbJpLlEITKHcVI6kaCMjHAm/iHSIkDAhOANPsl8jx
-        2fkPFNwwn4qzq74lFtgaDO8HY+TeosylQTMlE47uhfacbL8UGgvhsaPQp2TopFTfRQR2AJdcflpn
-        9Dg5y6dnhTXLYqf03+7QZUMpyqVKUS4qBblM00X4ERdJSSrIEv1T1CFkVrQC4w7fIYhbMLst8H5b
-        +Ce1fi0DEZr9TA8qfqqJfyDx65W47FFX8zd4WNbjWgwsy2JNlGRdfs9jDWDlKBuTo3fH5CgTk6P3
-        xCQIndFgflaeiUtb6C3Kd0HHmZ70r37eIPOitVjkk/47az/rUItmv7v2L77/iHC8QXgNKODbLBd/
-        4gkX1xic++0eLUg2z6r7OpFywd0YhyhgmVn8zwv3eQG1EGHTCoqT4y+zemLOod1rZTmHtmP6JCB2
-        KBxFrotDx9vNT7R7K8f/KxkbPEO7ZxiiYRhALtEb1sY7InDW6zeyZkeW/8Msuia0gcEkGrpLN1nX
-        xe5SQqG7IGTX77LHIhTYDnatNSAetMfDOKEsEpmQ0Esfh+32YaOxpnLavOhSr5GkcJochYvUPJMB
-        xlIv3S7ZuovYZfRCY4lon7bi4gt/g8xbZgnzrfhO4Db/OhhHbugsvOy8l3NY/RyjUDglJj3dSa4E
-        C2xzlU6Z7EYlx9VxV7z8uJVa4agbeOggbyu5ypH3iIt8WANvo9c4+ha2iI+2kuscef3XEwENowCn
-        hSWu8FdQMSFb2yrzrEa95lbiCkdcO9kOmcHRfnA8UFggVIV1pz1XiMRXwENo1p/Gt3bjC8E8o+2L
-        rjDxCZjNeE7A66jlY3zUa2y3AF5Ll8PIC6Pt9LyWei4yb2hYs70Kr6k2fYsE3TxRg1dfcrfYdlws
-        INOMV8iMitdaHZR81tveKq+41kU3zc7QUWrw0hLnJnTwxAiRl4aI5wAlsZkSHXYUwIh4HbWdwCym
-        BUsjJq4jWDjEZuK9GJG21AXboBcuPeeO35+PryVnDhAwv4+9XkqzNE7olWmfkBBCfwo5czyMigf6
-        vFtPsyuZxn0ZYF8YIw+N8BizYwVGbCyPyOSGM/MTPMrpJurcifCIdjH2xQsi0r9CixpE7xrcipe+
-        jKTyyNZPevWztIBHtuX4+Ba57rwLHtEjsGiLkPmIU3kUe/Vao5YW8NA1OimiKo8VQOGCvQpBrMt5
-        mzxwXfYqmbA4OkqJjFXVICG4xq67qh1NWrKaELzJaO5Sl9BbeQ2AEfCI0dfY4jUKK1rGzBsB5ks+
-        VltyBZ12OqA0HrLOSYqMVlp1A850u4fXeCz7beZomr3tI1DjsT3yI+o5iA/jCOIGxJHx6P4n8sj2
-        qUlfwth0wK7pm0bCqeNFd9tr8hpokyE12gbmrUHnVXDmIxModmiX105tjL5C/LdDLV5lXeQSoeaG
-        26dGndfmcYRusbOdnldzS0/fjXwC3/IaBv329hq8nk8807FAJ/QljwnxgtSEdV7LfccPI/L163Zx
-        S7ym/7jYHgmU5MfXW8ZuiwN3XdwcSLNPMgTxcSQvFUqP+YPPn4OfRPpzsFqU/+WgwAqeWWvDoukj
-        /VdgvyL7XVk/SZL0Fmv+5PWZ9Zf/NqLZ5kj/HoumDZshCR57uhFConASZe1FJWyfpeXfyniI78IC
-        Ca9hYqPJ99nKSMx1lwV+LObfeYWfgMWE3AjQRVy60xakS705a4rGUK+yCQlRVZH+ZDEYZ++6K/Ug
-        F/THhedd5KWO+imqDY65IhUq4HzFilSRnuGT03uaVNvPhMMnITGJmwXJomi3PWNzAk+RRX8dczx5
-        DZXxU0UGi+fYREEo/IsuqPAkW4EZnMbU7Hg/bgGSb3cbhQYksLzMYD8p+WE2RAOMB8gNSKaoGAJY
-        VrRvk9eWU8utB5abtvUgxrWpnKeEXl5px++cF3LH9I3zQq6evm/+JgbHvTi9JsuiaJ+2Vnnm7z0y
-        CZysI8TeomhPmY+8IH1rnN53mWLPYneuVyW5XNDRGy/9lO67HMuFsH67cbxR0Xb8IBzYJPKyljbL
-        r2m2KC0ss3C2Kf0Q8c0cGPa1kt1wOUU/PCzrZj+d+MVNb64sw9P1HcLW5eeI7nsJB/3uef5Z8176
-        Est3fGeHfeZhhwXBiuh/m3XBfNzQ7/A8DUwv3IjGuvPrYDqftpw7FrjVzNCZYhbBBZFvI/N1YrgQ
-        jYpqWa/IyNbFcglJoqYgWzSs0lDUhnKlpBqKYqlGhmg7VvuG80H2ibYpciM8UGX6XSGWXi9Y3+IK
-        cChes09EJCmPhM8DQ9LUckVDJVGRLBmkGkoismUsSgiXVAnLpmKaGWDsWO1lYOiVbCwg/y2gYD3A
-        MMYj+vWrkq5myJ1F80IhdWWDlFDwJhqXy1bZ0GURa4omahjLIqpoWJRtLNmKoWDJsrM0vlu1l4FR
-        1kvZYNCCt9d5ucL63670hOhlgmqymi0oLXgLQUsq1hFGWDRKZfBeFWUoVioWEjVTtbWhOSxbspYh
-        +o7VXgYG/fRjNhqs5HXguKLfvgxx8r0mH9OPhbEpO6Bce9F4YE5x/K1H+pB820mOn1JyCP6XqJzx
-        BJk0NyGXVlv+dPX4+H+xGemIrFMAAA==
+        H4sIAAAAAAAAA+Vde3fiuJL/Kj7snj1hBhPLNsbkn7sEyCQ7geYGku67PbkcYcvEG2MzfuQxId99
+        S7INAmRCnp2Z6XOGyFJJrvrVQyrZ8jyUXN8JSgcPpeDWJ2HpoIR9OyS3/x3Z19UgnJQqJR9PCdTH
+        JIpHkYX9kYrqtDoYxTickLh04GAvIpWSE3g2CUeuXTrwE8+rlKzAj8PAKx3EYQLtSQStMxJO3Shy
+        Az8qHSDVrJQi64rYiUdGSUK7wo2mMw/HRCbq2Kyb6lgeOw6SDUtHsmLbRNYUU7UsozGua6ZDHNO0
+        kT6uI2yZYw0YI7Ybj7DnBbfEXvBGGQf5Rpkw5wOp5QWJLQ3Seug2CzzXuoe2Qxy5ltQj8W0QXjMC
+        aI2ucEgWggXj/yNWzCRV9VqlFONJBkaUk2DLg/L3h9KKwEolxzmlst0IZL3P2Err+PISy/h+Rhm3
+        iYMTLy49VtZGZlBmY6P1gQuVulHPRFrcjWqs9HhZKV0FUWwFiR+zwTNF1ckY6Y5Zk5EyNmTdxpaM
+        La0um5ruYMeuG/q4RqGLcZwAhyVA0iIeoJiqY5TdZBaVKIIZellJrc6SMS1WY+LjsUciYiWhG99X
+        rWAK9NiLc8RHwOVS0TPLlWFwOZl5AV7V/wg4CakEtbquGZpqgDZidwp2jaezRXWtZmbkxLdXa69w
+        dD3OrRkucAKmFofYXZh4bmbZnVLV5ZVsPFr1CL3dKA7Ce2YhWZmZE0KKoSOzlulylOnDCgmOQdEj
+        GxxjVQIPg19OA9t1XEtAwxh/nsJ4vYiVlzpsyOy5QBPUQDcFq5s7CaZoxpOCqZxgpoNQwx6rMlIN
+        R9Y13ZAblkVkmxi2qWNNM3TzzQTL3CH1bhxFJM6FodV5OeNMtesNrd5QZcNQbVk360Qeq4ojEw1b
+        jqrqyFZRKe2Zx9md7H8WBpOQRFQApCigUGVfhb/wX+ZdOQH0CgnzW0VZbYmDGHtZvZ9MQXbrOoKQ
+        HbkQxam4rIVRFbRF5IZQnrLI8FByIXYzWPJYoS+JPPgLt1OoYWTN6kYr2tqqcq3KRqu2tVV/vHxc
+        VsKdmJcHIUCuasBmOg1ShmHiYDefwkSSTFPFupMrNqgFncEaPXaRqtu3yR0VC8ziJvHAtPHY9YCK
+        RDwSMMjMSyaunzmDihqLmkzxPdBJEkmDf/WkaDErLRlWFvQOnroenan6QRjntNSm6f1zhtaQ5G6u
+        qg1DX7/5gIQ3rkWkNolhZgNne+reeQeb68Dfn9cVWhVeQUp9/f7Hw2FfomOSUBqCm0owM0kXINYO
+        rHwl46zrOgjaNibQBggnrW5fGuYzgnRGfk+gCH+nQQzQYPrjRpYXRAnYzRNc/UKoLXhrHOlbOFKN
+        DVgGg+MiVKQTsNhwit9CWbVirsBSNaGyhmfNVkfaZ39/lbokvgrsSGpm6y6eIfU5KjOKWVGV2iYr
+        4IPSEcyp99I/E+zBXEFsqR1MsetLPSCR9o7+2e6VQYdR4CW7YCXWW72YLVM10DpbzRmGmCkdMteU
+        Tl0/uaOmE4fumDHxDDsqhsos5EnV2dJgDSowoHBI7mJpGGI/coCxfhjEgRV40h5Vafk5JlXMVqOY
+        rZqqbrA1bPX3Tzi3gwiYzGYQ2dasaGdVIaWQAV1DaENXzJrX7FfaA6wk2w3BXWAFU345GggVc2Oq
+        ykYMyiyHj4evDoOoOBjXFaMmjDpNbxLAra6mEQs6p9ifJHhCnqGdLph4dZ2T4ohMOTG3xL/WYUvq
+        BjaRWu7sCmSUOmxdtMoG2pGN4jBcR4q+MTVTNr4SfC11my0emdewUBxzG4qGhDphLHC3F6tCEG6F
+        DBh0yQKryVm+ms0uPZeuiNNrx/Viak90JZMxQqmrLr0lLN1tKv/CdOlaWDppl7jM/yFfdMMaFNId
+        2mlC7176rsgNLDuXD+ajvLe40B/l8oP2uLgGy92r7Exa/onnKr+TgmCBVzPqMh5btkwcBcm0Qjbq
+        ZoNW0RrIp0sBuDwGb6fSlsjvNElmvxAPrSt6lRYAlUkYJLNcan7Rd8/y8qwhVUIVx2nUJ1F1LITt
+        MJlADvn7rsD9m0p8+XMKy+XPYpl7593Dzhlj/s4j/iS+ohPVhwhJ7iDzduOREwIF3UIZwQL1BkcC
+        yVvN3kVzIHXSHtJR3kOIgx0GMxtyR2j0YCal/NOcGy5ZWla6LJTuFcKkrI8gJl9D8CsWob8g2Inx
+        tBdUtNVMeDoAXH+9ghRq1AcfA68MIT99F6nuQuIctDpnQ7nVEskELVLTvnEjmPp2NstWU04tUs4N
+        dL2m/NN/imwVyP4F/+STtrTnkgMJriGN1WTFLH+MWy7gKMLigh/rxX4qFp5ACndxLgELkFhD3E0x
+        gPRaQ+XP4r9BKDT9L2edT+27MyHX/c5O6qsK4+qw8234MUZp3ZBqiG9FElzsJsG/94ByDqGmLO+h
+        RqMxV5XvCrpk5lhOXfJBr8D8uhtdkQFfdMBdUU1umHWjkl0ZMqyiasZHIRVFozGOyCgqstSLwQBy
+        sYhIg4xid/f97bdq5sD/EMpfr9Y2xIQ1E5BO2O+bWDKVkD4WCSDb2S7lMKN6laRCQfWq+sGC3rDk
+        q9ALeGkvGOmOExX0VP+jc7B3Pu9/ac2P5sfzXru8f3Z6sPflaD6cf52fpxUtIGnNz8/mLXrN/ORF
+        PcsFrtM5OK5InYOjDVjf2DeexvH58DUvDvZO5815r7zfBGmP5935KRSTg73efDDvlvdbtNSft8r7
+        J4tSMy8tsHzdMEXAwqi9igS/zXeGVtsh7txoVeXPHny0HaMPk/XPH4K058SgVZmf60kH0Hs/jSgs
+        nnzLwkkWTb6lwQRiyfwMLjK/eV6nHxx+tF0xfBF0NID0IICczvtpCDmdH5f3+2e0lhXPWdw4K+8P
+        KF4tFlGOoanHIkpWauYlHuA3HvqHBqs0xfnaESng667Lycw1n8povnbWsxlI594llVvuVo1sElmh
+        O8t2rjdkpM8v2fOAt177vwHrC7BEjC/IpDOO7FOIsGll2cspI2yl+5qb8rRTiv1ffcgGpWZKF32e
+        nHEz+bXVEfE8NxBJ02ENnzkHXnCf9n1ShPdwkXfdpcA32PUoDyLZMqGaHM0n0QuLx532ocw2k4oY
+        b+MY0wXm2245faq94azmKhkX43DMGj+J5jKGM9oRAfUUrGw6K5RSByh3FSPrGkk4JBJv4r1AyhiQ
+        3Aim2d8TN2SPf6DhmsVUIu76nlgQezS+H02xd4uFqUEnJ5MO76XuguxzKTQVwmfv4DwlQy+n+iEi
+        sAdw2au3m4weZ2+S0WfqTdtm74i9PKCjhlpFhllFVbWC6rRchR95WVSUClLon2oNlsyqXmHckTsM
+        6xbC3lX7uC38k+ZFU4AIrX5mBJW/N+X/xfIfl/JqRF2vL4iw7I4ba2CE5KasoBr6yMcawMqhGJPD
+        D8fkUIjJ4UdiEsXuZLR4VC7EpSsNlu27oOPenFxc/lwg83K0VOSTiw/WvuihFq3+cO0Pf7xHuP4o
+        vgIUyK0oxJ/40vCKQHC//UQJSfGs+lknUm5xNyUxjliliP9F42dOoJYiFGVQnBx/muyJBYfu4EgU
+        HLquFQZR4MTSYeJ5JHb93eJEd7D2+H+toiAydAeNhtxoNIBcUeS62fhABL4MLtqi2ZHV/2WSrhkd
+        YDRLxt7KOYpNsfuUUOovCdkrz2JfhAbHJZ69AcSD/rifFtRlQQgJfeljv9vdb7c3VE6Hlz0aNbIS
+        yYuTeFlaVDLAWOm12yVbdxH7jF5qrxB9pq249H2/kfAts4z5o/SVwG3xdTRNvNhdRtnFXc4g+znG
+        sXQaWPTpTnYgRWKbq3TKZG9Dc1wd9+Xzb1upVY66TcYu9reSaxz5IPBwCDnwNnqdoz8idhDireQ1
+        jrz1y4mEx0lE8kaDa/wFVBwEW8eq86wmg85WYpMjbp5sh6zB0X51fVBYJB1Im0F7oRCF77DyinD6
+        fj/PaHfYl2ZhAGYzXRDwOjoKCTkctLdbAK+l83Hix8l2el5LAw9b13RZs70Lr6kuPcOIr5/owasv
+        O8/huB6RsGWlGTKj4rXWAiV/GWwflVfc0bCfVwt0lBu8ssK5BTd4wkPQiov4LlAGjpQd6MiJeB3l
+        7/qyhhWPERwCSQ8LrNyCbdBL5757x+/Pp6/vCx0EzO/bYJDTrPgJPYURBkEMS38KOQs8jIoH+qzf
+        yqtNoXGfRySUptjHEzIl7LECI26semR2EoDFCR7lfBN1EUR4RPuEhPIwkOlf6YgaxOAKwoqfH4XV
+        eGRbJ4PWl7yBR/bIDckt9rzFLXhED8Gi7SBYeJzGozhoNdvNvIGHrt3LEdV4rAAKD+xVilJdLsbk
+        geuzg8zS8tFRTtRYVw2Woivieeva0ZUVq4khmkwWIXUFvbXzZ4yAR4weok5zlPT0xQpm/gQwX4mx
+        +koo6HVzh9J5yHonOTK6sR4G3JvtEV7nsbzoskDTGWz3QJ3H9jBMaOQIQvAjWDdgjoxH938SP9g+
+        NdVWMLZcsGt6zjU7KrS1J6+BbjCmRtsmvDXUeBV8CbEFFDuMy2unOcV/wPpvh168yvrYC6SmF2+f
+        Gmu8No8TfEvc7fS8mo9q+cn8J/Ctb2Bw0d3eg9fziW+5NuiEnhubBX6Um3CN1/KFG8ZJ8Mcf28U1
+        lBWHuB3Qo+FS65fB6fZu6PHtEtptK8Jd05w9Zf4dwXI+XdMrFeOxvPfbb9FPMv3ZW28q/2Ovwhqe
+        2asgffpG/1XYr8x+1zIpRVHeI/vPztFsHkIvRLPLkf490qeCbZEMj0+6JRIk8SwR7UplbH/J21/K
+        eEzu4koQX8EUR4sfs6mRmesuqX4q5t8518/AYkIWAjRMW3fajPRoNGdD0dXUm2xHwvqqSn9EDKbV
+        u+5PPaBK7XEZeZd1eaB+iqogMJtKxYTgK5uKqTwjJudvbFJtPxOO7MiyCJJl0267x9YMrhKb/rrW
+        dPYWKuOnCgGLZ8TCUSz9F02tyEysQAGnKTV70J+OAMX3ey+FLkgg0RSwn7X8ZbZGI0JG2IsCoagE
+        lrKs6bNNXlueX259dFm0wVeix/7h8jSgr7F008+eVErH9KMnlVIr/+TJuxgc91WGDVmWTZ9pk5Vn
+        /t4PZpErepg4WDZ9UuYTP8qPj9M3X26Ib7O3r9clOV/S0XdfLnK6H/KALoZM7tr1J1XHDaN45ASJ
+        L0ptVg9sHlFaSLOI2JT+EuubBTDsq1m74XKK//KwbJr9zSysFp1hWYWnH7oBy8vPMN0Bk/Yu+mfl
+        Z817+XGWH3h6h33xYYeEYE30v01esPAb+j24p4EZxIVobAa/HqHz6ZF7xxZuTSt2bwhbwUVJ6GDr
+        bdZwMZ5UB+1fJdAWmQShcFGw2vyCJ390hBvsJURtQCsrrdXyu5mLalNIbAqJkSEiRoaQWEMiYg2J
+        R64JR66JR9aFI+tiAYXEqphYE6KhidHQhGhoYjTUupCNunhkIbEmJlaFOKtinIXyFYinCJlQxEwI
+        iVUxsdA+xeYpohQSCnUhVoXQIMT2gISKQGJF6JpwYE0MmCoETBWzIUQXidHVhK6kiV1JF46si0fW
+        hTzrYp5VIRuqmA0xGGIshCijApSFZqEWuKhwZFU8si70Ol3sdcKBxeMioXWignAlHrhgZKHbIbHf
+        aUKNaAUqEWKBxFgIzUJsFULnE/seEvKLxPxqQiQ0MRJIGDKhdvPRT0Ri+Yp9RCkr+UH8vEWCbTqm
+        MzaIXEeOJeuW0pAblqrK1lhvEJvYNV2vCRYPO3Z7waKCfVCcSTxq1PlYsdbwPmCgBlbqiqzbdRWk
+        MlR5rDuabCPVMjWCdZuF8k0wdur2OjDMmioGgza8Bxj0FgJhs+oXCrMmwrswrliqhQk2ZKIoY1kf
+        O1g28diQFWtcq9d0w3IsQyDYjt1ep0XDKNAibXgPMJBjIt2wayBLgzqqpshYNzTZsohuqMhp6IbI
+        v3fs9lIw2Mf4U8Hte2hwrXVUBBTvAY9lmwSbIJhWM0BOpBpyA9OPApJ6XUVYVZDeEMCzY7dXhr9G
+        QfRrvBEUl/R/1xCT7COPIaGftmbZfUQ59pPpyLoh6f+egF5kH4RE6VVOTuxVKnc6wxatzciV9ZG/
+        Xz4+/j9/WksyYGIAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -1861,12 +2048,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:55:48 GMT
+      - Thu, 21 Nov 2019 19:14:24 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1876,9 +2063,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - c6797b32a7d3f597f30d804a01ada557
+      - 75c40df30b033ac3d3f220682da52f14
     status:
       code: 200
       message: OK
@@ -1894,84 +2081,95 @@ interactions:
       Cookie:
       - nginx-cloud-site-id=us-2b
       User-Agent:
-      - TenableIOSDK Python/3.7.3/1.7.1
+      - TenableIOSDK Python/3.7.3/1.9.1
       X-APIKeys:
       - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scans/116
+    uri: https://cloud.tenable.com/scans/template-e2b8782b-bff1-6c41-0dde-3082cc69b738fef88d14b71ac8b3
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+Vce3PiOBL/Ki7u6irsYuInYP7ZIzw2uQuEDQkzuzNZStgy8cVYjB8kmZDvfi3Z
-        BgGGkMlj2NmpGiJLLan7161W62E/5BzPJrnqQ47cetjPVXPIs3x8++/AuikSf5Qr5Dw0xpAf4iAc
-        BCbyBoZOc8kgRP4Ih7mqjdwAF3I2cS3sDxwrV/Ui1y3kTOKFPnFz1dCPoDwKoHSC/bETBA7xglxV
-        ViqFXGBeYyty8SCKaFXoZzxxUYjFUsW2bA1ZYnmI4aekSGK5opqiXbKwjPAQI7VslVBZkiTF1LCq
-        WbYJjGHLCQfIdckttua8Ub5BvEEiy2VPqLsksoRenA/VJsR1zHsoO0KBYwodHN4S/4YRQGlwjXw8
-        F4wM/4fNkEkqy6VCLkSjBIwgJUGmC+lPD7klgaVCCnNMZTkByHqfsBXn8ekFluH9hDJuYRtFbph7
-        LKy0zKBM2pZXG96o07V82qEy741qLPd4VchdkyA0SeSFrPFEUbJpaLisYFGTZE3USmVTHA5tXcSy
-        JcuaLhugJgpdiMIIOMwBkiZ2AcVYHYOkk0mQowgm6CUppTiJhjRZDLGHhi4OsBn5TnhfNMkY6JEb
-        pogPgMuFoiemI0LjYjRxCVrW/wA48akEeklVKwYwCP06YzBrNJ7Ms8uynpBjz1rOvUbBzTC1ZnhA
-        EZha6CNnbuKpmSU9xapLM1l7NOsRajtBSPx7ZiFJOjYnqaIYqqwluhwk+jB9jEJQ9MCCgbEsgYtg
-        WI6J5diOmUHDGH+ewni9ZCsvHrA+s+cNmqAGui6YVNlJMMWQnxRMlxaCGUZJL5uSLg4tBYna0NRF
-        Q9HBZ9hIlVVVspCOXk2wZDjEoxsFAQ5TYWh2mk44U6yyoZYNRSyVFEvUKmUsDhXJFrGKTFtRNNlS
-        KOS0Zupmd7L/iU9GPg6oALIkifD/UIG/8D8ZXSkB1PIxG7eStFwSkhC5Sb4XjUF28yYAlx044MWx
-        lZQwqg1lAZ5iylPiGR5yDvhuBkuSoy9oXPgLvUnULpJSaa1U3lqqbC1Vt5Zqj1ePi8yYM5P4mKXi
-        GRASMGewymOYQ6IxS147o2uWMKEiGKIb5zJNexa+oyKBRUwjF6waDR0XqHDAgwDGMHGjkeMl84VC
-        R22Sk+i8A+qIAqH3e0cI5hPSgllpTm+jsePSSapL/DClpeZM+08Z4lGUlzuXZOpaljs/qbe7wkXq
-        B4Vz/CWCJPwdkxALDUR/nMB0SRABXk/w9SumMLgrHCmbOVIkXV3l6BjQFVrgKO+F3yLkggPAltAg
-        Y+R4QgdIhIPWb41OHlgMiBtR1/BtbKkb2VJ0RZFW2bqodw9POKhAYdFkAoqIncfz+9eo5cB4nqT+
-        JHl0HeqT4mfbcUOqYmpQCR+UuujQPsF5WtQ5pBzWqDcSTho5LvZ6SN0eeAGYcGilEe0890kSDSTa
-        Vw+VR/Fg/qA9ivkH9XH+LCuPB4WdSfM/8VylPUmyomp6qSyioWmJ2JZkkWaIpXLFoFk0ByKaHIGI
-        BsGMQaXN4S80TGG/YxSa1/QpTgAqI59Ek1Rqfuzds8goKYi1UEQwRzvDCOLX4jATtqNoBLP4l12B
-        +5NKfPVzDMvVz9kydy7bR81zxvydi71RCF5ErryLkPgOYh+IgW0fKGgQOwA/MUVBhuT1Wqdf6wnN
-        uIbQSmtk4mD5ZGLB7A2FLszslH8a9cAjmxhzVxule4EwMeuDCTJv0AhvFqE7J9iJ8bgWZDSURHja
-        ADx/uIZJbNCFMQaj0ocI4U2kuvOxXa03zy/Eej1LJigRatbUCSB82tks6zUxtkgxNdDVnPxP/8yy
-        VSD7Hf6JJw3hwMFVAZ4hkFBFqZJ/n2E5h2MTFn2+rW8ep9nCY5hJ+5cCsAChDfjdGAMIcFQ5vy/j
-        l/iZpn923tzrsTvJ5Lrb3El9xUy/etH8ePE+RmlOcdFHt1kS9HeT4M8DoJyBq8mLB7JhGDNF+iTJ
-        V8wc8/GQfNAKML/uRrfJgPtNGK4yLHkq5VIheSrBkgCm3PdCKggGQxTgQbDJUvu9nnAEFEIvodh9
-        +H7+XEwG8C+Z8peL+pqYEDMB6Yj9voolUwnpxhSBKG67lBcJ1YskzRRUKyrvLOgUm9DRxlHAS9tn
-        pDtOVFBT+UezenA5657VZ63Z8azTyB+en1YPzlqzi9mH2WWcUQeS+uzyfFanz2ycfFPN/Iah06we
-        F4RmtbUG6yuPjadxfD58tX714HRWm3XyhzWQ9njWnp1CMqoedGa9WTt/WKep7qyePzyZp2ppao7l
-        y5rZBCy02ikI8Ft7Y2jVHfzOVC1Kf3Xno+7ofZisf30XpD7HBy3L/NyRVIXah7FHYf7kY+JOEm/y
-        MXYm4Etm5/CQjJvnVfrO7kfdFcNvgo46kA44kNNZN3Yhp7Pj/GH3nOay5CXzG+f5wx7Fq848yjEU
-        dZhHSVK1NMUD/MpNf1dnFS9xPjSzFPBh13AyGZpPrWg+NFdXM7Cce5Ol3GK3amDhwPSdSbIbtyYj
-        3UFmm3evHfu/AutzsLIYn5MJ5xzZXoiwbmXJ8eAAmfG25ro8jZji8L8erAaFWkwX7M+acX3xaykD
-        7LoOyZKmyQr2eQ085z6u+6QIbzFE3nSXAk2R41IesmRLhKpxNHuiF+aPm40jkW0mbWK8gUJEA8zX
-        3XLaq73hJOc6Gm7G4ZgV7onmEoYT2gEG9WyIbJpLlEITKHcVI6kaCMjHAm/iHSIkDAhOANPsl8jx
-        2fkPFNwwn4qzq74lFtgaDO8HY+TeosylQTMlE47uhfacbL8UGgvhsaPQp2TopFTfRQR2AJdcflpn
-        9Dg5y6dnhTXLYqf03+7QZUMpyqVKUS4qBblM00X4ERdJSSrIEv1T1CFkVrQC4w7fIYhbMLst8H5b
-        +Ce1fi0DEZr9TA8qfqqJfyDx65W47FFX8zd4WNbjWgwsy2JNlGRdfs9jDWDlKBuTo3fH5CgTk6P3
-        xCQIndFgflaeiUtb6C3Kd0HHmZ70r37eIPOitVjkk/47az/rUItmv7v2L77/iHC8QXgNKODbLBd/
-        4gkX1xic++0eLUg2z6r7OpFywd0YhyhgmVn8zwv3eQG1EGHTCoqT4y+zemLOod1rZTmHtmP6JCB2
-        KBxFrotDx9vNT7R7K8f/KxkbPEO7ZxiiYRhALtEb1sY7InDW6zeyZkeW/8Msuia0gcEkGrpLN1nX
-        xe5SQqG7IGTX77LHIhTYDnatNSAetMfDOKEsEpmQ0Esfh+32YaOxpnLavOhSr5GkcJochYvUPJMB
-        xlIv3S7ZuovYZfRCY4lon7bi4gt/g8xbZgnzrfhO4Db/OhhHbugsvOy8l3NY/RyjUDglJj3dSa4E
-        C2xzlU6Z7EYlx9VxV7z8uJVa4agbeOggbyu5ypH3iIt8WANvo9c4+ha2iI+2kuscef3XEwENowCn
-        hSWu8FdQMSFb2yrzrEa95lbiCkdcO9kOmcHRfnA8UFggVIV1pz1XiMRXwENo1p/Gt3bjC8E8o+2L
-        rjDxCZjNeE7A66jlY3zUa2y3AF5Ll8PIC6Pt9LyWei4yb2hYs70Kr6k2fYsE3TxRg1dfcrfYdlws
-        INOMV8iMitdaHZR81tveKq+41kU3zc7QUWrw0hLnJnTwxAiRl4aI5wAlsZkSHXYUwIh4HbWdwCym
-        BUsjJq4jWDjEZuK9GJG21AXboBcuPeeO35+PryVnDhAwv4+9XkqzNE7olWmfkBBCfwo5czyMigf6
-        vFtPsyuZxn0ZYF8YIw+N8BizYwVGbCyPyOSGM/MTPMrpJurcifCIdjH2xQsi0r9CixpE7xrcipe+
-        jKTyyNZPevWztIBHtuX4+Ba57rwLHtEjsGiLkPmIU3kUe/Vao5YW8NA1OimiKo8VQOGCvQpBrMt5
-        mzxwXfYqmbA4OkqJjFXVICG4xq67qh1NWrKaELzJaO5Sl9BbeQ2AEfCI0dfY4jUKK1rGzBsB5ks+
-        VltyBZ12OqA0HrLOSYqMVlp1A850u4fXeCz7beZomr3tI1DjsT3yI+o5iA/jCOIGxJHx6P4n8sj2
-        qUlfwth0wK7pm0bCqeNFd9tr8hpokyE12gbmrUHnVXDmIxModmiX105tjL5C/LdDLV5lXeQSoeaG
-        26dGndfmcYRusbOdnldzS0/fjXwC3/IaBv329hq8nk8807FAJ/QljwnxgtSEdV7LfccPI/L163Zx
-        S7ym/7jYHgmU5MfXW8ZuiwN3XdwcSLNPMgTxcSQvFUqP+YPPn4OfRPpzsFqU/+WgwAqeWWvDoukj
-        /VdgvyL7XVk/SZL0Fmv+5PWZ9Zf/NqLZ5kj/HoumDZshCR57uhFConASZe1FJWyfpeXfyniI78IC
-        Ca9hYqPJ99nKSMx1lwV+LObfeYWfgMWE3AjQRVy60xakS705a4rGUK+yCQlRVZH+ZDEYZ++6K/Ug
-        F/THhedd5KWO+imqDY65IhUq4HzFilSRnuGT03uaVNvPhMMnITGJmwXJomi3PWNzAk+RRX8dczx5
-        DZXxU0UGi+fYREEo/IsuqPAkW4EZnMbU7Hg/bgGSb3cbhQYksLzMYD8p+WE2RAOMB8gNSKaoGAJY
-        VrRvk9eWU8utB5abtvUgxrWpnKeEXl5px++cF3LH9I3zQq6evm/+JgbHvTi9JsuiaJ+2Vnnm7z0y
-        CZysI8TeomhPmY+8IH1rnN53mWLPYneuVyW5XNDRGy/9lO67HMuFsH67cbxR0Xb8IBzYJPKyljbL
-        r2m2KC0ss3C2Kf0Q8c0cGPa1kt1wOUU/PCzrZj+d+MVNb64sw9P1HcLW5eeI7nsJB/3uef5Z8176
-        Est3fGeHfeZhhwXBiuh/m3XBfNzQ7/A8DUwv3IjGuvPrYDqftpw7FrjVzNCZYhbBBZFvI/N1YrgQ
-        jYpqWa/IyNbFcglJoqYgWzSs0lDUhnKlpBqKYqlGhmg7VvuG80H2ibYpciM8UGX6XSGWXi9Y3+IK
-        cChes09EJCmPhM8DQ9LUckVDJVGRLBmkGkoismUsSgiXVAnLpmKaGWDsWO1lYOiVbCwg/y2gYD3A
-        MMYj+vWrkq5myJ1F80IhdWWDlFDwJhqXy1bZ0GURa4omahjLIqpoWJRtLNmKoWDJsrM0vlu1l4FR
-        1kvZYNCCt9d5ucL63670hOhlgmqymi0oLXgLQUsq1hFGWDRKZfBeFWUoVioWEjVTtbWhOSxbspYh
-        +o7VXgYG/fRjNhqs5HXguKLfvgxx8r0mH9OPhbEpO6Bce9F4YE5x/K1H+pB820mOn1JyCP6XqJzx
-        BJk0NyGXVlv+dPX4+H+xGemIrFMAAA==
+        H4sIAAAAAAAAA+Vde3fiuJL/Kj7snj1hBhPLNsbkn7sEyCQ7geYGku67PbkcYcvEG2MzfuQxId99
+        S7INAmRCnp2Z6XOGyFJJrvrVQyrZ8jyUXN8JSgcPpeDWJ2HpoIR9OyS3/x3Z19UgnJQqJR9PCdTH
+        JIpHkYX9kYrqtDoYxTickLh04GAvIpWSE3g2CUeuXTrwE8+rlKzAj8PAKx3EYQLtSQStMxJO3Shy
+        Az8qHSDVrJQi64rYiUdGSUK7wo2mMw/HRCbq2Kyb6lgeOw6SDUtHsmLbRNYUU7UsozGua6ZDHNO0
+        kT6uI2yZYw0YI7Ybj7DnBbfEXvBGGQf5Rpkw5wOp5QWJLQ3Seug2CzzXuoe2Qxy5ltQj8W0QXjMC
+        aI2ucEgWggXj/yNWzCRV9VqlFONJBkaUk2DLg/L3h9KKwEolxzmlst0IZL3P2Err+PISy/h+Rhm3
+        iYMTLy49VtZGZlBmY6P1gQuVulHPRFrcjWqs9HhZKV0FUWwFiR+zwTNF1ckY6Y5Zk5EyNmTdxpaM
+        La0um5ruYMeuG/q4RqGLcZwAhyVA0iIeoJiqY5TdZBaVKIIZellJrc6SMS1WY+LjsUciYiWhG99X
+        rWAK9NiLc8RHwOVS0TPLlWFwOZl5AV7V/wg4CakEtbquGZpqgDZidwp2jaezRXWtZmbkxLdXa69w
+        dD3OrRkucAKmFofYXZh4bmbZnVLV5ZVsPFr1CL3dKA7Ce2YhWZmZE0KKoSOzlulylOnDCgmOQdEj
+        GxxjVQIPg19OA9t1XEtAwxh/nsJ4vYiVlzpsyOy5QBPUQDcFq5s7CaZoxpOCqZxgpoNQwx6rMlIN
+        R9Y13ZAblkVkmxi2qWNNM3TzzQTL3CH1bhxFJM6FodV5OeNMtesNrd5QZcNQbVk360Qeq4ojEw1b
+        jqrqyFZRKe2Zx9md7H8WBpOQRFQApCigUGVfhb/wX+ZdOQH0CgnzW0VZbYmDGHtZvZ9MQXbrOoKQ
+        HbkQxam4rIVRFbRF5IZQnrLI8FByIXYzWPJYoS+JPPgLt1OoYWTN6kYr2tqqcq3KRqu2tVV/vHxc
+        VsKdmJcHIUCuasBmOg1ShmHiYDefwkSSTFPFupMrNqgFncEaPXaRqtu3yR0VC8ziJvHAtPHY9YCK
+        RDwSMMjMSyaunzmDihqLmkzxPdBJEkmDf/WkaDErLRlWFvQOnroenan6QRjntNSm6f1zhtaQ5G6u
+        qg1DX7/5gIQ3rkWkNolhZgNne+reeQeb68Dfn9cVWhVeQUp9/f7Hw2FfomOSUBqCm0owM0kXINYO
+        rHwl46zrOgjaNibQBggnrW5fGuYzgnRGfk+gCH+nQQzQYPrjRpYXRAnYzRNc/UKoLXhrHOlbOFKN
+        DVgGg+MiVKQTsNhwit9CWbVirsBSNaGyhmfNVkfaZ39/lbokvgrsSGpm6y6eIfU5KjOKWVGV2iYr
+        4IPSEcyp99I/E+zBXEFsqR1MsetLPSCR9o7+2e6VQYdR4CW7YCXWW72YLVM10DpbzRmGmCkdMteU
+        Tl0/uaOmE4fumDHxDDsqhsos5EnV2dJgDSowoHBI7mJpGGI/coCxfhjEgRV40h5Vafk5JlXMVqOY
+        rZqqbrA1bPX3Tzi3gwiYzGYQ2dasaGdVIaWQAV1DaENXzJrX7FfaA6wk2w3BXWAFU345GggVc2Oq
+        ykYMyiyHj4evDoOoOBjXFaMmjDpNbxLAra6mEQs6p9ifJHhCnqGdLph4dZ2T4ohMOTG3xL/WYUvq
+        BjaRWu7sCmSUOmxdtMoG2pGN4jBcR4q+MTVTNr4SfC11my0emdewUBxzG4qGhDphLHC3F6tCEG6F
+        DBh0yQKryVm+ms0uPZeuiNNrx/Viak90JZMxQqmrLr0lLN1tKv/CdOlaWDppl7jM/yFfdMMaFNId
+        2mlC7176rsgNLDuXD+ajvLe40B/l8oP2uLgGy92r7Exa/onnKr+TgmCBVzPqMh5btkwcBcm0Qjbq
+        ZoNW0RrIp0sBuDwGb6fSlsjvNElmvxAPrSt6lRYAlUkYJLNcan7Rd8/y8qwhVUIVx2nUJ1F1LITt
+        MJlADvn7rsD9m0p8+XMKy+XPYpl7593Dzhlj/s4j/iS+ohPVhwhJ7iDzduOREwIF3UIZwQL1BkcC
+        yVvN3kVzIHXSHtJR3kOIgx0GMxtyR2j0YCal/NOcGy5ZWla6LJTuFcKkrI8gJl9D8CsWob8g2Inx
+        tBdUtNVMeDoAXH+9ghRq1AcfA68MIT99F6nuQuIctDpnQ7nVEskELVLTvnEjmPp2NstWU04tUs4N
+        dL2m/NN/imwVyP4F/+STtrTnkgMJriGN1WTFLH+MWy7gKMLigh/rxX4qFp5ACndxLgELkFhD3E0x
+        gPRaQ+XP4r9BKDT9L2edT+27MyHX/c5O6qsK4+qw8234MUZp3ZBqiG9FElzsJsG/94ByDqGmLO+h
+        RqMxV5XvCrpk5lhOXfJBr8D8uhtdkQFfdMBdUU1umHWjkl0ZMqyiasZHIRVFozGOyCgqstSLwQBy
+        sYhIg4xid/f97bdq5sD/EMpfr9Y2xIQ1E5BO2O+bWDKVkD4WCSDb2S7lMKN6laRCQfWq+sGC3rDk
+        q9ALeGkvGOmOExX0VP+jc7B3Pu9/ac2P5sfzXru8f3Z6sPflaD6cf52fpxUtIGnNz8/mLXrN/ORF
+        PcsFrtM5OK5InYOjDVjf2DeexvH58DUvDvZO5815r7zfBGmP5935KRSTg73efDDvlvdbtNSft8r7
+        J4tSMy8tsHzdMEXAwqi9igS/zXeGVtsh7txoVeXPHny0HaMPk/XPH4K058SgVZmf60kH0Hs/jSgs
+        nnzLwkkWTb6lwQRiyfwMLjK/eV6nHxx+tF0xfBF0NID0IICczvtpCDmdH5f3+2e0lhXPWdw4K+8P
+        KF4tFlGOoanHIkpWauYlHuA3HvqHBqs0xfnaESng667Lycw1n8povnbWsxlI594llVvuVo1sElmh
+        O8t2rjdkpM8v2fOAt177vwHrC7BEjC/IpDOO7FOIsGll2cspI2yl+5qb8rRTiv1ffcgGpWZKF32e
+        nHEz+bXVEfE8NxBJ02ENnzkHXnCf9n1ShPdwkXfdpcA32PUoDyLZMqGaHM0n0QuLx532ocw2k4oY
+        b+MY0wXm2245faq94azmKhkX43DMGj+J5jKGM9oRAfUUrGw6K5RSByh3FSPrGkk4JBJv4r1AyhiQ
+        3Aim2d8TN2SPf6DhmsVUIu76nlgQezS+H02xd4uFqUEnJ5MO76XuguxzKTQVwmfv4DwlQy+n+iEi
+        sAdw2au3m4weZ2+S0WfqTdtm74i9PKCjhlpFhllFVbWC6rRchR95WVSUClLon2oNlsyqXmHckTsM
+        6xbC3lX7uC38k+ZFU4AIrX5mBJW/N+X/xfIfl/JqRF2vL4iw7I4ba2CE5KasoBr6yMcawMqhGJPD
+        D8fkUIjJ4UdiEsXuZLR4VC7EpSsNlu27oOPenFxc/lwg83K0VOSTiw/WvuihFq3+cO0Pf7xHuP4o
+        vgIUyK0oxJ/40vCKQHC//UQJSfGs+lknUm5xNyUxjliliP9F42dOoJYiFGVQnBx/muyJBYfu4EgU
+        HLquFQZR4MTSYeJ5JHb93eJEd7D2+H+toiAydAeNhtxoNIBcUeS62fhABL4MLtqi2ZHV/2WSrhkd
+        YDRLxt7KOYpNsfuUUOovCdkrz2JfhAbHJZ69AcSD/rifFtRlQQgJfeljv9vdb7c3VE6Hlz0aNbIS
+        yYuTeFlaVDLAWOm12yVbdxH7jF5qrxB9pq249H2/kfAts4z5o/SVwG3xdTRNvNhdRtnFXc4g+znG
+        sXQaWPTpTnYgRWKbq3TKZG9Dc1wd9+Xzb1upVY66TcYu9reSaxz5IPBwCDnwNnqdoz8idhDireQ1
+        jrz1y4mEx0lE8kaDa/wFVBwEW8eq86wmg85WYpMjbp5sh6zB0X51fVBYJB1Im0F7oRCF77DyinD6
+        fj/PaHfYl2ZhAGYzXRDwOjoKCTkctLdbAK+l83Hix8l2el5LAw9b13RZs70Lr6kuPcOIr5/owasv
+        O8/huB6RsGWlGTKj4rXWAiV/GWwflVfc0bCfVwt0lBu8ssK5BTd4wkPQiov4LlAGjpQd6MiJeB3l
+        7/qyhhWPERwCSQ8LrNyCbdBL5757x+/Pp6/vCx0EzO/bYJDTrPgJPYURBkEMS38KOQs8jIoH+qzf
+        yqtNoXGfRySUptjHEzIl7LECI26semR2EoDFCR7lfBN1EUR4RPuEhPIwkOlf6YgaxOAKwoqfH4XV
+        eGRbJ4PWl7yBR/bIDckt9rzFLXhED8Gi7SBYeJzGozhoNdvNvIGHrt3LEdV4rAAKD+xVilJdLsbk
+        geuzg8zS8tFRTtRYVw2Woivieeva0ZUVq4khmkwWIXUFvbXzZ4yAR4weok5zlPT0xQpm/gQwX4mx
+        +koo6HVzh9J5yHonOTK6sR4G3JvtEV7nsbzoskDTGWz3QJ3H9jBMaOQIQvAjWDdgjoxH938SP9g+
+        NdVWMLZcsGt6zjU7KrS1J6+BbjCmRtsmvDXUeBV8CbEFFDuMy2unOcV/wPpvh168yvrYC6SmF2+f
+        Gmu8No8TfEvc7fS8mo9q+cn8J/Ctb2Bw0d3eg9fziW+5NuiEnhubBX6Um3CN1/KFG8ZJ8Mcf28U1
+        lBWHuB3Qo+FS65fB6fZu6PHtEtptK8Jd05w9Zf4dwXI+XdMrFeOxvPfbb9FPMv3ZW28q/2Ovwhqe
+        2asgffpG/1XYr8x+1zIpRVHeI/vPztFsHkIvRLPLkf490qeCbZEMj0+6JRIk8SwR7UplbH/J21/K
+        eEzu4koQX8EUR4sfs6mRmesuqX4q5t8518/AYkIWAjRMW3fajPRoNGdD0dXUm2xHwvqqSn9EDKbV
+        u+5PPaBK7XEZeZd1eaB+iqogMJtKxYTgK5uKqTwjJudvbFJtPxOO7MiyCJJl0267x9YMrhKb/rrW
+        dPYWKuOnCgGLZ8TCUSz9F02tyEysQAGnKTV70J+OAMX3ey+FLkgg0RSwn7X8ZbZGI0JG2IsCoagE
+        lrKs6bNNXlueX259dFm0wVeix/7h8jSgr7F008+eVErH9KMnlVIr/+TJuxgc91WGDVmWTZ9pk5Vn
+        /t4PZpErepg4WDZ9UuYTP8qPj9M3X26Ib7O3r9clOV/S0XdfLnK6H/KALoZM7tr1J1XHDaN45ASJ
+        L0ptVg9sHlFaSLOI2JT+EuubBTDsq1m74XKK//KwbJr9zSysFp1hWYWnH7oBy8vPMN0Bk/Yu+mfl
+        Z817+XGWH3h6h33xYYeEYE30v01esPAb+j24p4EZxIVobAa/HqHz6ZF7xxZuTSt2bwhbwUVJ6GDr
+        bdZwMZ5UB+1fJdAWmQShcFGw2vyCJ390hBvsJURtQCsrrdXyu5mLalNIbAqJkSEiRoaQWEMiYg2J
+        R64JR66JR9aFI+tiAYXEqphYE6KhidHQhGhoYjTUupCNunhkIbEmJlaFOKtinIXyFYinCJlQxEwI
+        iVUxsdA+xeYpohQSCnUhVoXQIMT2gISKQGJF6JpwYE0MmCoETBWzIUQXidHVhK6kiV1JF46si0fW
+        hTzrYp5VIRuqmA0xGGIshCijApSFZqEWuKhwZFU8si70Ol3sdcKBxeMioXWignAlHrhgZKHbIbHf
+        aUKNaAUqEWKBxFgIzUJsFULnE/seEvKLxPxqQiQ0MRJIGDKhdvPRT0Ri+Yp9RCkr+UH8vEWCbTqm
+        MzaIXEeOJeuW0pAblqrK1lhvEJvYNV2vCRYPO3Z7waKCfVCcSTxq1PlYsdbwPmCgBlbqiqzbdRWk
+        MlR5rDuabCPVMjWCdZuF8k0wdur2OjDMmioGgza8Bxj0FgJhs+oXCrMmwrswrliqhQk2ZKIoY1kf
+        O1g28diQFWtcq9d0w3IsQyDYjt1ep0XDKNAibXgPMJBjIt2wayBLgzqqpshYNzTZsohuqMhp6IbI
+        v3fs9lIw2Mf4U8Hte2hwrXVUBBTvAY9lmwSbIJhWM0BOpBpyA9OPApJ6XUVYVZDeEMCzY7dXhr9G
+        QfRrvBEUl/R/1xCT7COPIaGftmbZfUQ59pPpyLoh6f+egF5kH4RE6VVOTuxVKnc6wxatzciV9ZG/
+        Xz4+/j9/WksyYGIAAA==
     headers:
       Cache-Control:
       - no-cache
@@ -1982,12 +2180,12 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Jul 2019 18:55:51 GMT
+      - Thu, 21 Nov 2019 19:14:29 GMT
       Server:
       - tenable.io
       Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; Secure
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Transfer-Encoding:
@@ -1997,9 +2195,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Gateway-Site-ID:
-      - nginx-router-c-prod-us-west-1
+      - nginx-router-b-ca-central-1-prod
       X-Request-Uuid:
-      - c623f0eddf3ea6ca2cceb22655471654
+      - 5e64f983200df2ebb5aedbc2771501ce
     status:
       code: 200
       message: OK


### PR DESCRIPTION
Many of the Scans API endpoints will accept either the numeric `scan_id` or a `schedule_uuid` as a parameter to query or take an action for a specific scan. Tenable advises the use of the `schedule_uuid` where possible for better performance. This change enables the SDK to make use of the schedule_uuid wherever possible. 

- All applicable Scans API methods should now accept the schedule_uuid as a param and use this if the scan_id is not supplied. 
- Several of the Helper methods will use the schedule_uuid as the default argument when calling the Scans API. 
