### PR TITLE
Library deprecation warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,7 @@ Tenable has decided to deprecate the ``tenable_io`` package in favor of the more
 `pyTenable <https://github.com/tenable/pyTenable>`_. `pyTenable <https://github.com/tenable/pyTenable>`_ offers all of
 the same functionality as this package, as well as support for `tenable.sc <https://docs.tenable.com/Tenablesc.htm>`_.
 However, it should be noted that ``pyTenable`` functions are not compatible with ``tenable_io`` functions.
+Sunset for support with be on August 1, 2020.
 
 Original README
 ===============

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,13 @@
+NOTICE: Tenable.io SDK for Python is being deprecated in favor of `pyTenable <https://github.com/tenable/pyTenable>`_
+=====================================================================================================================
+
+Tenable has decided to deprecate the ``tenable_io`` package in favor of the more widely used library,
+`pyTenable <https://github.com/tenable/pyTenable>`_. `pyTenable <https://github.com/tenable/pyTenable>`_ offers all of
+the same functionality as this package, as well as support for `tenable.sc <https://docs.tenable.com/Tenablesc.htm>`_.
+However, it should be noted that ``pyTenable`` functions are not compatible with ``tenable_io`` functions.
+
+Original README
+===============
 Tenable.io SDK for Python
 =========================
 .. image:: https://img.shields.io/pypi/v/tenable-io.svg?style=flat-square

--- a/tenable_io/__init__.py
+++ b/tenable_io/__init__.py
@@ -1,1 +1,7 @@
+import warnings
+
+warnings.warn('tenable_io is being deprecated in favor of pyTenable', DeprecationWarning)
+
 __version__ = "1.13.0"
+__url__ = 'https://github.com/tenable/Tenable.io-SDK-for-Python'
+__description__ = 'Python Interface into tenable.io'


### PR DESCRIPTION
Tenable has decided to deprecate this library in favor of the more popular and more capable [pyTenable](https://github.com/tenable/pyTenable) library.  

The Sunset date for support of this library will be August 1, 2020. 